### PR TITLE
Add @aikirun/endpoint package for push-based workflow execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ const aikiClient = client({
 
 // Start a worker
 const myWorker = worker({
-  name: "trial-worker",
   workflows: [trialV1],
 });
 const workerHandle = await myWorker.spawn(aikiClient);

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,14 @@
         "@orpc/client": "^1.9.3",
       },
     },
+    "sdk/endpoint": {
+      "name": "@aikirun/endpoint",
+      "version": "0.23.1",
+      "dependencies": {
+        "@aikirun/types": "workspace:*",
+        "@aikirun/workflow": "workspace:*",
+      },
+    },
     "sdk/subscriber/db": {
       "name": "@aikirun/subscriber-db",
       "version": "0.23.1",
@@ -136,6 +144,8 @@
   },
   "packages": {
     "@aikirun/client": ["@aikirun/client@workspace:sdk/client"],
+
+    "@aikirun/endpoint": ["@aikirun/endpoint@workspace:sdk/endpoint"],
 
     "@aikirun/examples": ["@aikirun/examples@workspace:examples"],
 

--- a/docs/core-concepts/workers.md
+++ b/docs/core-concepts/workers.md
@@ -15,7 +15,6 @@ const aikiClient = client({
 });
 
 const aikiWorker = worker({
-  name: "order-worker",
   workflows: [orderWorkflowV1, userWorkflowV1],
   opts: {
     maxConcurrentWorkflowRuns: 10,
@@ -42,8 +41,8 @@ Workers scale naturally. You can add capacity in several ways:
 **Run multiple instances** of the same worker to share load. Each gets a portion of the work automatically:
 
 ```typescript
-const worker1 = worker({ name: "worker-1", workflows: [orderWorkflowV1] });
-const worker2 = worker({ name: "worker-2", workflows: [orderWorkflowV1] });
+const worker1 = worker({ workflows: [orderWorkflowV1] });
+const worker2 = worker({ workflows: [orderWorkflowV1] });
 
 const handle1 = await worker1.spawn(aikiClient);
 const handle2 = await worker2.spawn(aikiClient);
@@ -99,7 +98,6 @@ npm install @aikirun/subscriber-redis
 import { redisSubscriber } from "@aikirun/subscriber-redis";
 
 const aikiWorker = worker({
-  name: "order-worker",
   workflows: [orderWorkflowV1],
   subscriber: redisSubscriber({ host: "localhost", port: 6379 }),
 });

--- a/docs/getting-started/first-workflow.md
+++ b/docs/getting-started/first-workflow.md
@@ -168,7 +168,6 @@ const aikiClient = client({
 });
 
 const aikiWorker = worker({
-	name: "restaurant-worker",
 	workflows: [restaurantOrderV1, courierDeliveryV1],
 });
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -46,7 +46,7 @@ const aikiClient = client({
 });
 
 // 4. Create a worker (executes workflows)
-const myWorker = worker({ name: "my-worker", workflows: [helloV1] });
+const myWorker = worker({ workflows: [helloV1] });
 const workerHandle = await myWorker.spawn(aikiClient);
 
 // 5. Execute your workflow

--- a/examples/shared/worker.ts
+++ b/examples/shared/worker.ts
@@ -17,18 +17,16 @@ config({ path: join(__dirname, "../.env") });
  */
 export async function runWithWorker(
 	workflows: AnyWorkflowVersion[],
-	callback: (client: Client<null>) => Promise<void>
+	callback: (client: Client) => Promise<void>
 ): Promise<void> {
 	const aikiClient = client({ url: process.env.AIKI_SERVER_URL ?? "http://localhost:9850" });
 
 	const workerA = worker({
-		name: "worker-A",
 		workflows,
 		opts: { maxConcurrentWorkflowRuns: 10 },
 	});
 
 	const workerB = worker({
-		name: "worker-B",
 		workflows,
 		opts: { maxConcurrentWorkflowRuns: 10 },
 	});

--- a/package.json
+++ b/package.json
@@ -3,17 +3,18 @@
 	"private": true,
 	"type": "module",
 	"workspaces": [
-		"types",
+		"examples",
 		"lib",
-		"sdk/workflow",
-		"sdk/task",
 		"sdk/client",
+		"sdk/endpoint",
 		"sdk/subscriber/db",
 		"sdk/subscriber/redis",
+		"sdk/task",
 		"sdk/worker",
+		"sdk/workflow",
 		"server",
-		"web",
-		"examples"
+		"types",
+		"web"
 	],
 	"scripts": {
 		"check": "tsc --noEmit && tsc --noEmit -p web/tsconfig.json",
@@ -34,14 +35,14 @@
 		"clean": "rm -rf types/dist lib/dist server/dist sdk/*/dist",
 		"build:types": "bun run --cwd types build",
 		"build:lib": "bun run --cwd lib build",
-		"build:sdk": "bun run --cwd sdk/workflow build && bun run --cwd sdk/task build && bun run --cwd sdk/client build && bun run --cwd sdk/subscriber/db build && bun run --cwd sdk/subscriber/redis build && bun run --cwd sdk/worker build",
+		"build:sdk": "bun run --cwd sdk/workflow build && bun run --cwd sdk/task build && bun run --cwd sdk/client build && bun run --cwd sdk/subscriber/db build && bun run --cwd sdk/subscriber/redis build && bun run --cwd sdk/worker build && bun run --cwd sdk/endpoint build",
 		"build:server": "bun build server/index.ts --compile --outfile server/dist/aiki-server",
 		"docker:build": "docker compose build",
 		"docker:up": "docker compose up -d",
 		"docker:down": "docker compose down",
 		"docker:logs": "docker compose logs -f",
 		"release": "bun run build:types && bun run build:lib && bun run build:sdk && bun run release:publish && git tag v$(bun -e \"console.log(require('./types/package.json').version)\") && git push && git push --tags",
-		"release:publish": "for pkg in types sdk/workflow sdk/task sdk/client sdk/subscriber/redis sdk/worker; do (cd $pkg && bun publish --access public) || true; done",
+		"release:publish": "for pkg in types sdk/workflow sdk/task sdk/client sdk/subscriber/redis sdk/worker sdk/endpoint; do (cd $pkg && bun publish --access public) || true; done",
 		"prepare": "husky"
 	},
 	"lint-staged": {

--- a/sdk/endpoint/endpoint.ts
+++ b/sdk/endpoint/endpoint.ts
@@ -1,0 +1,109 @@
+import type { Client } from "@aikirun/types/client";
+import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
+import type { WorkflowRun, WorkflowRunId } from "@aikirun/types/workflow-run";
+import {
+	type AnyWorkflowVersion,
+	executeWorkflowRun,
+	getSystemWorkflows,
+	type WorkflowExecutionOptions,
+	workflowRegistry,
+} from "@aikirun/workflow";
+
+import { verifySignature } from "./signature";
+
+export interface EndpointParams {
+	workflows: AnyWorkflowVersion[];
+	client: Client;
+	secret: string;
+	options?: EndpointOptions;
+}
+
+export interface EndpointOptions {
+	signatureMaxAgeMs?: number;
+	workflowRun?: WorkflowExecutionOptions;
+}
+
+export function endpoint(params: EndpointParams): (request: Request) => Promise<Response> {
+	const { client, secret, options } = params;
+	const signatureMaxAgeMs = options?.signatureMaxAgeMs ?? 30_000;
+	const workflowRunOpts = {
+		heartbeatIntervalMs: options?.workflowRun?.heartbeatIntervalMs ?? 30_000,
+		spinThresholdMs: options?.workflowRun?.spinThresholdMs ?? 10,
+	};
+
+	const registry = workflowRegistry().addMany(getSystemWorkflows(client.api)).addMany(params.workflows);
+
+	const logger = client.logger.child({ "aiki.component": "endpoint" });
+
+	return async (request: Request): Promise<Response> => {
+		const signatureHeader = request.headers.get("x-aiki-signature");
+		if (!signatureHeader) {
+			return jsonResponse(401);
+		}
+
+		const body = await request.text();
+
+		const valid = await verifySignature({
+			header: signatureHeader,
+			body,
+			secret,
+			signatureMaxAgeMs,
+		});
+		if (!valid) {
+			return jsonResponse(401);
+		}
+
+		let workflowRunId: string | undefined;
+		try {
+			const parsedBody = JSON.parse(body);
+			workflowRunId = parsedBody.workflowRunId;
+			if (typeof workflowRunId !== "string" || workflowRunId === "") {
+				return jsonResponse(400);
+			}
+		} catch {
+			return jsonResponse(400);
+		}
+
+		let workflowRun: WorkflowRun | undefined;
+		try {
+			const response = await client.api.workflowRun.getByIdV1({ id: workflowRunId });
+			workflowRun = response.run;
+		} catch (error) {
+			logger.warn("Failed to fetch workflow run", {
+				"aiki.workflowRunId": workflowRunId,
+				"aiki.error": error instanceof Error ? error.message : String(error),
+			});
+			return jsonResponse(404);
+		}
+
+		const runLogger = logger.child({
+			"aiki.workflowName": workflowRun.name,
+			"aiki.workflowVersionId": workflowRun.versionId,
+			"aiki.workflowRunId": workflowRun.id,
+		});
+
+		const workflowVersion = registry.get(workflowRun.name as WorkflowName, workflowRun.versionId as WorkflowVersionId);
+		if (!workflowVersion) {
+			runLogger.warn("Workflow version not found");
+			return jsonResponse(404);
+		}
+
+		const success = await executeWorkflowRun({
+			client,
+			workflowRun,
+			workflowVersion,
+			logger: runLogger,
+			options: {
+				spinThresholdMs: workflowRunOpts.spinThresholdMs,
+				heartbeatIntervalMs: workflowRunOpts.heartbeatIntervalMs,
+			},
+			heartbeat: () => client.api.workflowRun.heartbeatV1({ id: workflowRun.id as WorkflowRunId }),
+		});
+
+		return jsonResponse(success ? 200 : 500);
+	};
+}
+
+function jsonResponse(status: number): Response {
+	return new Response(null, { status });
+}

--- a/sdk/endpoint/index.ts
+++ b/sdk/endpoint/index.ts
@@ -1,0 +1,2 @@
+export type { EndpointOptions, EndpointParams } from "./endpoint";
+export { endpoint } from "./endpoint";

--- a/sdk/endpoint/package.json
+++ b/sdk/endpoint/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@aikirun/endpoint",
+	"version": "0.23.1",
+	"description": "Push-based HTTP endpoint for Aiki - execute workflows from serverless environments",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsup"
+	},
+	"dependencies": {
+		"@aikirun/types": "workspace:*",
+		"@aikirun/workflow": "workspace:*"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"license": "Apache-2.0"
+}

--- a/sdk/endpoint/signature.ts
+++ b/sdk/endpoint/signature.ts
@@ -1,0 +1,82 @@
+const encoder = new TextEncoder();
+
+export async function verifySignature(params: {
+	header: string;
+	body: string;
+	secret: string;
+	signatureMaxAgeMs: number;
+}): Promise<boolean> {
+	const { header, body, secret, signatureMaxAgeMs } = params;
+
+	const parsed = parseSignatureHeader(header);
+	if (!parsed) {
+		return false;
+	}
+
+	const { timestamp, signature } = parsed;
+
+	const age = Date.now() - timestamp;
+	if (age < 0 || age > signatureMaxAgeMs) {
+		return false;
+	}
+
+	const signedPayload = `${timestamp}.${body}`;
+	const expectedSignature = await computeHmac(secret, signedPayload);
+
+	return timingSafeEqual(signature, expectedSignature);
+}
+
+function parseSignatureHeader(header: string): { timestamp: number; signature: string } | null {
+	let timestamp: number | undefined;
+	let signature: string | undefined;
+
+	for (const part of header.split(",")) {
+		const [key, value] = part.split("=", 2);
+		if (!key || !value) {
+			return null;
+		}
+
+		const trimmedKey = key.trim();
+		if (trimmedKey === "t") {
+			timestamp = Number(value.trim());
+			if (!Number.isFinite(timestamp)) {
+				return null;
+			}
+		} else if (trimmedKey === "v1") {
+			signature = value.trim();
+		}
+	}
+
+	if (timestamp === undefined || signature === undefined) {
+		return null;
+	}
+
+	return { timestamp, signature };
+}
+
+async function computeHmac(secret: string, payload: string): Promise<string> {
+	const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, [
+		"sign",
+	]);
+
+	const signatureBuffer = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+	const signatureArray = new Uint8Array(signatureBuffer);
+
+	let hex = "";
+	for (const byte of signatureArray) {
+		hex += byte.toString(16).padStart(2, "0");
+	}
+	return hex;
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+
+	let result = 0;
+	for (let i = 0; i < b.length; i++) {
+		result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	return result === 0;
+}

--- a/sdk/endpoint/tsconfig.json
+++ b/sdk/endpoint/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../tsconfig.json",
+	"include": ["./**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/sdk/endpoint/tsup.config.ts
+++ b/sdk/endpoint/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["index.ts"],
+	format: ["esm"],
+	dts: true,
+	clean: true,
+	outDir: "dist",
+	noExternal: ["@aikirun/lib"],
+});

--- a/sdk/subscriber/db/db-subscriber.ts
+++ b/sdk/subscriber/db/db-subscriber.ts
@@ -50,11 +50,7 @@ export function dbSubscriber(params: DbSubscriberParams): CreateSubscriber {
 	};
 
 	return (context: SubscriberContext): Subscriber => {
-		const { workerId, workflows, shards, logger: parentLogger } = context;
-
-		const logger = parentLogger.child({
-			"aiki.component": "db-subscriber",
-		});
+		const { workerId, workflows, shards } = context;
 
 		const workflowFilters = !isNonEmptyArray(shards)
 			? workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId }))
@@ -76,22 +72,7 @@ export function dbSubscriber(params: DbSubscriberParams): CreateSubscriber {
 					data: { workflowRunId: run.id as WorkflowRunId },
 				}));
 			},
-			async heartbeat(workflowRunId: WorkflowRunId): Promise<void> {
-				try {
-					await api.workflowRun.heartbeatV1({ id: workflowRunId });
-					logger.debug("Heartbeat sent", {
-						"aiki.workerId": workerId,
-						"aiki.workflowRunId": workflowRunId,
-					});
-				} catch (error) {
-					logger.warn("Heartbeat failed", {
-						"aiki.workerId": workerId,
-						"aiki.workflowRunId": workflowRunId,
-						"aiki.error": error instanceof Error ? error.message : String(error),
-					});
-				}
-			},
-			async acknowledge(): Promise<void> {},
+			heartbeat: (workflowRunId: WorkflowRunId) => api.workflowRun.heartbeatV1({ id: workflowRunId }),
 		};
 	};
 }

--- a/sdk/subscriber/redis/redis-subscriber.ts
+++ b/sdk/subscriber/redis/redis-subscriber.ts
@@ -133,7 +133,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 		});
 
 		const logger = parentLogger.child({
-			"aiki.component": "redis-subscriber",
+			"aiki.subscriber": "redis",
 		});
 
 		const streamConsumerGroupMap = getRedisStreamConsumerGroupMap(workflows, shards);
@@ -178,20 +178,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 				if (!meta) {
 					return;
 				}
-				try {
-					await redis.xclaim(meta.stream, meta.consumerGroup, workerId, 0, meta.messageId, "JUSTID");
-					logger.debug("Heartbeat sent", {
-						"aiki.workerId": workerId,
-						"aiki.workflowRunId": workflowRunId,
-						"aiki.messageId": meta.messageId,
-					});
-				} catch (error) {
-					logger.warn("Heartbeat failed", {
-						"aiki.workerId": workerId,
-						"aiki.workflowRunId": workflowRunId,
-						"aiki.error": error instanceof Error ? error.message : String(error),
-					});
-				}
+				await redis.xclaim(meta.stream, meta.consumerGroup, workerId, 0, meta.messageId, "JUSTID");
 			},
 			async acknowledge(workflowRunId: WorkflowRunId): Promise<void> {
 				const meta = pendingMessageMetaByWorkflowRunId.get(workflowRunId);
@@ -205,20 +192,17 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 						logger.warn("Message already acknowledged", {
 							"aiki.workerId": workerId,
 							"aiki.workflowRunId": workflowRunId,
-							"aiki.messageId": meta.messageId,
 						});
 					} else {
 						logger.debug("Message acknowledged", {
 							"aiki.workerId": workerId,
 							"aiki.workflowRunId": workflowRunId,
-							"aiki.messageId": meta.messageId,
 						});
 					}
 				} catch (error) {
 					logger.error("Failed to acknowledge message", {
 						"aiki.workerId": workerId,
 						"aiki.workflowRunId": workflowRunId,
-						"aiki.messageId": meta.messageId,
 						"aiki.error": error instanceof Error ? error.message : String(error),
 					});
 					throw error;
@@ -374,7 +358,6 @@ async function processRedisStreamMessages(
 				if (messageData instanceof type.errors) {
 					logger.warn("Invalid message structure", {
 						"aiki.stream": stream,
-						"aiki.messageId": messageId,
 						"aiki.error": messageData.summary,
 					});
 					await redis.xack(stream, consumerGroup, messageId);

--- a/sdk/task/task.ts
+++ b/sdk/task/task.ts
@@ -140,7 +140,6 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		});
 
 		const logger = run.logger.child({
-			"aiki.component": "task-execution",
 			"aiki.taskName": this.name,
 			"aiki.taskId": taskInfo.id,
 		});
@@ -242,7 +241,6 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		});
 
 		const logger = run.logger.child({
-			"aiki.component": "task-execution",
 			"aiki.taskName": this.name,
 			"aiki.taskId": taskInfo.id,
 		});

--- a/sdk/worker/README.md
+++ b/sdk/worker/README.md
@@ -21,7 +21,6 @@ const aikiClient = client({
 });
 
 const aikiWorker = worker({
-	name: "order-worker",
 	workflows: [orderWorkflowV1],
 });
 

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -5,27 +5,18 @@ import { dbSubscriber } from "@aikirun/subscriber-db";
 import type { Client } from "@aikirun/types/client";
 import type { Logger } from "@aikirun/types/logger";
 import type { CreateSubscriber, Subscriber, SubscriberContext, WorkflowRunBatch } from "@aikirun/types/subscriber";
-import { INTERNAL } from "@aikirun/types/symbols";
-import type { WorkerId, WorkerName } from "@aikirun/types/worker";
+import type { WorkerId } from "@aikirun/types/worker";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRun, WorkflowRunId } from "@aikirun/types/workflow-run";
 import {
-	NonDeterminismError,
-	WorkflowRunFailedError,
-	WorkflowRunNotExecutableError,
-	WorkflowRunRevisionConflictError,
-	WorkflowRunSuspendedError,
-} from "@aikirun/types/workflow-run-error";
-import {
-	createEventWaiters,
-	createReplayManifest,
-	createSleeper,
+	type AnyWorkflowVersion,
+	executeWorkflowRun,
+	getSystemWorkflows,
+	type WorkflowExecutionOptions,
 	type WorkflowRegistry,
 	type WorkflowVersion,
 	workflowRegistry,
-	workflowRunHandle,
 } from "@aikirun/workflow";
-import { getSystemWorkflows } from "sdk/workflow/system";
 import { ulid } from "ulidx";
 
 /**
@@ -35,7 +26,6 @@ import { ulid } from "ulidx";
  * execution, which returns a handle for controlling the running worker.
  *
  * @param params - Worker configuration parameters
- * @param params.name - Unique worker name for identification and monitoring
  * @param params.workflows - Array of workflow versions this worker can execute
  * @param params.subscriber - Optional subscriber factory for work discovery (default: DB polling)
  * @returns Worker definition, call spawn(client) to begin execution
@@ -43,7 +33,6 @@ import { ulid } from "ulidx";
  * @example
  * ```typescript
  * export const myWorker = worker({
- *   name: "order-worker",
  *   workflows: [orderWorkflowV1, paymentWorkflowV1],
  *   opts: {
  *     maxConcurrentWorkflowRuns: 10,
@@ -62,16 +51,14 @@ export function worker(params: WorkerParams): Worker {
 }
 
 export interface WorkerParams {
-	name: string;
-	// biome-ignore lint/suspicious/noExplicitAny: AppContext is contravariant
-	workflows: WorkflowVersion<any, any, any, any>[];
+	workflows: AnyWorkflowVersion[];
 	subscriber?: CreateSubscriber;
 	opts?: WorkerDefinitionOptions;
 }
 
 export interface WorkerDefinitionOptions {
 	maxConcurrentWorkflowRuns?: number;
-	workflowRun?: WorkflowRunOptions;
+	workflowRun?: WorkflowExecutionOptions;
 	gracefulShutdownTimeoutMs?: number;
 }
 
@@ -91,37 +78,18 @@ export interface WorkerSpawnOptions extends WorkerDefinitionOptions {
 	};
 }
 
-interface WorkflowRunOptions {
-	heartbeatIntervalMs?: number;
-	/**
-	 * Threshold for spinning vs persisting delays (default: 10ms).
-	 *
-	 * Delays <= threshold: In-memory wait (fast, no history, not durable)
-	 * Delays > threshold: Server state transition (history recorded, durable)
-	 *
-	 * Set to 0 to record all delays in transition history.
-	 */
-	spinThresholdMs?: number;
-}
-
 export interface Worker {
-	name: WorkerName;
 	with(): WorkerBuilder;
 	spawn: <AppContext>(client: Client<AppContext>) => Promise<WorkerHandle>;
 }
 
 export interface WorkerHandle {
 	id: WorkerId;
-	name: WorkerName;
 	stop: () => Promise<void>;
 }
 
 class WorkerImpl implements Worker {
-	public readonly name: WorkerName;
-
-	constructor(private readonly params: WorkerParams) {
-		this.name = params.name as WorkerName;
-	}
+	constructor(private readonly params: WorkerParams) {}
 
 	public with(): WorkerBuilder {
 		const spawnOpts: WorkerSpawnOptions = this.params.opts ?? {};
@@ -150,8 +118,7 @@ interface ActiveWorkflowRun {
 
 class WorkerHandleImpl<AppContext> implements WorkerHandle {
 	public readonly id: WorkerId;
-	public readonly name: WorkerName;
-	private readonly workflowRunOpts: Required<WorkflowRunOptions>;
+	private readonly workflowRunOpts: Required<WorkflowExecutionOptions>;
 	private readonly registry: WorkflowRegistry;
 	private readonly logger: Logger;
 	private abortController: AbortController | undefined;
@@ -166,7 +133,6 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		private readonly spawnOpts: WorkerSpawnOptions
 	) {
 		this.id = ulid() as WorkerId;
-		this.name = params.name as WorkerName;
 		this.workflowRunOpts = {
 			heartbeatIntervalMs: this.spawnOpts.workflowRun?.heartbeatIntervalMs ?? 30_000,
 			spinThresholdMs: this.spawnOpts.workflowRun?.spinThresholdMs ?? 10,
@@ -177,7 +143,6 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		this.logger = client.logger.child({
 			"aiki.component": "worker",
 			"aiki.workerId": this.id,
-			"aiki.workerName": this.name,
 			...(reference && { "aiki.workerReferenceId": reference.id }),
 		});
 	}
@@ -335,8 +300,15 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 			}
 
 			// TODO: maybe load multiple workflows in one request
-			const { run: workflowRun } = await this.client.api.workflowRun.getByIdV1({ id: workflowRunId });
-			if (!workflowRun) {
+			let workflowRun: WorkflowRun | undefined;
+			try {
+				const response = await this.client.api.workflowRun.getByIdV1({ id: workflowRunId });
+				workflowRun = response.run;
+			} catch (error) {
+				this.logger.warn("Failed to fetch workflow run", {
+					"aiki.workflowRunId": workflowRunId,
+					"aiki.error": error instanceof Error ? error.message : String(error),
+				});
 				if (subscriber.acknowledge) {
 					await subscriber.acknowledge(workflowRunId).catch(() => {});
 				}
@@ -378,90 +350,41 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		subscriber: Subscriber
 	): Promise<void> {
 		const logger = this.logger.child({
-			"aiki.component": "workflow-execution",
 			"aiki.workflowName": workflowRun.name,
 			"aiki.workflowVersionId": workflowRun.versionId,
 			"aiki.workflowRunId": workflowRun.id,
 		});
 
-		let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
-		let shouldAcknowledge = false;
+		const heartbeat = subscriber.heartbeat;
 
-		try {
-			const heartbeat = subscriber.heartbeat;
-			if (heartbeat) {
-				heartbeatInterval = setInterval(() => {
-					try {
-						heartbeat(workflowRun.id as WorkflowRunId);
-					} catch (error) {
-						logger.warn("Failed to send heartbeat", {
-							"aiki.error": error instanceof Error ? error.message : String(error),
-						});
-					}
-				}, this.workflowRunOpts.heartbeatIntervalMs);
-			}
+		const success = await executeWorkflowRun({
+			client: this.client,
+			workflowRun,
+			workflowVersion,
+			logger,
+			options: {
+				spinThresholdMs: this.workflowRunOpts.spinThresholdMs,
+				heartbeatIntervalMs: this.workflowRunOpts.heartbeatIntervalMs,
+			},
+			heartbeat: heartbeat ? () => heartbeat(workflowRun.id as WorkflowRunId) : undefined,
+		});
 
-			const eventsDefinition = workflowVersion[INTERNAL].eventsDefinition;
-			const handle = await workflowRunHandle(this.client, workflowRun, eventsDefinition, logger);
-
-			const appContext = this.client[INTERNAL].createContext ? this.client[INTERNAL].createContext(workflowRun) : null;
-
-			await workflowVersion[INTERNAL].handler(
-				{
-					id: workflowRun.id as WorkflowRunId,
-					name: workflowRun.name as WorkflowName,
-					versionId: workflowRun.versionId as WorkflowVersionId,
-					options: workflowRun.options ?? {},
-					logger,
-					sleep: createSleeper(handle, logger),
-					events: createEventWaiters(handle, eventsDefinition, logger),
-					[INTERNAL]: {
-						handle,
-						replayManifest: createReplayManifest(workflowRun),
-						options: { spinThresholdMs: this.workflowRunOpts.spinThresholdMs },
-					},
-				},
-				workflowRun.input,
-				appContext instanceof Promise ? await appContext : appContext
-			);
-
-			shouldAcknowledge = true;
-		} catch (error) {
-			if (
-				error instanceof WorkflowRunNotExecutableError ||
-				error instanceof WorkflowRunSuspendedError ||
-				error instanceof WorkflowRunFailedError ||
-				error instanceof WorkflowRunRevisionConflictError ||
-				error instanceof NonDeterminismError
-			) {
-				shouldAcknowledge = true;
-			} else {
-				logger.error("Unexpected error during workflow execution", {
-					"aiki.error": error instanceof Error ? error.message : String(error),
-					"aiki.stack": error instanceof Error ? error.stack : undefined,
-				});
-				shouldAcknowledge = false;
-			}
-		} finally {
-			if (heartbeatInterval) clearInterval(heartbeatInterval);
-
-			if (subscriber.acknowledge) {
-				if (shouldAcknowledge) {
-					try {
-						await subscriber.acknowledge(workflowRun.id as WorkflowRunId);
-					} catch (error) {
-						logger.error("Failed to acknowledge message, it may be reprocessed", {
-							"aiki.errorType": "MESSAGE_ACK_FAILED",
-							"aiki.error": error instanceof Error ? error.message : String(error),
-						});
-					}
-				} else {
-					logger.debug("Message left in PEL for retry");
+		if (subscriber.acknowledge) {
+			if (success) {
+				try {
+					await subscriber.acknowledge(workflowRun.id as WorkflowRunId);
+				} catch (error) {
+					logger.error("Failed to acknowledge message, it may be reprocessed", {
+						"aiki.errorType": "MESSAGE_ACK_FAILED",
+						"aiki.error": error instanceof Error ? error.message : String(error),
+					});
 				}
+			} else {
+				logger.debug("Message left pending for retry");
 			}
-
-			this.activeWorkflowRunsById.delete(workflowRun.id);
 		}
+
+		this.activeWorkflowRunsById.delete(workflowRun.id);
 	}
 }
 

--- a/sdk/workflow/index.ts
+++ b/sdk/workflow/index.ts
@@ -11,12 +11,15 @@ export type {
 	EventWaiters,
 } from "./run/event";
 export { createEventSenders, createEventWaiters, event } from "./run/event";
+export type { ExecuteWorkflowParams, WorkflowExecutionOptions } from "./run/execute";
+export { executeWorkflowRun } from "./run/execute";
 export type { WorkflowRunHandle, WorkflowRunWaitOptions } from "./run/handle";
 export { workflowRunHandle } from "./run/handle";
 export { createReplayManifest } from "./run/replay-manifest";
 export { createSleeper } from "./run/sleeper";
 export type { ScheduleDefinition, ScheduleHandle, ScheduleParams } from "./schedule";
 export { schedule } from "./schedule";
+export { getSystemWorkflows } from "./system";
 export type { Workflow, WorkflowParams } from "./workflow";
 export { workflow } from "./workflow";
 export type { AnyWorkflowVersion, WorkflowVersion, WorkflowVersionParams } from "./workflow-version";

--- a/sdk/workflow/run/execute.ts
+++ b/sdk/workflow/run/execute.ts
@@ -1,0 +1,107 @@
+import type { Client } from "@aikirun/types/client";
+import type { Logger } from "@aikirun/types/logger";
+import { INTERNAL } from "@aikirun/types/symbols";
+import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
+import type { WorkflowRun, WorkflowRunId } from "@aikirun/types/workflow-run";
+import {
+	NonDeterminismError,
+	WorkflowRunFailedError,
+	WorkflowRunNotExecutableError,
+	WorkflowRunRevisionConflictError,
+	WorkflowRunSuspendedError,
+} from "@aikirun/types/workflow-run-error";
+
+import { createEventWaiters } from "./event";
+import { workflowRunHandle } from "./handle";
+import { createReplayManifest } from "./replay-manifest";
+import { createSleeper } from "./sleeper";
+import type { UnknownWorkflowVersion } from "../workflow-version";
+
+export interface ExecuteWorkflowParams<AppContext> {
+	client: Client<AppContext>;
+	workflowRun: WorkflowRun;
+	workflowVersion: UnknownWorkflowVersion;
+	logger: Logger;
+	options: Required<WorkflowExecutionOptions>;
+	heartbeat?: () => Promise<void>;
+}
+
+export interface WorkflowExecutionOptions {
+	heartbeatIntervalMs?: number;
+	/**
+	 * Threshold for spinning vs persisting task retry delays (default: 10ms).
+	 *
+	 * Delays <= threshold: In-memory wait (fast, no task history entry)
+	 * Delays > threshold: Server state transition (recorded in task history)
+	 *
+	 * Set to 0 to record all task delays in transition history.
+	 */
+	spinThresholdMs?: number;
+}
+
+export async function executeWorkflowRun<AppContext>(params: ExecuteWorkflowParams<AppContext>): Promise<boolean> {
+	const { client, workflowRun, workflowVersion, logger, options, heartbeat } = params;
+
+	let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
+
+	try {
+		if (heartbeat) {
+			heartbeatInterval = setInterval(async () => {
+				try {
+					await heartbeat();
+					logger.debug("Heartbeat sent");
+				} catch (error) {
+					logger.warn("Failed to send heartbeat", {
+						"aiki.error": error instanceof Error ? error.message : String(error),
+					});
+				}
+			}, options.heartbeatIntervalMs);
+		}
+
+		const eventsDefinition = workflowVersion[INTERNAL].eventsDefinition;
+		const handle = await workflowRunHandle(client, workflowRun, eventsDefinition, logger);
+
+		const appContext = client[INTERNAL].createContext ? client[INTERNAL].createContext(workflowRun) : null;
+
+		await workflowVersion[INTERNAL].handler(
+			{
+				id: workflowRun.id as WorkflowRunId,
+				name: workflowRun.name as WorkflowName,
+				versionId: workflowRun.versionId as WorkflowVersionId,
+				options: workflowRun.options ?? {},
+				logger,
+				sleep: createSleeper(handle, logger),
+				events: createEventWaiters(handle, eventsDefinition, logger),
+				[INTERNAL]: {
+					handle,
+					replayManifest: createReplayManifest(workflowRun),
+					options: { spinThresholdMs: options.spinThresholdMs },
+				},
+			},
+			workflowRun.input,
+			appContext instanceof Promise ? await appContext : appContext
+		);
+
+		return true;
+	} catch (error) {
+		if (
+			error instanceof WorkflowRunNotExecutableError ||
+			error instanceof WorkflowRunSuspendedError ||
+			error instanceof WorkflowRunFailedError ||
+			error instanceof WorkflowRunRevisionConflictError ||
+			error instanceof NonDeterminismError
+		) {
+			return true;
+		}
+
+		logger.error("Unexpected error during workflow execution", {
+			"aiki.error": error instanceof Error ? error.message : String(error),
+			"aiki.stack": error instanceof Error ? error.stack : undefined,
+		});
+		return false;
+	} finally {
+		if (heartbeatInterval) {
+			clearInterval(heartbeatInterval);
+		}
+	}
+}

--- a/sdk/workflow/workflow.ts
+++ b/sdk/workflow/workflow.ts
@@ -3,7 +3,12 @@ import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 
 import type { EventsDefinition } from "./run/event";
-import { type WorkflowVersion, WorkflowVersionImpl, type WorkflowVersionParams } from "./workflow-version";
+import {
+	type UnknownWorkflowVersion,
+	type WorkflowVersion,
+	WorkflowVersionImpl,
+	type WorkflowVersionParams,
+} from "./workflow-version";
 
 /**
  * Defines a durable workflow with versioning and multiple task execution.
@@ -74,15 +79,15 @@ export interface Workflow {
 	) => WorkflowVersion<Input, Output, AppContext, TEvents>;
 
 	[INTERNAL]: {
-		getAllVersions: () => WorkflowVersion<unknown, unknown, unknown>[];
-		getVersion: (versionId: WorkflowVersionId) => WorkflowVersion<unknown, unknown, unknown> | undefined;
+		getAllVersions: () => UnknownWorkflowVersion[];
+		getVersion: (versionId: WorkflowVersionId) => UnknownWorkflowVersion | undefined;
 	};
 }
 
 class WorkflowImpl implements Workflow {
 	public readonly name: WorkflowName;
 	public readonly [INTERNAL]: Workflow[typeof INTERNAL];
-	private workflowVersions = new Map<WorkflowVersionId, WorkflowVersion<unknown, unknown, unknown>>();
+	private workflowVersions = new Map<WorkflowVersionId, UnknownWorkflowVersion>();
 
 	constructor(params: WorkflowParams) {
 		this.name = params.name as WorkflowName;
@@ -101,19 +106,16 @@ class WorkflowImpl implements Workflow {
 		}
 
 		const workflowVersion = new WorkflowVersionImpl(this.name, versionId as WorkflowVersionId, params);
-		this.workflowVersions.set(
-			versionId as WorkflowVersionId,
-			workflowVersion as unknown as WorkflowVersion<unknown, unknown, unknown>
-		);
+		this.workflowVersions.set(versionId as WorkflowVersionId, workflowVersion as unknown as UnknownWorkflowVersion);
 
 		return workflowVersion;
 	}
 
-	private getAllVersions(): WorkflowVersion<unknown, unknown, unknown>[] {
+	private getAllVersions(): UnknownWorkflowVersion[] {
 		return Array.from(this.workflowVersions.values());
 	}
 
-	private getVersion(versionId: WorkflowVersionId): WorkflowVersion<unknown, unknown, unknown> | undefined {
+	private getVersion(versionId: WorkflowVersionId): UnknownWorkflowVersion | undefined {
 		return this.workflowVersions.get(versionId);
 	}
 }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,6 +7,7 @@ COPY lib/package.json ./lib/
 COPY types/package.json ./types/
 COPY server/package.json ./server/
 COPY sdk/client/package.json ./sdk/client/
+COPY sdk/endpoint/package.json ./sdk/endpoint/
 COPY sdk/subscriber/db/package.json ./sdk/subscriber/db/
 COPY sdk/subscriber/redis/package.json ./sdk/subscriber/redis/
 COPY sdk/task/package.json ./sdk/task/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,14 +11,15 @@
 
 		"baseUrl": ".",
 		"paths": {
-			"@aikirun/lib/*": ["./lib/*/index.ts"],
-			"@aikirun/types/*": ["./types/*.ts"],
 			"@aikirun/client": ["./sdk/client/index.ts"],
+			"@aikirun/endpoint": ["./sdk/endpoint/index.ts"],
+			"@aikirun/lib/*": ["./lib/*/index.ts"],
 			"@aikirun/subscriber-db": ["./sdk/subscriber/db/index.ts"],
 			"@aikirun/subscriber-redis": ["./sdk/subscriber/redis/index.ts"],
-			"@aikirun/workflow": ["./sdk/workflow/index.ts"],
 			"@aikirun/task": ["./sdk/task/index.ts"],
-			"@aikirun/worker": ["./sdk/worker/index.ts"]
+			"@aikirun/types/*": ["./types/*.ts"],
+			"@aikirun/worker": ["./sdk/worker/index.ts"],
+			"@aikirun/workflow": ["./sdk/workflow/index.ts"]
 		},
 
 		"esModuleInterop": true,

--- a/types/client.ts
+++ b/types/client.ts
@@ -5,14 +5,14 @@ import type { WorkflowRunApi } from "@aikirun/types/workflow-run-api";
 import type { Logger } from "./logger";
 import { INTERNAL } from "./symbols";
 
-export interface ClientParams<AppContext = unknown> {
+export interface ClientParams<AppContext = null> {
 	url: string;
 	apiKey?: string;
 	logger?: Logger;
 	createContext?: (run: Readonly<WorkflowRun>) => AppContext | Promise<AppContext>;
 }
 
-export interface Client<AppContext = unknown> {
+export interface Client<AppContext = null> {
 	api: ApiClient;
 	logger: Logger;
 	[INTERNAL]: {

--- a/types/worker.ts
+++ b/types/worker.ts
@@ -1,3 +1,1 @@
-export type WorkerName = string & { _brand: "worker_name" };
-
 export type WorkerId = string & { _brand: "worker_id" };

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,6 +7,7 @@ COPY lib/package.json ./lib/
 COPY types/package.json ./types/
 COPY server/package.json ./server/
 COPY sdk/client/package.json ./sdk/client/
+COPY sdk/endpoint/package.json ./sdk/endpoint/
 COPY sdk/subscriber/db/package.json ./sdk/subscriber/db/
 COPY sdk/subscriber/redis/package.json ./sdk/subscriber/redis/
 COPY sdk/task/package.json ./sdk/task/


### PR DESCRIPTION
Introduce a new SDK package that enables serverless environments to execute workflows via HTTP push instead of long-lived polling.

- Extract shared execution logic from worker into sdk/workflow/run/execute.ts so both worker and endpoint reuse the same engine
- Add HMAC-SHA256 signature verification for secure request validation using Web Crypto API (cross-runtime compatible)
- Simplify heartbeat implementations across endpoint, db subscriber, and redis subscriber. Error handling is now centralized in executeWorkflowRun
- Remove worker name from WorkerParams and update all docs