### PR TITLE
feat: Add SQLite database provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,14 @@
 
 .claude
 
+.env
 app/server/.env
 app/server/.env.prod
 examples/.env
+
+*.db
+*.db-shm
+*.db-wal
 
 notes/
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ Install the Aiki SDK:
 npm install @aikirun/workflow @aikirun/client @aikirun/worker
 ```
 
-Start Aiki (requires PostgreSQL — see [Installation Guide](./docs/getting-started/installation.md)):
+Start Aiki (PostgreSQL by default, or SQLite for a zero-dependency setup — see [Installation Guide](./docs/getting-started/installation.md)):
 
 ```bash
 # First clone the repo
 git clone https://github.com/aikirun/aiki.git
 cd aiki
 
-# Configure your database connection, then start
+# docker-compose provisions PostgreSQL; skip it when using DATABASE_PROVIDER=sqlite
 docker-compose up
 
 # Or run directly with Bun

--- a/cli/src/commands/migrate-apply.ts
+++ b/cli/src/commands/migrate-apply.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { ConsoleLogger } from "@aikirun/lib/logger";
 
-import { loadDatabaseConfig, type PgDatabaseConfig } from "../lib/db-config";
+import { loadDatabaseConfig, type PgDatabaseConfig, type SqliteDatabaseConfig } from "../lib/db-config";
 import { loadEnv } from "../lib/env";
 import { resolvePackageRoot, type SupportedPackage } from "../lib/resolve-package";
 
@@ -24,6 +24,8 @@ export async function migrateApply(options: MigrateApplyOptions): Promise<void> 
 			await applyPg(dbConfig, migrationsFolder, migrationsTable, logger);
 			break;
 		case "sqlite":
+			await applySqlite(dbConfig, migrationsFolder, migrationsTable, logger);
+			break;
 		case "mysql":
 			throw new Error(`DATABASE_PROVIDER=${dbConfig.provider} is not yet supported by aiki migrate.`);
 		default:
@@ -86,5 +88,27 @@ async function applyPg(
 		logger.info("Migrations applied");
 	} finally {
 		await client.end();
+	}
+}
+
+async function applySqlite(
+	config: SqliteDatabaseConfig,
+	migrationsFolder: string,
+	migrationsTable: string,
+	logger: ConsoleLogger
+): Promise<void> {
+	const { Database } = await import("bun:sqlite");
+	const { drizzle } = await import("drizzle-orm/bun-sqlite");
+	const { migrate } = await import("drizzle-orm/bun-sqlite/migrator");
+
+	const client = new Database(config.path);
+	client.exec("PRAGMA journal_mode = WAL");
+	client.exec("PRAGMA foreign_keys = ON");
+
+	try {
+		migrate(drizzle(client), { migrationsFolder, migrationsTable });
+		logger.info("Migrations applied");
+	} finally {
+		client.close();
 	}
 }

--- a/sdk/iam/src/auth.ts
+++ b/sdk/iam/src/auth.ts
@@ -2,11 +2,14 @@ import type { Database } from "@aikirun/types/infra/db";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
+import { drizzle as bunSqliteDrizzle } from "drizzle-orm/bun-sqlite";
 import { drizzle } from "drizzle-orm/postgres-js";
 
 import type { PgClient } from "./infra/db/pg/provider";
 import * as schema from "./infra/db/pg/schema";
 import { extractDbClient } from "./infra/db/repo";
+import { sqliteBetterAuthSchema } from "./infra/db/sqlite/better-auth";
+import type { SqliteClient } from "./infra/db/sqlite/provider";
 
 const pgBetterAuthSchema = {
 	user: schema.user,
@@ -35,8 +38,11 @@ function createDrizzleAdapter(db: Database) {
 		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		case "sqlite": {
+			const client = extractDbClient(db) as SqliteClient;
+			const handle = bunSqliteDrizzle(client, { schema: sqliteBetterAuthSchema });
+			return drizzleAdapter(handle, { provider: db.provider, schema: sqliteBetterAuthSchema });
+		}
 		default:
 			return db.provider satisfies never;
 	}

--- a/sdk/iam/src/infra/db/repo.ts
+++ b/sdk/iam/src/infra/db/repo.ts
@@ -3,6 +3,8 @@ import { INTERNAL } from "@aikirun/types/symbols";
 
 import { createPgRepos } from "./pg";
 import { createPgHandle, type PgClient } from "./pg/provider";
+import { createSqliteRepos } from "./sqlite";
+import { createSqliteHandle, type SqliteClient } from "./sqlite/provider";
 import type { Repositories } from "./types";
 
 export function extractDbClient(db: Database): unknown {
@@ -22,8 +24,11 @@ export function createRepos(database: Database): Repositories {
 		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		case "sqlite": {
+			const client = extractDbClient(database) as SqliteClient;
+			const handle = createSqliteHandle(client);
+			return createSqliteRepos(handle, client);
+		}
 		default:
 			return database.provider satisfies never;
 	}

--- a/sdk/iam/src/infra/db/sqlite/better-auth.ts
+++ b/sdk/iam/src/infra/db/sqlite/better-auth.ts
@@ -1,0 +1,23 @@
+import {
+	account,
+	namespace,
+	namespaceMember,
+	organization,
+	organizationInvitation,
+	organizationMember,
+	session,
+	user,
+	verification,
+} from "./schema";
+
+export const sqliteBetterAuthSchema = {
+	user,
+	session,
+	account,
+	verification,
+	organization,
+	organization_member: organizationMember,
+	organization_invitation: organizationInvitation,
+	namespace,
+	namespace_member: namespaceMember,
+};

--- a/sdk/iam/src/infra/db/sqlite/custom-types.ts
+++ b/sdk/iam/src/infra/db/sqlite/custom-types.ts
@@ -1,0 +1,32 @@
+import { sql } from "drizzle-orm";
+import { customType } from "drizzle-orm/sqlite-core";
+
+// iam stores timestamps as epoch milliseconds (matching the pg `timestampMs` type).
+export const sqliteTimestampMs = customType<{ data: number; driverData: number }>({
+	dataType() {
+		return "integer";
+	},
+	fromDriver(value: number): number {
+		return value;
+	},
+	toDriver(value: number | Date): number {
+		if (value instanceof Date) return value.getTime();
+		return value;
+	},
+});
+
+export const sqliteJson = customType<{ data: unknown; driverData: string }>({
+	dataType() {
+		return "text";
+	},
+	fromDriver(value: string): unknown {
+		if (value === null || value === undefined) return null;
+		return typeof value === "string" ? JSON.parse(value) : value;
+	},
+	toDriver(value: unknown): string {
+		if (value === null || value === undefined) return null as unknown as string;
+		return JSON.stringify(value);
+	},
+});
+
+export const SQLITE_CURRENT_TIMESTAMP_MS = sql`(cast(unixepoch('subsec') * 1000 as integer))`;

--- a/sdk/iam/src/infra/db/sqlite/index.ts
+++ b/sdk/iam/src/infra/db/sqlite/index.ts
@@ -1,0 +1,85 @@
+import type { SqliteClient, SqliteDb, SqliteHandle } from "./provider";
+import { createApiKeyRepository } from "./repository/api-key";
+import { createNamespaceRepository } from "./repository/namespace";
+import { createOrganizationRepository } from "./repository/organization";
+import { createSessionRepository } from "./repository/session";
+import type { Repositories } from "../types";
+
+// bun:sqlite is synchronous and drizzle's bun-sqlite transactions cannot wrap async
+// callbacks, so serialize all DB access through a single queue and drive BEGIN/COMMIT
+// on the raw connection. NOTE: this serializer is scoped to the iam repositories; it
+// does not coordinate with the server package's serializer over the same connection
+// (see PR notes on cross-package transactions).
+function createTransactionSerializer() {
+	let queue: Promise<void> = Promise.resolve();
+
+	return function serialize<T>(fn: () => Promise<T>): Promise<T> {
+		let release: () => void;
+		const prevQueue = queue;
+		queue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		return prevQueue.then(async () => {
+			try {
+				return await fn();
+			} finally {
+				release?.();
+			}
+		});
+	};
+}
+
+export function createSqliteRepos(handle: SqliteHandle, client: SqliteClient): Repositories {
+	const serialize = createTransactionSerializer();
+	const serializedRepos = wrapSerialized(createRepos(handle), serialize);
+
+	return {
+		...serializedRepos,
+		async transaction<T>(fn: (txRepos: Omit<Repositories, "transaction">) => Promise<T>): Promise<T> {
+			return serialize(async () => {
+				client.exec("BEGIN IMMEDIATE");
+				try {
+					const result = await fn(createRepos(handle));
+					client.exec("COMMIT");
+					return result;
+				} catch (e) {
+					try {
+						client.exec("ROLLBACK");
+					} catch {
+						// ROLLBACK throws if SQLite already auto-rolled-back; ignore.
+					}
+					throw e;
+				}
+			});
+		},
+	};
+}
+
+function createRepos(db: SqliteDb): Omit<Repositories, "transaction"> {
+	return {
+		namespace: createNamespaceRepository(db),
+		organization: createOrganizationRepository(db),
+		session: createSessionRepository(db),
+		apiKey: createApiKeyRepository(db),
+	};
+}
+
+function wrapSerialized(
+	repos: Omit<Repositories, "transaction">,
+	serialize: <T>(fn: () => Promise<T>) => Promise<T>
+): Omit<Repositories, "transaction"> {
+	const serialized = {} as Record<string, Record<string, unknown>>;
+
+	for (const [repoName, repo] of Object.entries(repos as Record<string, Record<string, unknown>>)) {
+		serialized[repoName] = {};
+		for (const [methodName, method] of Object.entries(repo)) {
+			if (typeof method === "function") {
+				serialized[repoName][methodName] = (...args: unknown[]) =>
+					serialize(() => (method as (...a: unknown[]) => Promise<unknown>).apply(repo, args));
+			}
+		}
+	}
+
+	return serialized as Omit<Repositories, "transaction">;
+}

--- a/sdk/iam/src/infra/db/sqlite/migration/0000_open_tana_nile.sql
+++ b/sdk/iam/src/infra/db/sqlite/migration/0000_open_tana_nile.sql
@@ -1,0 +1,141 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`access_token_expires_at` integer,
+	`refresh_token_expires_at` integer,
+	`scope` text,
+	`id_token` text,
+	`password` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_account_user_provider` ON `account` (`user_id`,`provider_id`);--> statement-breakpoint
+CREATE TABLE `api_key` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`created_by_user_id` text NOT NULL,
+	`name` text NOT NULL,
+	`key_hash` text NOT NULL,
+	`key_prefix` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`expires_at` integer,
+	`revoked_at` integer,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`namespace_id`) REFERENCES `namespace`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_api_key_key_hash` ON `api_key` (`key_hash`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_api_key_namespace_created_by_user_name` ON `api_key` (`namespace_id`,`created_by_user_id`,`name`);--> statement-breakpoint
+CREATE INDEX `idx_api_key_namespace_name` ON `api_key` (`namespace_id`,`name`);--> statement-breakpoint
+CREATE TABLE `namespace` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_namespace_org_name` ON `namespace` (`organization_id`,`name`);--> statement-breakpoint
+CREATE TABLE `namespace_member` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`role` text DEFAULT 'viewer' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`namespace_id`) REFERENCES `namespace`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_namespace_member_namespace_user` ON `namespace_member` (`namespace_id`,`user_id`);--> statement-breakpoint
+CREATE INDEX `idx_namespace_member_user_id` ON `namespace_member` (`user_id`);--> statement-breakpoint
+CREATE TABLE `organization` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`slug` text NOT NULL,
+	`logo` text,
+	`metadata` text,
+	`type` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_organization_slug` ON `organization` (`slug`);--> statement-breakpoint
+CREATE TABLE `organization_invitation` (
+	`id` text PRIMARY KEY NOT NULL,
+	`email` text NOT NULL,
+	`inviter_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`role` text NOT NULL,
+	`status` text NOT NULL,
+	`namespace_id` text,
+	`expires_at` integer NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`inviter_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_org_invitation_pending_email_org_namespace` ON `organization_invitation` (`email`,`organization_id`,`namespace_id`) WHERE "organization_invitation"."status" = 'pending';--> statement-breakpoint
+CREATE TABLE `organization_member` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`role` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`organization_id`) REFERENCES `organization`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_org_member_org_user` ON `organization_member` (`organization_id`,`user_id`);--> statement-breakpoint
+CREATE INDEX `idx_org_member_user_id` ON `organization_member` (`user_id`);--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`token` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`active_organization_id` text,
+	`active_namespace_id` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_session_token` ON `session` (`token`);--> statement-breakpoint
+CREATE INDEX `idx_session_active_namespace_id` ON `session` (`active_namespace_id`);--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text,
+	`email` text NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`status` text DEFAULT 'active' NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_user_email` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsec') * 1000 as integer)) NOT NULL
+);

--- a/sdk/iam/src/infra/db/sqlite/migration/meta/0000_snapshot.json
+++ b/sdk/iam/src/infra/db/sqlite/migration/meta/0000_snapshot.json
@@ -1,0 +1,941 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "0902b260-13a8-48a7-8369-6935653684b9",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uqidx_account_user_provider": {
+					"name": "uqidx_account_user_provider",
+					"columns": ["user_id", "provider_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"fk_account_user_id": {
+					"name": "fk_account_user_id",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"api_key": {
+			"name": "api_key",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uq_api_key_key_hash": {
+					"name": "uq_api_key_key_hash",
+					"columns": ["key_hash"],
+					"isUnique": true
+				},
+				"uqidx_api_key_namespace_created_by_user_name": {
+					"name": "uqidx_api_key_namespace_created_by_user_name",
+					"columns": ["namespace_id", "created_by_user_id", "name"],
+					"isUnique": true
+				},
+				"idx_api_key_namespace_name": {
+					"name": "idx_api_key_namespace_name",
+					"columns": ["namespace_id", "name"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_api_key_namespace_id": {
+					"name": "fk_api_key_namespace_id",
+					"tableFrom": "api_key",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"fk_api_key_organization_id": {
+					"name": "fk_api_key_organization_id",
+					"tableFrom": "api_key",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"fk_api_key_created_by_user_id": {
+					"name": "fk_api_key_created_by_user_id",
+					"tableFrom": "api_key",
+					"tableTo": "user",
+					"columnsFrom": ["created_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"namespace": {
+			"name": "namespace",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uqidx_namespace_org_name": {
+					"name": "uqidx_namespace_org_name",
+					"columns": ["organization_id", "name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"fk_namespace_org_id": {
+					"name": "fk_namespace_org_id",
+					"tableFrom": "namespace",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"namespace_member": {
+			"name": "namespace_member",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'viewer'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uqidx_namespace_member_namespace_user": {
+					"name": "uqidx_namespace_member_namespace_user",
+					"columns": ["namespace_id", "user_id"],
+					"isUnique": true
+				},
+				"idx_namespace_member_user_id": {
+					"name": "idx_namespace_member_user_id",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_namespace_member_namespace_id": {
+					"name": "fk_namespace_member_namespace_id",
+					"tableFrom": "namespace_member",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_namespace_member_user_id": {
+					"name": "fk_namespace_member_user_id",
+					"tableFrom": "namespace_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"organization": {
+			"name": "organization",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uq_organization_slug": {
+					"name": "uq_organization_slug",
+					"columns": ["slug"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"organization_invitation": {
+			"name": "organization_invitation",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uqidx_org_invitation_pending_email_org_namespace": {
+					"name": "uqidx_org_invitation_pending_email_org_namespace",
+					"columns": ["email", "organization_id", "namespace_id"],
+					"isUnique": true,
+					"where": "\"organization_invitation\".\"status\" = 'pending'"
+				}
+			},
+			"foreignKeys": {
+				"fk_org_invitation_inviter_id": {
+					"name": "fk_org_invitation_inviter_id",
+					"tableFrom": "organization_invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_org_invitation_organization_id": {
+					"name": "fk_org_invitation_organization_id",
+					"tableFrom": "organization_invitation",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"organization_member": {
+			"name": "organization_member",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uqidx_org_member_org_user": {
+					"name": "uqidx_org_member_org_user",
+					"columns": ["organization_id", "user_id"],
+					"isUnique": true
+				},
+				"idx_org_member_user_id": {
+					"name": "idx_org_member_user_id",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_org_member_user_id": {
+					"name": "fk_org_member_user_id",
+					"tableFrom": "organization_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_org_member_org_id": {
+					"name": "fk_org_member_org_id",
+					"tableFrom": "organization_member",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"active_namespace_id": {
+					"name": "active_namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uq_session_token": {
+					"name": "uq_session_token",
+					"columns": ["token"],
+					"isUnique": true
+				},
+				"idx_session_active_namespace_id": {
+					"name": "idx_session_active_namespace_id",
+					"columns": ["active_namespace_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_session_user_id": {
+					"name": "fk_session_user_id",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {
+				"uq_user_email": {
+					"name": "uq_user_email",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(cast(unixepoch('subsec') * 1000 as integer))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/sdk/iam/src/infra/db/sqlite/migration/meta/_journal.json
+++ b/sdk/iam/src/infra/db/sqlite/migration/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1780012680199,
+			"tag": "0000_open_tana_nile",
+			"breakpoints": true
+		}
+	]
+}

--- a/sdk/iam/src/infra/db/sqlite/provider.ts
+++ b/sdk/iam/src/infra/db/sqlite/provider.ts
@@ -1,0 +1,14 @@
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "./schema";
+import type { Database } from "bun:sqlite";
+
+export type SqliteClient = Database;
+
+export function createSqliteHandle(client: SqliteClient) {
+	return drizzle(client, { schema });
+}
+
+export type SqliteHandle = ReturnType<typeof createSqliteHandle>;
+export type SqliteTransaction = Parameters<Parameters<SqliteHandle["transaction"]>[0]>[0];
+export type SqliteDb = SqliteHandle | SqliteTransaction;

--- a/sdk/iam/src/infra/db/sqlite/repository/api-key.ts
+++ b/sdk/iam/src/infra/db/sqlite/repository/api-key.ts
@@ -1,0 +1,86 @@
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { OrganizationId } from "@aikirun/types/organization";
+import { and, eq } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { apiKey } from "../schema";
+
+export type ApiKeyRow = typeof apiKey.$inferSelect;
+export type ApiKeyRowInsert = typeof apiKey.$inferInsert;
+
+export function createApiKeyRepository(db: SqliteDb) {
+	return {
+		async create(input: ApiKeyRowInsert): Promise<ApiKeyRow> {
+			const result = await db.insert(apiKey).values(input).returning();
+			const created = result[0];
+			if (!created) {
+				throw new Error("Failed to create API key - no row returned");
+			}
+			return created;
+		},
+
+		async getByActiveKeyByHash(keyHash: string): Promise<ApiKeyRow | null> {
+			const result = await db
+				.select()
+				.from(apiKey)
+				.where(and(eq(apiKey.status, "active"), eq(apiKey.keyHash, keyHash)));
+			return result[0] ?? null;
+		},
+
+		async list(filter: {
+			organizationId: OrganizationId;
+			namespaceId: NamespaceId;
+			createdByUserId?: string;
+			name?: string;
+		}) {
+			return db
+				.select({
+					id: apiKey.id,
+					name: apiKey.name,
+					keyPrefix: apiKey.keyPrefix,
+					status: apiKey.status,
+					createdAt: apiKey.createdAt,
+					expiresAt: apiKey.expiresAt,
+				})
+				.from(apiKey)
+				.where(
+					and(
+						eq(apiKey.organizationId, filter.organizationId),
+						eq(apiKey.namespaceId, filter.namespaceId),
+						filter.createdByUserId !== undefined ? eq(apiKey.createdByUserId, filter.createdByUserId) : undefined,
+						filter.name !== undefined ? eq(apiKey.name, filter.name) : undefined
+					)
+				);
+		},
+
+		async expire(id: string): Promise<void> {
+			await db.update(apiKey).set({ status: "expired" }).where(eq(apiKey.id, id));
+		},
+
+		async revoke(filter: { id: string; namespaceId: NamespaceId }): Promise<string | null> {
+			const rows = await db
+				.update(apiKey)
+				.set({
+					status: "revoked",
+					revokedAt: Date.now(),
+				})
+				.where(and(eq(apiKey.id, filter.id), eq(apiKey.namespaceId, filter.namespaceId)))
+				.returning({ keyHash: apiKey.keyHash });
+			return rows[0]?.keyHash ?? null;
+		},
+
+		async revokeByNamespace(namespaceId: NamespaceId): Promise<string[]> {
+			const rows = await db
+				.update(apiKey)
+				.set({
+					status: "revoked",
+					revokedAt: Date.now(),
+				})
+				.where(and(eq(apiKey.namespaceId, namespaceId), eq(apiKey.status, "active")))
+				.returning({ keyHash: apiKey.keyHash });
+			return rows.map((row) => row.keyHash);
+		},
+	};
+}
+
+export type ApiKeyRepository = ReturnType<typeof createApiKeyRepository>;

--- a/sdk/iam/src/infra/db/sqlite/repository/namespace.ts
+++ b/sdk/iam/src/infra/db/sqlite/repository/namespace.ts
@@ -1,0 +1,151 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import { ConflictError } from "@aikirun/lib/error";
+import type { NamespaceRole } from "@aikirun/types/namespace";
+import { and, eq, sql } from "drizzle-orm";
+import { ulid } from "ulidx";
+
+import type { NamespaceMemberInfo, NamespaceMemberInput } from "../../../../contract/schema/namespace";
+import type { SqliteDb } from "../provider";
+import { namespace, namespaceMember, user } from "../schema";
+
+export type NamespaceRow = typeof namespace.$inferSelect;
+export type NamespaceRowInsert = Pick<typeof namespace.$inferInsert, "name" | "organizationId">;
+export type NamespaceMemberRowInsert = Pick<typeof namespaceMember.$inferInsert, "userId" | "role">;
+export type NamespaceMemberRow = typeof namespaceMember.$inferSelect;
+export type NamespaceRowWithRole = NamespaceRow & { role: NamespaceRole };
+
+export function createNamespaceRepository(db: SqliteDb) {
+	return {
+		async create(namespaceParams: NamespaceRowInsert): Promise<NamespaceRow> {
+			const [createdNamespace] = await db
+				.insert(namespace)
+				.values({ ...namespaceParams, id: ulid() })
+				.onConflictDoUpdate({
+					target: [namespace.organizationId, namespace.name],
+					set: { status: "active" },
+					where: eq(namespace.status, "deleted"),
+				})
+				.returning();
+			if (!createdNamespace) {
+				throw new ConflictError(`Namespace with name "${namespaceParams.name}" already exists`);
+			}
+
+			return createdNamespace;
+		},
+
+		async createMember(memberParams: NamespaceMemberRowInsert & { id: string; namespaceId: string }): Promise<void> {
+			await db
+				.insert(namespaceMember)
+				.values(memberParams)
+				.onConflictDoUpdate({
+					target: [namespaceMember.namespaceId, namespaceMember.userId],
+					set: { role: memberParams.role },
+				});
+		},
+
+		async getMember(namespaceId: string, userId: string): Promise<NamespaceMemberRow | null> {
+			const [row] = await db
+				.select()
+				.from(namespaceMember)
+				.where(and(eq(namespaceMember.namespaceId, namespaceId), eq(namespaceMember.userId, userId)))
+				.limit(1);
+			return row ?? null;
+		},
+
+		async exists(filter: { organizationId: string; namespaceId: string }): Promise<boolean> {
+			const [row] = await db
+				.select({ id: namespace.id })
+				.from(namespace)
+				.where(and(eq(namespace.organizationId, filter.organizationId), eq(namespace.id, filter.namespaceId)))
+				.limit(1);
+			return row?.id !== undefined;
+		},
+
+		async listByUser(organizationId: string, userId: string): Promise<NamespaceRowWithRole[]> {
+			const rows = await db
+				.select({
+					id: namespace.id,
+					name: namespace.name,
+					organizationId: namespace.organizationId,
+					status: namespace.status,
+					createdAt: namespace.createdAt,
+					updatedAt: namespace.updatedAt,
+					role: namespaceMember.role,
+				})
+				.from(namespace)
+				.innerJoin(namespaceMember, eq(namespace.id, namespaceMember.namespaceId))
+				.where(
+					and(
+						eq(namespace.organizationId, organizationId),
+						eq(namespaceMember.userId, userId),
+						eq(namespace.status, "active")
+					)
+				);
+			return rows;
+		},
+
+		async listByOrganization(organizationId: string): Promise<NamespaceRow[]> {
+			return db
+				.select()
+				.from(namespace)
+				.where(and(eq(namespace.organizationId, organizationId), eq(namespace.status, "active")));
+		},
+
+		async softDelete(namespaceId: string): Promise<void> {
+			await db.update(namespace).set({ status: "deleted" }).where(eq(namespace.id, namespaceId));
+		},
+
+		async upsertMembers(namespaceId: string, members: NonEmptyArray<NamespaceMemberInput>): Promise<void> {
+			await db
+				.insert(namespaceMember)
+				.values(
+					members.map((m) => ({
+						id: ulid(),
+						namespaceId,
+						userId: m.userId,
+						role: m.role,
+					}))
+				)
+				.onConflictDoUpdate({
+					target: [namespaceMember.namespaceId, namespaceMember.userId],
+					set: { role: sql`excluded.role` },
+				});
+		},
+
+		async removeMember(namespaceId: string, userId: string): Promise<void> {
+			await db
+				.delete(namespaceMember)
+				.where(and(eq(namespaceMember.namespaceId, namespaceId), eq(namespaceMember.userId, userId)));
+		},
+
+		async listMembers(namespaceId: string): Promise<NamespaceMemberInfo[]> {
+			const rows = await db
+				.select({
+					userId: namespaceMember.userId,
+					name: user.name,
+					email: user.email,
+					role: namespaceMember.role,
+				})
+				.from(namespaceMember)
+				.innerJoin(user, eq(namespaceMember.userId, user.id))
+				.where(eq(namespaceMember.namespaceId, namespaceId));
+			return rows.map((row) => ({
+				userId: row.userId,
+				name: row.name ?? undefined,
+				email: row.email,
+				role: row.role,
+			}));
+		},
+
+		async countActiveByOrganizationForUpdate(organizationId: string): Promise<number> {
+			// SQLite has no SELECT ... FOR UPDATE; the transaction serializer provides isolation.
+			const rows = await db
+				.select({ id: namespace.id })
+				.from(namespace)
+				.where(and(eq(namespace.organizationId, organizationId), eq(namespace.status, "active")));
+			return rows.length;
+		},
+	};
+}
+
+export type NamespaceRepository = ReturnType<typeof createNamespaceRepository>;

--- a/sdk/iam/src/infra/db/sqlite/repository/organization.ts
+++ b/sdk/iam/src/infra/db/sqlite/repository/organization.ts
@@ -1,0 +1,19 @@
+import { and, eq } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { organizationMember } from "../schema";
+
+export function createOrganizationRepository(db: SqliteDb) {
+	return {
+		async getMemberRole(organizationId: string, userId: string) {
+			const [row] = await db
+				.select({ role: organizationMember.role })
+				.from(organizationMember)
+				.where(and(eq(organizationMember.organizationId, organizationId), eq(organizationMember.userId, userId)))
+				.limit(1);
+			return row?.role ?? null;
+		},
+	};
+}
+
+export type OrganizationRepository = ReturnType<typeof createOrganizationRepository>;

--- a/sdk/iam/src/infra/db/sqlite/repository/session.ts
+++ b/sdk/iam/src/infra/db/sqlite/repository/session.ts
@@ -1,0 +1,14 @@
+import { eq } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { session } from "../schema";
+
+export function createSessionRepository(db: SqliteDb) {
+	return {
+		async clearActiveByNamespaceId(namespaceId: string): Promise<void> {
+			await db.update(session).set({ activeNamespaceId: null }).where(eq(session.activeNamespaceId, namespaceId));
+		},
+	};
+}
+
+export type SessionRepository = ReturnType<typeof createSessionRepository>;

--- a/sdk/iam/src/infra/db/sqlite/schema.ts
+++ b/sdk/iam/src/infra/db/sqlite/schema.ts
@@ -1,0 +1,241 @@
+import { NAMESPACE_ROLES } from "@aikirun/types/namespace";
+import { sql } from "drizzle-orm";
+import { foreignKey, index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+import { SQLITE_CURRENT_TIMESTAMP_MS, sqliteJson, sqliteTimestampMs } from "./custom-types";
+import { API_KEY_STATUSES } from "../constants/api-key";
+import { NAMESPACE_STATUSES } from "../constants/namespace";
+import {
+	ORGANIZATION_INVITATION_STATUSES,
+	ORGANIZATION_ROLES,
+	ORGANIZATION_STATUSES,
+	ORGANIZATION_TYPES,
+} from "../constants/organization";
+import { USER_STATUSES } from "../constants/user";
+
+export const user = sqliteTable("user", {
+	id: text("id").primaryKey(),
+	name: text("name"),
+	email: text("email").notNull().unique("uq_user_email"),
+	emailVerified: integer("email_verified", { mode: "boolean" }).notNull().default(false),
+	image: text("image"),
+	status: text("status", { enum: USER_STATUSES }).notNull().default("active"),
+	createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+});
+
+export const session = sqliteTable(
+	"session",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id").notNull(),
+		token: text("token").notNull().unique("uq_session_token"),
+		expiresAt: sqliteTimestampMs("expires_at").notNull(),
+		ipAddress: text("ip_address"),
+		userAgent: text("user_agent"),
+		activeOrganizationId: text("active_organization_id"),
+		activeNamespaceId: text("active_namespace_id"),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_session_user_id",
+			columns: [table.userId],
+			foreignColumns: [user.id],
+		}).onDelete("cascade"),
+		index("idx_session_active_namespace_id").on(table.activeNamespaceId),
+	]
+);
+
+export const account = sqliteTable(
+	"account",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id").notNull(),
+		accountId: text("account_id").notNull(),
+		providerId: text("provider_id").notNull(),
+		accessToken: text("access_token"),
+		refreshToken: text("refresh_token"),
+		accessTokenExpiresAt: sqliteTimestampMs("access_token_expires_at"),
+		refreshTokenExpiresAt: sqliteTimestampMs("refresh_token_expires_at"),
+		scope: text("scope"),
+		idToken: text("id_token"),
+		password: text("password"),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_account_user_id",
+			columns: [table.userId],
+			foreignColumns: [user.id],
+		}).onDelete("cascade"),
+		uniqueIndex("uqidx_account_user_provider").on(table.userId, table.providerId),
+	]
+);
+
+export const verification = sqliteTable("verification", {
+	id: text("id").primaryKey(),
+	identifier: text("identifier").notNull(),
+	value: text("value").notNull(),
+	expiresAt: sqliteTimestampMs("expires_at").notNull(),
+	createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+});
+
+export const organization = sqliteTable("organization", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	slug: text("slug").notNull().unique("uq_organization_slug"),
+	logo: text("logo"),
+	metadata: sqliteJson("metadata"),
+	type: text("type", { enum: ORGANIZATION_TYPES }).notNull(),
+	status: text("status", { enum: ORGANIZATION_STATUSES }).notNull().default("active"),
+	createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+});
+
+export const organizationMember = sqliteTable(
+	"organization_member",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id").notNull(),
+		organizationId: text("organization_id").notNull(),
+		role: text("role", { enum: ORGANIZATION_ROLES }).notNull(),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_org_member_user_id",
+			columns: [table.userId],
+			foreignColumns: [user.id],
+		}),
+		foreignKey({
+			name: "fk_org_member_org_id",
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+		}),
+		uniqueIndex("uqidx_org_member_org_user").on(table.organizationId, table.userId),
+		index("idx_org_member_user_id").on(table.userId),
+	]
+);
+
+export const organizationInvitation = sqliteTable(
+	"organization_invitation",
+	{
+		id: text("id").primaryKey(),
+		email: text("email").notNull(),
+		inviterId: text("inviter_id").notNull(),
+		organizationId: text("organization_id").notNull(),
+		role: text("role", { enum: ORGANIZATION_ROLES }).notNull(),
+		status: text("status", { enum: ORGANIZATION_INVITATION_STATUSES }).notNull(),
+		namespaceId: text("namespace_id"),
+		expiresAt: sqliteTimestampMs("expires_at").notNull(),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_org_invitation_inviter_id",
+			columns: [table.inviterId],
+			foreignColumns: [user.id],
+		}),
+		foreignKey({
+			name: "fk_org_invitation_organization_id",
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+		}),
+		uniqueIndex("uqidx_org_invitation_pending_email_org_namespace")
+			.on(table.email, table.organizationId, table.namespaceId)
+			.where(sql`${table.status} = 'pending'`),
+	]
+);
+
+export const namespace = sqliteTable(
+	"namespace",
+	{
+		id: text("id").primaryKey(),
+		name: text("name").notNull(),
+		organizationId: text("organization_id").notNull(),
+		status: text("status", { enum: NAMESPACE_STATUSES }).notNull().default("active"),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_namespace_org_id",
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+		}),
+		uniqueIndex("uqidx_namespace_org_name").on(table.organizationId, table.name),
+	]
+);
+
+export const namespaceMember = sqliteTable(
+	"namespace_member",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		userId: text("user_id").notNull(),
+		role: text("role", { enum: NAMESPACE_ROLES }).notNull().default("viewer"),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_namespace_member_namespace_id",
+			columns: [table.namespaceId],
+			foreignColumns: [namespace.id],
+		}),
+		foreignKey({
+			name: "fk_namespace_member_user_id",
+			columns: [table.userId],
+			foreignColumns: [user.id],
+		}),
+		uniqueIndex("uqidx_namespace_member_namespace_user").on(table.namespaceId, table.userId),
+		index("idx_namespace_member_user_id").on(table.userId),
+	]
+);
+
+export const apiKey = sqliteTable(
+	"api_key",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		organizationId: text("organization_id").notNull(),
+		createdByUserId: text("created_by_user_id").notNull(),
+		name: text("name").notNull(),
+		keyHash: text("key_hash").notNull().unique("uq_api_key_key_hash"),
+		keyPrefix: text("key_prefix").notNull(),
+		status: text("status", { enum: API_KEY_STATUSES }).notNull().default("active"),
+		expiresAt: sqliteTimestampMs("expires_at"),
+		revokedAt: sqliteTimestampMs("revoked_at"),
+		createdAt: sqliteTimestampMs("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+		updatedAt: sqliteTimestampMs("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP_MS),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_api_key_namespace_id",
+			columns: [table.namespaceId],
+			foreignColumns: [namespace.id],
+		}).onDelete("cascade"),
+		foreignKey({
+			name: "fk_api_key_organization_id",
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+		}).onDelete("cascade"),
+		foreignKey({
+			name: "fk_api_key_created_by_user_id",
+			columns: [table.createdByUserId],
+			foreignColumns: [user.id],
+		}),
+		uniqueIndex("uqidx_api_key_namespace_created_by_user_name").on(
+			table.namespaceId,
+			table.createdByUserId,
+			table.name
+		),
+		index("idx_api_key_namespace_name").on(table.namespaceId, table.name),
+	]
+);

--- a/sdk/iam/tsup.config.ts
+++ b/sdk/iam/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 	clean: true,
 	outDir: "dist",
 	noExternal: ["@aikirun/lib"],
+	external: ["bun:sqlite"],
 	async onSuccess() {
 		for (const provider of DATABASE_PROVIDERS) {
 			const sourceDir = path.join("src", "infra", "db", provider, "migration");

--- a/sdk/server/src/infra/db/index.ts
+++ b/sdk/server/src/infra/db/index.ts
@@ -3,6 +3,7 @@ import { INTERNAL } from "@aikirun/types/symbols";
 import { type } from "arktype";
 
 import { createPgClient } from "./pg/provider";
+import { createSqliteClient } from "./sqlite/provider";
 import { type DatabaseConfig, databaseConfigSchema } from "../../config";
 
 export function database(params: DatabaseConfig): Database {
@@ -16,8 +17,10 @@ export function database(params: DatabaseConfig): Database {
 			const client = createPgClient(params);
 			return { provider: params.provider, [INTERNAL]: { client } };
 		}
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		case "sqlite": {
+			const client = createSqliteClient(params);
+			return { provider: params.provider, [INTERNAL]: { client } };
+		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
 		default:

--- a/sdk/server/src/infra/db/repo.ts
+++ b/sdk/server/src/infra/db/repo.ts
@@ -3,6 +3,8 @@ import { INTERNAL } from "@aikirun/types/symbols";
 
 import { createPgRepos } from "./pg";
 import { createPgHandle, type PgClient } from "./pg/provider";
+import { createSqliteRepos } from "./sqlite";
+import { createSqliteHandle, type SqliteClient } from "./sqlite/provider";
 import type { Repositories } from "./types";
 
 function extractDbClient(db: Database): unknown {
@@ -19,8 +21,10 @@ export function createRepos(db: Database): Repositories {
 			return createPgRepos(createPgHandle(extractDbClient(db) as PgClient));
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		case "sqlite": {
+			const client = extractDbClient(db) as SqliteClient;
+			return createSqliteRepos(createSqliteHandle(client), client);
+		}
 		default:
 			return db.provider satisfies never;
 	}

--- a/sdk/server/src/infra/db/sqlite/custom-types.ts
+++ b/sdk/server/src/infra/db/sqlite/custom-types.ts
@@ -1,0 +1,32 @@
+import { sql } from "drizzle-orm";
+import { customType } from "drizzle-orm/sqlite-core";
+
+export const sqliteTimestamp = customType<{ data: Date; driverData: string }>({
+	dataType() {
+		return "text";
+	},
+	fromDriver(value: string): Date {
+		if (value === null || value === undefined) return null as unknown as Date;
+		return new Date(value);
+	},
+	toDriver(value: Date): string {
+		return value.toISOString();
+	},
+});
+
+export const sqliteJson = customType<{ data: unknown; driverData: string }>({
+	dataType() {
+		return "text";
+	},
+	fromDriver(value: string): unknown {
+		if (value === null || value === undefined) return null;
+		return typeof value === "string" ? JSON.parse(value) : value;
+	},
+	toDriver(value: unknown): string {
+		if (value === null || value === undefined) return null as unknown as string;
+		return JSON.stringify(value);
+	},
+});
+
+// ISO-8601 UTC, lexicographically sortable so range queries on timestamp columns work.
+export const SQLITE_CURRENT_TIMESTAMP = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;

--- a/sdk/server/src/infra/db/sqlite/index.ts
+++ b/sdk/server/src/infra/db/sqlite/index.ts
@@ -1,0 +1,96 @@
+import type { SqliteClient, SqliteDb, SqliteHandle } from "./provider";
+import { createChildWorkflowRunWaitQueueRepository } from "./repository/child-workflow-run-wait-queue";
+import { createEventWaitQueueRepository } from "./repository/event-wait-queue";
+import { createScheduleRepository } from "./repository/schedule";
+import { createSleepQueueRepository } from "./repository/sleep-queue";
+import { createStateTransitionRepository } from "./repository/state-transition";
+import { createTaskRepository } from "./repository/task";
+import { createWorkflowRepository } from "./repository/workflow";
+import { createWorkflowRunRepository } from "./repository/workflow-run";
+import { createWorkflowRunOutboxRepository } from "./repository/workflow-run-outbox";
+import type { Repositories } from "../types";
+
+// bun:sqlite is synchronous and drizzle's bun-sqlite transactions cannot wrap async
+// callbacks. The new Repositories contract hands the transaction an async callback, so
+// we serialize all DB access through a single in-process queue and drive BEGIN/COMMIT
+// on the raw connection ourselves.
+function createTransactionSerializer() {
+	let queue: Promise<void> = Promise.resolve();
+
+	return function serialize<T>(fn: () => Promise<T>): Promise<T> {
+		let release: () => void;
+		const prevQueue = queue;
+		queue = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		return prevQueue.then(async () => {
+			try {
+				return await fn();
+			} finally {
+				release?.();
+			}
+		});
+	};
+}
+
+export function createSqliteRepos(handle: SqliteHandle, client: SqliteClient): Repositories {
+	const serialize = createTransactionSerializer();
+	const serializedRepos = wrapSerialized(createRepos(handle), serialize);
+
+	return {
+		...serializedRepos,
+		async transaction<T>(fn: (txRepos: Omit<Repositories, "transaction">) => Promise<T>): Promise<T> {
+			return serialize(async () => {
+				client.exec("BEGIN IMMEDIATE");
+				try {
+					// Use the unserialized repos here: this block already holds the
+					// serializer lock, so re-acquiring it per call would deadlock.
+					const result = await fn(createRepos(handle));
+					client.exec("COMMIT");
+					return result;
+				} catch (e) {
+					try {
+						client.exec("ROLLBACK");
+					} catch {
+						// ROLLBACK throws if SQLite already auto-rolled-back; ignore.
+					}
+					throw e;
+				}
+			});
+		},
+	};
+}
+
+function createRepos(db: SqliteDb): Omit<Repositories, "transaction"> {
+	return {
+		workflowRun: createWorkflowRunRepository(db),
+		task: createTaskRepository(db),
+		stateTransition: createStateTransitionRepository(db),
+		schedule: createScheduleRepository(db),
+		workflow: createWorkflowRepository(db),
+		sleepQueue: createSleepQueueRepository(db),
+		eventWaitQueue: createEventWaitQueueRepository(db),
+		childWorkflowRunWaitQueue: createChildWorkflowRunWaitQueueRepository(db),
+		workflowRunOutbox: createWorkflowRunOutboxRepository(db),
+	};
+}
+
+function wrapSerialized(
+	repos: Omit<Repositories, "transaction">,
+	serialize: <T>(fn: () => Promise<T>) => Promise<T>
+): Omit<Repositories, "transaction"> {
+	const serialized = {} as Record<string, Record<string, unknown>>;
+
+	for (const [repoName, repo] of Object.entries(repos as Record<string, Record<string, unknown>>)) {
+		serialized[repoName] = {};
+		for (const [methodName, method] of Object.entries(repo)) {
+			if (typeof method === "function") {
+				serialized[repoName][methodName] = (...args: unknown[]) =>
+					serialize(() => (method as (...a: unknown[]) => Promise<unknown>).apply(repo, args));
+			}
+		}
+	}
+
+	return serialized as Omit<Repositories, "transaction">;
+}

--- a/sdk/server/src/infra/db/sqlite/migration/0000_workable_archangel.sql
+++ b/sdk/server/src/infra/db/sqlite/migration/0000_workable_archangel.sql
@@ -1,0 +1,179 @@
+CREATE TABLE `child_workflow_run_wait_queue` (
+	`id` text PRIMARY KEY NOT NULL,
+	`parent_workflow_run_id` text NOT NULL,
+	`child_workflow_run_id` text NOT NULL,
+	`child_workflow_run_status` text NOT NULL,
+	`status` text NOT NULL,
+	`completed_at` text,
+	`timed_out_at` text,
+	`child_workflow_run_state_transition_id` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`parent_workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`child_workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`child_workflow_run_state_transition_id`) REFERENCES `state_transition`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_child_workflow_run_wait_completed_invariants" CHECK("child_workflow_run_wait_queue"."status" != 'completed' OR ("child_workflow_run_wait_queue"."completed_at" IS NOT NULL AND "child_workflow_run_wait_queue"."child_workflow_run_state_transition_id" IS NOT NULL)),
+	CONSTRAINT "chk_child_workflow_run_wait_timeout_requires_timed_out_at" CHECK("child_workflow_run_wait_queue"."status" != 'timeout' OR "child_workflow_run_wait_queue"."timed_out_at" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_child_workflow_run_wait_queue_parent_id` ON `child_workflow_run_wait_queue` (`parent_workflow_run_id`,`id`);--> statement-breakpoint
+CREATE TABLE `event_wait_queue` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workflow_run_id` text NOT NULL,
+	`name` text NOT NULL,
+	`status` text NOT NULL,
+	`reference_id` text,
+	`data` text,
+	`timed_out_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_event_wait_queue_timeout_requires_timed_out_at" CHECK("event_wait_queue"."status" != 'timeout' OR "event_wait_queue"."timed_out_at" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_event_wait_queue_workflow_run_name_reference` ON `event_wait_queue` (`workflow_run_id`,`name`,`reference_id`);--> statement-breakpoint
+CREATE INDEX `idx_event_wait_queue_workflow_run_id` ON `event_wait_queue` (`workflow_run_id`,`id`);--> statement-breakpoint
+CREATE TABLE `schedule` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`workflow_id` text NOT NULL,
+	`status` text NOT NULL,
+	`type` text NOT NULL,
+	`cron_expression` text,
+	`interval_ms` integer,
+	`overlap_policy` text,
+	`workflow_run_input` text,
+	`workflow_run_input_hash` text NOT NULL,
+	`definition_hash` text NOT NULL,
+	`reference_id` text,
+	`conflict_policy` text,
+	`last_occurrence` text,
+	`next_run_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_id`) REFERENCES `workflow`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_schedule_namespace_definition` ON `schedule` (`namespace_id`,`definition_hash`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_schedule_namespace_reference` ON `schedule` (`namespace_id`,`reference_id`);--> statement-breakpoint
+CREATE INDEX `idx_schedule_namespace_workflow` ON `schedule` (`namespace_id`,`workflow_id`);--> statement-breakpoint
+CREATE INDEX `idx_schedule_status_next_run_at_id` ON `schedule` (`status`,`next_run_at`,`id`);--> statement-breakpoint
+CREATE TABLE `sleep_queue` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workflow_run_id` text NOT NULL,
+	`name` text NOT NULL,
+	`status` text NOT NULL,
+	`awake_at` text NOT NULL,
+	`completed_at` text,
+	`cancelled_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_sleep_queue_completed_requires_completed_at" CHECK("sleep_queue"."status" != 'completed' OR "sleep_queue"."completed_at" IS NOT NULL),
+	CONSTRAINT "chk_sleep_queue_cancelled_requires_cancelled_at" CHECK("sleep_queue"."status" != 'cancelled' OR "sleep_queue"."cancelled_at" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_sleep_queue_one_active_per_run` ON `sleep_queue` (`workflow_run_id`) WHERE "sleep_queue"."status" = 'sleeping';--> statement-breakpoint
+CREATE INDEX `idx_sleep_queue_workflow_run_id` ON `sleep_queue` (`workflow_run_id`,`id`);--> statement-breakpoint
+CREATE TABLE `state_transition` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workflow_run_id` text NOT NULL,
+	`type` text NOT NULL,
+	`task_id` text,
+	`status` text NOT NULL,
+	`attempt` integer NOT NULL,
+	`state` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`task_id`) REFERENCES `task`(`id`) ON UPDATE no action ON DELETE no action,
+	CONSTRAINT "chk_task_state_transition_requires_task_id" CHECK(("state_transition"."type" = 'task' AND "state_transition"."task_id" IS NOT NULL) OR ("state_transition"."type" = 'workflow_run' AND "state_transition"."task_id" IS NULL)),
+	CONSTRAINT "chk_state_transition_status_matches_type" CHECK((type = 'workflow_run' AND status IN ('scheduled', 'queued', 'running', 'paused', 'sleeping', 'awaiting_event', 'awaiting_retry', 'awaiting_child_workflow', 'cancelled', 'completed', 'failed')) OR (type = 'task' AND status IN ('running', 'awaiting_retry', 'completed', 'failed', 'discarded')))
+);
+--> statement-breakpoint
+CREATE INDEX `idx_state_transition_workflow_run_id` ON `state_transition` (`workflow_run_id`,`id`);--> statement-breakpoint
+CREATE TABLE `task` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`workflow_run_id` text NOT NULL,
+	`status` text NOT NULL,
+	`attempts` integer NOT NULL,
+	`input` text,
+	`input_hash` text NOT NULL,
+	`options` text,
+	`latest_state_transition_id` text NOT NULL,
+	`next_attempt_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `idx_task_workflow_run_id` ON `task` (`workflow_run_id`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_task_workflow_run_status` ON `task` (`workflow_run_id`,`status`);--> statement-breakpoint
+CREATE INDEX `idx_task_status_next_attempt_at_workflow_run` ON `task` (`status`,`next_attempt_at`,`workflow_run_id`);--> statement-breakpoint
+CREATE TABLE `workflow` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`source` text DEFAULT 'user' NOT NULL,
+	`name` text NOT NULL,
+	`version_id` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_workflow_namespace_source_name_version` ON `workflow` (`namespace_id`,`source`,`name`,`version_id`);--> statement-breakpoint
+CREATE TABLE `workflow_run` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`workflow_id` text NOT NULL,
+	`schedule_id` text,
+	`parent_workflow_run_id` text,
+	`status` text NOT NULL,
+	`revision` integer DEFAULT 0 NOT NULL,
+	`attempts` integer DEFAULT 1 NOT NULL,
+	`input` text,
+	`input_hash` text NOT NULL,
+	`options` text,
+	`reference_id` text,
+	`conflict_policy` text,
+	`latest_state_transition_id` text NOT NULL,
+	`scheduled_at` text,
+	`awake_at` text,
+	`timeout_at` text,
+	`next_attempt_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`workflow_id`) REFERENCES `workflow`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`schedule_id`) REFERENCES `schedule`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`parent_workflow_run_id`) REFERENCES `workflow_run`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_workflow_run_workflow_reference` ON `workflow_run` (`workflow_id`,`reference_id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_namespace_id` ON `workflow_run` (`namespace_id`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_namespace_status_id` ON `workflow_run` (`namespace_id`,`status`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_workflow_id` ON `workflow_run` (`workflow_id`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_workflow_status_id` ON `workflow_run` (`workflow_id`,`status`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_schedule` ON `workflow_run` (`schedule_id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_parent_workflow_run_status` ON `workflow_run` (`parent_workflow_run_id`,`status`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_status_scheduled_at_id` ON `workflow_run` (`status`,`scheduled_at`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_status_awake_at_id` ON `workflow_run` (`status`,`awake_at`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_status_timeout_at_id` ON `workflow_run` (`status`,`timeout_at`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_status_next_attempt_at_id` ON `workflow_run` (`status`,`next_attempt_at`,`id`);--> statement-breakpoint
+CREATE TABLE `workflow_run_outbox` (
+	`id` text PRIMARY KEY NOT NULL,
+	`namespace_id` text NOT NULL,
+	`workflow_run_id` text NOT NULL,
+	`workflow_name` text NOT NULL,
+	`workflow_version_id` text NOT NULL,
+	`shard` text,
+	`rank` real NOT NULL,
+	`status` text NOT NULL,
+	`published_at` text,
+	`claimed_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	`updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	CONSTRAINT "chk_workflow_run_outbox_published_requires_published_at" CHECK("workflow_run_outbox"."status" != 'published' OR "workflow_run_outbox"."published_at" IS NOT NULL),
+	CONSTRAINT "chk_workflow_run_outbox_claimed_requires_claimed_at" CHECK("workflow_run_outbox"."status" != 'claimed' OR "workflow_run_outbox"."claimed_at" IS NOT NULL)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uqidx_workflow_run_outbox_workflow_run_id` ON `workflow_run_outbox` (`workflow_run_id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_outbox_status_workflow_rank_id` ON `workflow_run_outbox` (`namespace_id`,`status`,`workflow_name`,`workflow_version_id`,`shard`,`rank`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_outbox_status_workflow_claimed_rank_id` ON `workflow_run_outbox` (`namespace_id`,`status`,`workflow_name`,`workflow_version_id`,`shard`,`claimed_at`,`rank`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_outbox_status_rank_id` ON `workflow_run_outbox` (`status`,`rank`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_outbox_status_published_id` ON `workflow_run_outbox` (`status`,`published_at`,`id`);--> statement-breakpoint
+CREATE INDEX `idx_workflow_run_outbox_status_claimed_id` ON `workflow_run_outbox` (`status`,`claimed_at`,`id`);

--- a/sdk/server/src/infra/db/sqlite/migration/meta/0000_snapshot.json
+++ b/sdk/server/src/infra/db/sqlite/migration/meta/0000_snapshot.json
@@ -1,0 +1,1154 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "6e261913-e38c-480f-8377-1858470a1451",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"tables": {
+		"child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": ["parent_workflow_run_id", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			}
+		},
+		"event_wait_queue": {
+			"name": "event_wait_queue",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"data": {
+					"name": "data",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": ["workflow_run_id", "name", "reference_id"],
+					"isUnique": true
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": ["workflow_run_id", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			}
+		},
+		"schedule": {
+			"name": "schedule",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": ["namespace_id", "definition_hash"],
+					"isUnique": true
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": ["namespace_id", "reference_id"],
+					"isUnique": true
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": ["namespace_id", "workflow_id"],
+					"isUnique": false
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": ["status", "next_run_at", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sleep_queue": {
+			"name": "sleep_queue",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": ["workflow_run_id"],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'"
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": ["workflow_run_id", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			}
+		},
+		"state_transition": {
+			"name": "state_transition",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": ["workflow_run_id", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(type = 'workflow_run' AND status IN ('scheduled', 'queued', 'running', 'paused', 'sleeping', 'awaiting_event', 'awaiting_retry', 'awaiting_child_workflow', 'cancelled', 'completed', 'failed')) OR (type = 'task' AND status IN ('running', 'awaiting_retry', 'completed', 'failed', 'discarded'))"
+				}
+			}
+		},
+		"task": {
+			"name": "task",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"input": {
+					"name": "input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"options": {
+					"name": "options",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": ["workflow_run_id", "id"],
+					"isUnique": false
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": ["workflow_run_id", "status"],
+					"isUnique": false
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": ["status", "next_attempt_at", "workflow_run_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workflow": {
+			"name": "workflow",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": ["namespace_id", "source", "name", "version_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workflow_run": {
+			"name": "workflow_run",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"options": {
+					"name": "options",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": ["workflow_id", "reference_id"],
+					"isUnique": true
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": ["namespace_id", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": ["namespace_id", "status", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": ["workflow_id", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": ["workflow_id", "status", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": ["schedule_id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": ["parent_workflow_run_id", "status"],
+					"isUnique": false
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": ["status", "scheduled_at", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_status_awake_at_id": {
+					"name": "idx_workflow_run_status_awake_at_id",
+					"columns": ["status", "awake_at", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": ["status", "timeout_at", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": ["status", "next_attempt_at", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": ["workflow_run_id"],
+					"isUnique": true
+				},
+				"idx_workflow_run_outbox_status_workflow_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_rank_id",
+					"columns": ["namespace_id", "status", "workflow_name", "workflow_version_id", "shard", "rank", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_outbox_status_workflow_claimed_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_claimed_rank_id",
+					"columns": [
+						"namespace_id",
+						"status",
+						"workflow_name",
+						"workflow_version_id",
+						"shard",
+						"claimed_at",
+						"rank",
+						"id"
+					],
+					"isUnique": false
+				},
+				"idx_workflow_run_outbox_status_rank_id": {
+					"name": "idx_workflow_run_outbox_status_rank_id",
+					"columns": ["status", "rank", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_outbox_status_published_id": {
+					"name": "idx_workflow_run_outbox_status_published_id",
+					"columns": ["status", "published_at", "id"],
+					"isUnique": false
+				},
+				"idx_workflow_run_outbox_status_claimed_id": {
+					"name": "idx_workflow_run_outbox_status_claimed_id",
+					"columns": ["status", "claimed_at", "id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/sdk/server/src/infra/db/sqlite/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/sqlite/migration/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1780012667319,
+			"tag": "0000_workable_archangel",
+			"breakpoints": true
+		}
+	]
+}

--- a/sdk/server/src/infra/db/sqlite/provider.ts
+++ b/sdk/server/src/infra/db/sqlite/provider.ts
@@ -1,0 +1,24 @@
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "./schema";
+import { Database } from "bun:sqlite";
+import type { SqliteDatabaseConfig } from "../../../config";
+
+export type SqliteClient = Database;
+
+export function createSqliteClient(params: SqliteDatabaseConfig): SqliteClient {
+	const client = new Database(params.path);
+	client.exec("PRAGMA journal_mode = WAL");
+	client.exec("PRAGMA synchronous = FULL");
+	client.exec("PRAGMA foreign_keys = ON");
+	client.exec("PRAGMA busy_timeout = 5000");
+	return client;
+}
+
+export function createSqliteHandle(client: SqliteClient) {
+	return drizzle(client, { schema });
+}
+
+export type SqliteHandle = ReturnType<typeof createSqliteHandle>;
+export type SqliteTransaction = Parameters<Parameters<SqliteHandle["transaction"]>[0]>[0];
+export type SqliteDb = SqliteHandle | SqliteTransaction;

--- a/sdk/server/src/infra/db/sqlite/repository/child-workflow-run-wait-queue.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/child-workflow-run-wait-queue.ts
@@ -1,0 +1,28 @@
+import { eq } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { childWorkflowRunWaitQueue } from "../schema";
+
+export type ChildWorkflowRunWaitQueueRow = typeof childWorkflowRunWaitQueue.$inferSelect;
+export type ChildWorkflowRunWaitQueueRowInsert = typeof childWorkflowRunWaitQueue.$inferInsert;
+
+export function createChildWorkflowRunWaitQueueRepository(db: SqliteDb) {
+	return {
+		async insert(input: ChildWorkflowRunWaitQueueRowInsert | ChildWorkflowRunWaitQueueRowInsert[]): Promise<void> {
+			const values = Array.isArray(input) ? input : [input];
+			await db.insert(childWorkflowRunWaitQueue).values(values);
+		},
+
+		async listByParentRunId(parentRunId: string): Promise<ChildWorkflowRunWaitQueueRow[]> {
+			// TODO: explore loading in chunks
+			return db
+				.select()
+				.from(childWorkflowRunWaitQueue)
+				.where(eq(childWorkflowRunWaitQueue.parentWorkflowRunId, parentRunId))
+				.orderBy(childWorkflowRunWaitQueue.id)
+				.limit(10_000);
+		},
+	};
+}
+
+export type ChildWorkflowRunWaitQueueRepository = ReturnType<typeof createChildWorkflowRunWaitQueueRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/event-wait-queue.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/event-wait-queue.ts
@@ -1,0 +1,38 @@
+import type { RequiredNonNullableProp } from "@aikirun/lib/object";
+import { eq } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { eventWaitQueue } from "../schema";
+
+export type EventWaitQueueRow = typeof eventWaitQueue.$inferSelect;
+export type EventWaitQueueRowInsert = typeof eventWaitQueue.$inferInsert;
+
+export function createEventWaitQueueRepository(db: SqliteDb) {
+	return {
+		async insert(input: EventWaitQueueRowInsert | EventWaitQueueRowInsert[]): Promise<void> {
+			const values = Array.isArray(input) ? input : [input];
+			await db.insert(eventWaitQueue).values(values);
+		},
+
+		async upsert(input: RequiredNonNullableProp<EventWaitQueueRowInsert, "referenceId">): Promise<void> {
+			await db
+				.insert(eventWaitQueue)
+				.values(input)
+				.onConflictDoNothing({
+					target: [eventWaitQueue.workflowRunId, eventWaitQueue.name, eventWaitQueue.referenceId],
+				});
+		},
+
+		async listByWorkflowRunId(workflowRunId: string): Promise<EventWaitQueueRow[]> {
+			// TODO: explore loading in chunks
+			return db
+				.select()
+				.from(eventWaitQueue)
+				.where(eq(eventWaitQueue.workflowRunId, workflowRunId))
+				.orderBy(eventWaitQueue.id)
+				.limit(10_000);
+		},
+	};
+}
+
+export type EventWaitQueueRepository = ReturnType<typeof createEventWaitQueueRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/lib/rank-stream.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/lib/rank-stream.ts
@@ -1,0 +1,19 @@
+import { and, gt, or, type SQL, sql } from "drizzle-orm";
+import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
+
+import type { RankStreamCursor } from "../../../../../lib/rank-stream";
+
+export function rankStreamCursorFilter(
+	rankCol: SQLiteColumn,
+	idCol: SQLiteColumn,
+	cursor: RankStreamCursor | undefined
+): SQL | undefined {
+	if (!cursor) {
+		return undefined;
+	}
+	return or(
+		sql`${rankCol} > ${cursor.rank}`,
+		and(sql`${rankCol} = ${cursor.rank}`, gt(idCol, cursor.id)),
+		and(sql`${rankCol} < ${cursor.rank}`, gt(idCol, cursor.maxId))
+	);
+}

--- a/sdk/server/src/infra/db/sqlite/repository/lib/timer-stream.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/lib/timer-stream.ts
@@ -1,0 +1,22 @@
+import { and, gt, or, type SQL, sql } from "drizzle-orm";
+import type { SQLiteColumn } from "drizzle-orm/sqlite-core";
+
+import type { TimerStreamCursor } from "../../../../../lib/timer-stream";
+
+export function timerStreamCursorFilter(
+	dueAtCol: SQLiteColumn | SQL,
+	idCol: SQLiteColumn,
+	cursor: TimerStreamCursor | undefined
+): SQL | undefined {
+	if (!cursor) {
+		return undefined;
+	}
+	// Timestamps are stored as ISO-8601 text; bun:sqlite cannot bind a Date in raw SQL,
+	// and ISO-8601 UTC sorts lexicographically the same as chronologically.
+	const dueAt = cursor.dueAt.toISOString();
+	return or(
+		sql`${dueAtCol} > ${dueAt}`,
+		and(sql`${dueAtCol} = ${dueAt}`, gt(idCol, cursor.id)),
+		and(sql`${dueAtCol} < ${dueAt}`, gt(idCol, cursor.maxId))
+	);
+}

--- a/sdk/server/src/infra/db/sqlite/repository/schedule.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/schedule.ts
@@ -1,0 +1,203 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import { and, count, eq, getTableColumns, inArray, lte, type SQL, sql } from "drizzle-orm";
+
+import { timerStreamCursorFilter } from "./lib/timer-stream";
+import type { TimerStreamCursor } from "../../../../lib/timer-stream";
+import type { DaemonContext } from "../../../../middleware/context";
+import type { SqliteDb } from "../provider";
+import { schedule, workflow } from "../schema";
+
+export type ScheduleRow = typeof schedule.$inferSelect;
+type ScheduleRowInsert = typeof schedule.$inferInsert;
+type ScheduleRowUpdate = Partial<
+	Pick<
+		ScheduleRowInsert,
+		| "status"
+		| "type"
+		| "cronExpression"
+		| "intervalMs"
+		| "overlapPolicy"
+		| "workflowRunInput"
+		| "workflowRunInputHash"
+		| "definitionHash"
+		| "referenceId"
+		| "conflictPolicy"
+		| "lastOccurrence"
+		| "nextRunAt"
+		| "workflowId"
+	>
+>;
+
+export function createScheduleRepository(db: SqliteDb) {
+	return {
+		async create(input: ScheduleRowInsert): Promise<ScheduleRow> {
+			const result = await db.insert(schedule).values(input).returning();
+			const created = result[0];
+			if (!created) {
+				throw new Error("Failed to create schedule - no row returned");
+			}
+			return created;
+		},
+
+		async update(namespaceId: NamespaceId, id: string, updates: ScheduleRowUpdate): Promise<ScheduleRow | null> {
+			const result = await db
+				.update(schedule)
+				.set(updates)
+				.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.id, id)))
+				.returning();
+			return result[0] ?? null;
+		},
+
+		async bulkUpdateOccurrence(
+			entries: NonEmptyArray<{ id: string; lastOccurrence?: Date; nextRunAt: Date }>
+		): Promise<void> {
+			// SQLite has no UPDATE ... FROM (VALUES ...), so drive the per-row updates with CASE.
+			const ids = entries.map((entry) => entry.id);
+			const nextRunAtCases = entries.map((entry) => sql`WHEN ${entry.id} THEN ${entry.nextRunAt.toISOString()}`);
+			const lastOccurrenceCases: SQL[] = [];
+			for (const entry of entries) {
+				if (entry.lastOccurrence) {
+					lastOccurrenceCases.push(sql`WHEN ${entry.id} THEN ${entry.lastOccurrence.toISOString()}`);
+				}
+			}
+
+			const nextRunAtCase = sql`CASE ${schedule.id} ${sql.join(nextRunAtCases, sql` `)} END`;
+
+			if (lastOccurrenceCases.length > 0) {
+				const lastOccurrenceCase = sql`CASE ${schedule.id} ${sql.join(lastOccurrenceCases, sql` `)} ELSE ${schedule.lastOccurrence} END`;
+				await db
+					.update(schedule)
+					.set({ nextRunAt: nextRunAtCase, lastOccurrence: lastOccurrenceCase })
+					.where(inArray(schedule.id, ids));
+			} else {
+				await db.update(schedule).set({ nextRunAt: nextRunAtCase }).where(inArray(schedule.id, ids));
+			}
+		},
+
+		async getByReferenceId(namespaceId: NamespaceId, referenceId: string): Promise<ScheduleRow | null> {
+			const result = await db
+				.select()
+				.from(schedule)
+				.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.referenceId, referenceId)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async getByDefinitionHash(namespaceId: NamespaceId, definitionHash: string): Promise<ScheduleRow | null> {
+			const result = await db
+				.select()
+				.from(schedule)
+				.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.definitionHash, definitionHash)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async listByFilters(
+			namespaceId: NamespaceId,
+			filter: {
+				id?: string;
+				referenceId?: string;
+				status?: string[];
+				workflowIds?: string[];
+			},
+			limit = 50,
+			offset = 0
+		) {
+			const conditions = [eq(schedule.namespaceId, namespaceId)];
+
+			if (filter.id) {
+				conditions.push(eq(schedule.id, filter.id));
+			}
+			if (filter.referenceId) {
+				conditions.push(eq(schedule.referenceId, filter.referenceId));
+			}
+			if (filter.status && filter.status.length > 0) {
+				conditions.push(inArray(schedule.status, filter.status as typeof schedule.status.enumValues));
+			}
+			if (filter.workflowIds && filter.workflowIds.length > 0) {
+				conditions.push(inArray(schedule.workflowId, filter.workflowIds));
+			}
+
+			const whereClause = and(...conditions);
+
+			const [rows, countResult] = await Promise.all([
+				db
+					.select({
+						schedule: getTableColumns(schedule),
+						workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+					})
+					.from(schedule)
+					.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+					.where(whereClause)
+					.orderBy(schedule.createdAt)
+					.limit(limit)
+					.offset(offset),
+				db.select({ count: count() }).from(schedule).where(whereClause),
+			]);
+
+			return { rows, total: countResult[0]?.count ?? 0 };
+		},
+
+		async listActiveByIds(_context: DaemonContext, ids: NonEmptyArray<string>) {
+			return db
+				.select({
+					schedule: getTableColumns(schedule),
+					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+				})
+				.from(schedule)
+				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+				.where(and(eq(schedule.status, "active"), inArray(schedule.id, ids)));
+		},
+
+		async listDueSchedules(_context: DaemonContext, before: Date, limit: number, cursor?: TimerStreamCursor) {
+			return db
+				.select({
+					schedule: {
+						...getTableColumns(schedule),
+						nextRunAt: sql<Date>`${schedule.nextRunAt}`.mapWith(schedule.nextRunAt),
+					},
+					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+				})
+				.from(schedule)
+				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+				.where(
+					and(
+						eq(schedule.status, "active"),
+						lte(schedule.nextRunAt, before),
+						timerStreamCursorFilter(schedule.nextRunAt, schedule.id, cursor)
+					)
+				)
+				.orderBy(schedule.nextRunAt, schedule.id)
+				.limit(limit);
+		},
+
+		async getByIdWithWorkflow(namespaceId: NamespaceId, id: string) {
+			const result = await db
+				.select({
+					schedule: getTableColumns(schedule),
+					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+				})
+				.from(schedule)
+				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+				.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.id, id)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async getByReferenceIdWithWorkflow(namespaceId: NamespaceId, referenceId: string) {
+			const result = await db
+				.select({
+					schedule: getTableColumns(schedule),
+					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+				})
+				.from(schedule)
+				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+				.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.referenceId, referenceId)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+	};
+}
+
+export type ScheduleRepository = ReturnType<typeof createScheduleRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/sleep-queue.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/sleep-queue.ts
@@ -1,0 +1,54 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import { and, eq, inArray } from "drizzle-orm";
+
+import type { SqliteDb } from "../provider";
+import { sleepQueue } from "../schema";
+
+export type SleepQueueRow = typeof sleepQueue.$inferSelect;
+type SleepQueueRowInsert = typeof sleepQueue.$inferInsert;
+
+export function createSleepQueueRepository(db: SqliteDb) {
+	return {
+		async create(input: SleepQueueRowInsert): Promise<void> {
+			await db.insert(sleepQueue).values(input);
+		},
+
+		async update(
+			id: string,
+			updates: { status: "completed"; completedAt: Date } | { status: "cancelled"; cancelledAt: Date }
+		): Promise<void> {
+			await db.update(sleepQueue).set(updates).where(eq(sleepQueue.id, id));
+		},
+
+		async listByWorkflowRunId(workflowRunId: WorkflowRunId): Promise<SleepQueueRow[]> {
+			// TODO: explore loading in chunks
+			return db
+				.select()
+				.from(sleepQueue)
+				.where(eq(sleepQueue.workflowRunId, workflowRunId))
+				.orderBy(sleepQueue.id)
+				.limit(10_000);
+		},
+
+		async bulkCompleteByWorkflowRunIds(workflowRunIds: NonEmptyArray<string>, completedAt: Date): Promise<void> {
+			await db
+				.update(sleepQueue)
+				.set({ status: "completed", completedAt })
+				.where(and(inArray(sleepQueue.workflowRunId, workflowRunIds), eq(sleepQueue.status, "sleeping")));
+		},
+
+		async getActiveByWorkflowRunIdAndName(workflowRunId: WorkflowRunId, name: string): Promise<SleepQueueRow | null> {
+			const result = await db
+				.select()
+				.from(sleepQueue)
+				.where(
+					and(eq(sleepQueue.workflowRunId, workflowRunId), eq(sleepQueue.status, "sleeping"), eq(sleepQueue.name, name))
+				)
+				.limit(1);
+			return result[0] ?? null;
+		},
+	};
+}
+
+export type SleepQueueRepository = ReturnType<typeof createSleepQueueRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/state-transition.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/state-transition.ts
@@ -1,0 +1,103 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import { TERMINAL_WORKFLOW_RUN_STATUSES, type WorkflowRunState } from "@aikirun/types/workflow/run";
+import type { TaskState } from "@aikirun/types/workflow/task";
+import { and, count, eq, gt, inArray, sql } from "drizzle-orm";
+
+import { toTaskState, toWorkflowRunState } from "../../pg/repository/state-transition";
+import type { SqliteDb } from "../provider";
+import { stateTransition, workflowRun } from "../schema";
+
+type _StateTransitionRow = typeof stateTransition.$inferSelect;
+export type StateTransitionRow = Omit<_StateTransitionRow, "state"> & {
+	state: WorkflowRunState | TaskState;
+};
+export type StateTransitionRowInsert = typeof stateTransition.$inferInsert;
+
+export function createStateTransitionRepository(db: SqliteDb) {
+	return {
+		async append(input: StateTransitionRowInsert): Promise<void> {
+			await db.insert(stateTransition).values(input);
+		},
+
+		async appendBatch(inputs: NonEmptyArray<StateTransitionRowInsert>): Promise<void> {
+			await db.insert(stateTransition).values(inputs);
+		},
+
+		async getById(id: string): Promise<StateTransitionRow | null> {
+			const result = await db.select().from(stateTransition).where(eq(stateTransition.id, id)).limit(1);
+			const row = result[0];
+			return row ? normalizeRow(row) : null;
+		},
+
+		async getByIds(ids: NonEmptyArray<string>): Promise<StateTransitionRow[]> {
+			const rows = await db.select().from(stateTransition).where(inArray(stateTransition.id, ids));
+			return rows.map(normalizeRow);
+		},
+
+		async listByRunId(
+			runId: string,
+			limit = 50,
+			offset = 0,
+			sort?: { order: "asc" | "desc" }
+		): Promise<{ rows: StateTransitionRow[]; total: number }> {
+			const sortOrder = sort?.order ?? "desc";
+			const orderBy = sql`${stateTransition.id} ${sql.raw(sortOrder)}`;
+
+			const [rows, countResult] = await Promise.all([
+				db
+					.select()
+					.from(stateTransition)
+					.where(eq(stateTransition.workflowRunId, runId))
+					.orderBy(orderBy)
+					.limit(limit)
+					.offset(offset),
+				db.select({ count: count() }).from(stateTransition).where(eq(stateTransition.workflowRunId, runId)),
+			]);
+
+			return { rows: rows.map(normalizeRow), total: countResult[0]?.count ?? 0 };
+		},
+
+		async hasTerminated(
+			namespaceId: NamespaceId,
+			workflowRunId: string,
+			afterStateTransitionId: string
+		): Promise<{ runFound: true; terminated: boolean; latestStateTransitionId: string } | { runFound: false }> {
+			const result = await db
+				.select({
+					terminalStateTransitionId: stateTransition.id,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+				})
+				.from(workflowRun)
+				.leftJoin(
+					stateTransition,
+					and(
+						eq(stateTransition.workflowRunId, workflowRun.id),
+						eq(stateTransition.type, "workflow_run"),
+						inArray(stateTransition.status, TERMINAL_WORKFLOW_RUN_STATUSES),
+						gt(stateTransition.id, afterStateTransitionId)
+					)
+				)
+				.where(and(eq(workflowRun.id, workflowRunId), eq(workflowRun.namespaceId, namespaceId)))
+				.limit(1);
+
+			const row = result[0];
+			if (!row) {
+				return { runFound: false };
+			}
+
+			return {
+				runFound: true,
+				terminated: row.terminalStateTransitionId !== null,
+				latestStateTransitionId: row.latestStateTransitionId,
+			};
+		},
+	};
+}
+
+export type StateTransitionRepository = ReturnType<typeof createStateTransitionRepository>;
+
+function normalizeRow(row: _StateTransitionRow): StateTransitionRow {
+	(row as Record<string, unknown>).state = row.type === "task" ? toTaskState(row.state) : toWorkflowRunState(row.state);
+	return row as unknown as StateTransitionRow;
+}

--- a/sdk/server/src/infra/db/sqlite/repository/task.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/task.ts
@@ -1,0 +1,102 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { TaskStatus } from "@aikirun/types/workflow/task";
+import { and, eq, inArray, lte, min, ne, sql } from "drizzle-orm";
+
+import { timerStreamCursorFilter } from "./lib/timer-stream";
+import type { TimerStreamCursor } from "../../../../lib/timer-stream";
+import type { DaemonContext } from "../../../../middleware/context";
+import type { SqliteDb } from "../provider";
+import { task } from "../schema";
+
+export type TaskRow = typeof task.$inferSelect;
+type TaskRowInsert = typeof task.$inferInsert;
+type TaskRowUpdate = Partial<Pick<TaskRowInsert, "status" | "attempts" | "latestStateTransitionId" | "nextAttemptAt">>;
+
+export function createTaskRepository(db: SqliteDb) {
+	return {
+		async create(input: TaskRowInsert): Promise<TaskRow> {
+			const result = await db.insert(task).values(input).returning();
+			const created = result[0];
+			if (!created) {
+				throw new Error("Failed to create task - no row returned");
+			}
+			return created;
+		},
+
+		async getById(id: string): Promise<TaskRow | null> {
+			const result = await db.select().from(task).where(eq(task.id, id)).limit(1);
+			return result[0] ?? null;
+		},
+
+		async update(id: string, updates: TaskRowUpdate): Promise<TaskRow | null> {
+			const result = await db.update(task).set(updates).where(eq(task.id, id)).returning();
+			return result[0] ?? null;
+		},
+
+		async listByWorkflowRunId(workflowRunId: string): Promise<TaskRow[]> {
+			// TODO: explore loading in chunks
+			return db
+				.select()
+				.from(task)
+				.where(and(eq(task.workflowRunId, workflowRunId), ne(task.status, "discarded")))
+				.orderBy(task.id)
+				.limit(10_000);
+		},
+
+		async listRetryableTaskWorkflowRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		) {
+			const dueAtExpr = min(task.nextAttemptAt);
+
+			return db
+				.select({
+					workflowRunId: task.workflowRunId,
+					dueAt: sql<Date>`${dueAtExpr}`.mapWith(task.nextAttemptAt),
+				})
+				.from(task)
+				.where(and(eq(task.status, "awaiting_retry"), lte(task.nextAttemptAt, before)))
+				.groupBy(task.workflowRunId)
+				.having(timerStreamCursorFilter(dueAtExpr, task.workflowRunId, cursor))
+				.orderBy(dueAtExpr, task.workflowRunId)
+				.limit(limit);
+		},
+
+		async listByWorkflowRunIdsAndStatuses(
+			workflowRunIds: string | NonEmptyArray<string>,
+			statuses: TaskStatus[]
+		): Promise<Array<Pick<TaskRow, "id" | "workflowRunId" | "attempts">>> {
+			const runIdsFilter =
+				typeof workflowRunIds === "string"
+					? eq(task.workflowRunId, workflowRunIds)
+					: inArray(task.workflowRunId, workflowRunIds);
+			return db
+				.select({ id: task.id, workflowRunId: task.workflowRunId, attempts: task.attempts })
+				.from(task)
+				.where(and(runIdsFilter, inArray(task.status, statuses)));
+		},
+
+		async bulkDiscard(
+			tasks: NonEmptyArray<{ filter: { id: string }; update: { latestStateTransitionId: string } }>
+		): Promise<void> {
+			// SQLite has no UPDATE ... FROM (VALUES ...); drive the per-row update with CASE.
+			const ids = tasks.map(({ filter }) => filter.id);
+			const caseFragments = tasks.map(
+				({ filter, update }) => sql`WHEN ${filter.id} THEN ${update.latestStateTransitionId}`
+			);
+
+			await db
+				.update(task)
+				.set({
+					status: "discarded",
+					nextAttemptAt: null,
+					latestStateTransitionId: sql`CASE ${task.id} ${sql.join(caseFragments, sql` `)} END`,
+				})
+				.where(inArray(task.id, ids));
+		},
+	};
+}
+
+export type TaskRepository = ReturnType<typeof createTaskRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/workflow-run-outbox.ts
@@ -1,0 +1,255 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import { isNonEmptyArray } from "@aikirun/lib/array";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import { and, eq, inArray, isNull, lt, or } from "drizzle-orm";
+
+import { rankStreamCursorFilter } from "./lib/rank-stream";
+import { timerStreamCursorFilter } from "./lib/timer-stream";
+import type { RankStreamCursor } from "../../../../lib/rank-stream";
+import type { TimerStreamCursor } from "../../../../lib/timer-stream";
+import type { DaemonContext } from "../../../../middleware/context";
+import type { SqliteDb } from "../provider";
+import { workflowRunOutbox } from "../schema";
+
+export type WorkflowRunOutboxRow = typeof workflowRunOutbox.$inferSelect;
+export type WorkflowRunOutboxRowInsert = typeof workflowRunOutbox.$inferInsert;
+export type WorkflowRunOutboxRowPublished = WorkflowRunOutboxRow & { status: "published"; publishedAt: Date };
+export type WorkflowRunOutboxRowClaimed = WorkflowRunOutboxRow & { status: "claimed"; claimedAt: Date };
+
+interface ClaimFilter {
+	workflows: NonEmptyArray<{ name: string; versionId: string }>;
+	shards?: string[];
+}
+
+function buildClaimFilterPredicate(filters: ClaimFilter) {
+	const workflowsPredicate = or(
+		...filters.workflows.map((workflow) =>
+			and(
+				eq(workflowRunOutbox.workflowName, workflow.name),
+				eq(workflowRunOutbox.workflowVersionId, workflow.versionId)
+			)
+		)
+	);
+	const shardsPredicate = isNonEmptyArray(filters.shards)
+		? inArray(workflowRunOutbox.shard, filters.shards)
+		: isNull(workflowRunOutbox.shard);
+
+	return and(workflowsPredicate, shardsPredicate);
+}
+
+export function createWorkflowRunOutboxRepository(db: SqliteDb) {
+	return {
+		async createBatch(rows: NonEmptyArray<WorkflowRunOutboxRowInsert>): Promise<void> {
+			await db.insert(workflowRunOutbox).values(rows);
+		},
+
+		async deleteByWorkflowRunIds(_context: DaemonContext, workflowRunIds: NonEmptyArray<string>): Promise<void> {
+			await db.delete(workflowRunOutbox).where(inArray(workflowRunOutbox.workflowRunId, workflowRunIds));
+		},
+
+		async listPending(
+			_context: DaemonContext,
+			limit: number,
+			cursor?: RankStreamCursor
+		): Promise<WorkflowRunOutboxRow[]> {
+			return db
+				.select()
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "pending"),
+						rankStreamCursorFilter(workflowRunOutbox.rank, workflowRunOutbox.id, cursor)
+					)
+				)
+				.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
+				.limit(limit);
+		},
+
+		async markPublished(ids: NonEmptyArray<string>): Promise<void> {
+			await db
+				.update(workflowRunOutbox)
+				.set({ status: "published", publishedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "pending"), inArray(workflowRunOutbox.id, ids)));
+		},
+
+		async markRepublished(ids: NonEmptyArray<string>): Promise<void> {
+			await db
+				.update(workflowRunOutbox)
+				.set({ publishedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "published"), inArray(workflowRunOutbox.id, ids)));
+		},
+
+		async releaseStaleClaim(ids: NonEmptyArray<string>): Promise<void> {
+			await db
+				.update(workflowRunOutbox)
+				.set({ status: "published", claimedAt: null, publishedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "claimed"), inArray(workflowRunOutbox.id, ids)));
+		},
+
+		async markClaimed(namespaceId: string, workflowRunId: WorkflowRunId): Promise<void> {
+			await db
+				.update(workflowRunOutbox)
+				.set({ status: "claimed", claimedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.namespaceId, namespaceId), eq(workflowRunOutbox.workflowRunId, workflowRunId)));
+		},
+
+		async reclaim(namespaceId: string, workflowRunId: WorkflowRunId): Promise<void> {
+			await db
+				.update(workflowRunOutbox)
+				.set({ claimedAt: new Date() })
+				.where(
+					and(
+						eq(workflowRunOutbox.namespaceId, namespaceId),
+						eq(workflowRunOutbox.workflowRunId, workflowRunId),
+						eq(workflowRunOutbox.status, "claimed")
+					)
+				);
+		},
+
+		async listStalePublished(
+			_context: DaemonContext,
+			claimMinIdleTimeMs: number,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<WorkflowRunOutboxRowPublished[]> {
+			const now = Date.now();
+			const staleThreshold = new Date(now - claimMinIdleTimeMs);
+
+			const rows = await db
+				.select()
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "published"),
+						lt(workflowRunOutbox.publishedAt, staleThreshold),
+						timerStreamCursorFilter(workflowRunOutbox.publishedAt, workflowRunOutbox.id, cursor)
+					)
+				)
+				.orderBy(workflowRunOutbox.publishedAt, workflowRunOutbox.id)
+				.limit(limit);
+
+			return rows as WorkflowRunOutboxRowPublished[];
+		},
+
+		async listStaleClaimed(
+			_context: DaemonContext,
+			claimMinIdleTimeMs: number,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<WorkflowRunOutboxRowClaimed[]> {
+			const now = Date.now();
+			const staleThreshold = new Date(now - claimMinIdleTimeMs);
+
+			const rows = await db
+				.select()
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "claimed"),
+						lt(workflowRunOutbox.claimedAt, staleThreshold),
+						timerStreamCursorFilter(workflowRunOutbox.claimedAt, workflowRunOutbox.id, cursor)
+					)
+				)
+				.orderBy(workflowRunOutbox.claimedAt, workflowRunOutbox.id)
+				.limit(limit);
+
+			return rows as WorkflowRunOutboxRowClaimed[];
+		},
+
+		async deleteByWorkflowRunId(namespaceId: string, workflowRunId: string): Promise<void> {
+			await db
+				.delete(workflowRunOutbox)
+				.where(and(eq(workflowRunOutbox.namespaceId, namespaceId), eq(workflowRunOutbox.workflowRunId, workflowRunId)));
+		},
+
+		async stealStaleClaimed(namespaceId: string, filters: ClaimFilter, claimMinIdleTimeMs: number, limit: number) {
+			const now = Date.now();
+			const staleThreshold = new Date(now - claimMinIdleTimeMs);
+
+			const staleEntries = await db
+				.select({ id: workflowRunOutbox.id })
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.namespaceId, namespaceId),
+						eq(workflowRunOutbox.status, "claimed"),
+						lt(workflowRunOutbox.claimedAt, staleThreshold),
+						buildClaimFilterPredicate(filters)
+					)
+				)
+				.orderBy(workflowRunOutbox.claimedAt, workflowRunOutbox.rank, workflowRunOutbox.id)
+				.limit(limit);
+
+			const staleEntryIds = staleEntries.map(({ id }) => id);
+			if (!isNonEmptyArray(staleEntryIds)) {
+				return [];
+			}
+
+			return db
+				.update(workflowRunOutbox)
+				.set({ claimedAt: new Date(now) })
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "claimed"),
+						inArray(workflowRunOutbox.id, staleEntryIds),
+						lt(workflowRunOutbox.claimedAt, staleThreshold)
+					)
+				)
+				.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
+		},
+
+		async claimPublished(namespaceId: string, filters: ClaimFilter, limit: number) {
+			const entries = await db
+				.select({ id: workflowRunOutbox.id })
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.namespaceId, namespaceId),
+						eq(workflowRunOutbox.status, "published"),
+						buildClaimFilterPredicate(filters)
+					)
+				)
+				.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
+				.limit(limit);
+
+			const entryIds = entries.map(({ id }) => id);
+			if (!isNonEmptyArray(entryIds)) {
+				return [];
+			}
+
+			return db
+				.update(workflowRunOutbox)
+				.set({ status: "claimed", claimedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "published"), inArray(workflowRunOutbox.id, entryIds)))
+				.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
+		},
+
+		async claimPending(namespaceId: string, filters: ClaimFilter, limit: number) {
+			const pendingEntries = await db
+				.select({ id: workflowRunOutbox.id })
+				.from(workflowRunOutbox)
+				.where(
+					and(
+						eq(workflowRunOutbox.namespaceId, namespaceId),
+						eq(workflowRunOutbox.status, "pending"),
+						buildClaimFilterPredicate(filters)
+					)
+				)
+				.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
+				.limit(limit);
+
+			const pendingEntryIds = pendingEntries.map(({ id }) => id);
+			if (!isNonEmptyArray(pendingEntryIds)) {
+				return [];
+			}
+
+			return db
+				.update(workflowRunOutbox)
+				.set({ status: "claimed", claimedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "pending"), inArray(workflowRunOutbox.id, pendingEntryIds)))
+				.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
+		},
+	};
+}
+
+export type WorkflowRunOutboxRepository = ReturnType<typeof createWorkflowRunOutboxRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/workflow-run.ts
@@ -1,0 +1,530 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { WorkflowRunId, WorkflowRunState, WorkflowRunStatus } from "@aikirun/types/workflow/run";
+import { NON_TERMINAL_WORKFLOW_RUN_STATUSES } from "@aikirun/types/workflow/run";
+import type { TaskStatus } from "@aikirun/types/workflow/task";
+import { and, count, eq, inArray, lte, or, sql } from "drizzle-orm";
+
+import { timerStreamCursorFilter } from "./lib/timer-stream";
+import type { TimerStreamCursor } from "../../../../lib/timer-stream";
+import type { DaemonContext } from "../../../../middleware/context";
+import { toWorkflowRunState } from "../../pg/repository/state-transition";
+import type { DueWorkflowRun } from "../../pg/repository/workflow-run";
+import type { SqliteDb } from "../provider";
+import { stateTransition, task, workflow, workflowRun } from "../schema";
+
+export type WorkflowRunRow = typeof workflowRun.$inferSelect;
+export type WorkflowRunRowInsert = typeof workflowRun.$inferInsert;
+type WorkflowRunRowUpdate = Partial<
+	Pick<
+		WorkflowRunRowInsert,
+		"status" | "attempts" | "latestStateTransitionId" | "scheduledAt" | "awakeAt" | "timeoutAt" | "nextAttemptAt"
+	>
+>;
+
+export function createWorkflowRunRepository(db: SqliteDb) {
+	return {
+		async insert(input: WorkflowRunRowInsert | NonEmptyArray<WorkflowRunRowInsert>): Promise<void> {
+			const values = Array.isArray(input) ? input : [input];
+			await db.insert(workflowRun).values(values);
+		},
+
+		async update(
+			filter: { id: WorkflowRunId; revision?: number },
+			updates: WorkflowRunRowUpdate
+		): Promise<{ revision: number } | undefined> {
+			const conditions = [eq(workflowRun.id, filter.id)];
+			if (filter.revision !== undefined) {
+				conditions.push(eq(workflowRun.revision, filter.revision));
+			}
+
+			const whereClause = and(...conditions);
+
+			const result = await db
+				.update(workflowRun)
+				.set({
+					...updates,
+					revision: sql`${workflowRun.revision} + 1`,
+				})
+				.where(whereClause)
+				.returning({ revision: workflowRun.revision });
+
+			const revision = result[0]?.revision;
+			if (revision === undefined) {
+				return undefined;
+			}
+
+			return { revision };
+		},
+
+		async exists(namespaceId: NamespaceId, id: string): Promise<boolean> {
+			const result = await db
+				.select({ id: workflowRun.id })
+				.from(workflowRun)
+				.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
+				.limit(1);
+			return result.length > 0;
+		},
+
+		async getById(namespaceId: NamespaceId, id: string): Promise<WorkflowRunRow | null> {
+			const result = await db
+				.select()
+				.from(workflowRun)
+				.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async getByIds(namespaceId: NamespaceId, ids: NonEmptyArray<string>): Promise<WorkflowRunRow[]> {
+			return db
+				.select()
+				.from(workflowRun)
+				.where(and(eq(workflowRun.namespaceId, namespaceId), inArray(workflowRun.id, ids)));
+		},
+
+		async getByIdWithState(namespaceId: NamespaceId, id: string, _options?: { forUpdate?: boolean }) {
+			// SQLite has no SELECT ... FOR UPDATE; write serialization is handled by the
+			// transaction serializer and BEGIN IMMEDIATE, so forUpdate is a no-op here.
+			const result = await db
+				.select({
+					id: workflowRun.id,
+					status: workflowRun.status,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
+					options: workflowRun.options,
+					state: stateTransition.state,
+				})
+				.from(workflowRun)
+				.innerJoin(stateTransition, eq(workflowRun.latestStateTransitionId, stateTransition.id))
+				.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
+				.limit(1);
+
+			const row = result[0];
+			if (!row) {
+				return null;
+			}
+			(row as Record<string, unknown>).state = toWorkflowRunState(row.state);
+			return row as Omit<typeof row, "state"> & { state: WorkflowRunState };
+		},
+
+		async listByIdsAndStatus(_context: DaemonContext, ids: NonEmptyArray<string>, status: WorkflowRunStatus) {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+				})
+				.from(workflowRun)
+				.where(and(inArray(workflowRun.id, ids), eq(workflowRun.status, status)));
+		},
+
+		async getChildRuns(filter: {
+			parentRunId: string;
+			status?: NonEmptyArray<WorkflowRunStatus>;
+		}): Promise<WorkflowRunRow[]> {
+			const conditions = [eq(workflowRun.parentWorkflowRunId, filter.parentRunId)];
+			if (filter.status) {
+				conditions.push(inArray(workflowRun.status, filter.status));
+			}
+
+			const whereClause = and(...conditions);
+
+			return db.select().from(workflowRun).where(whereClause).limit(10_000);
+		},
+
+		async hasChildRuns(
+			parentRunIds: NonEmptyArray<string>,
+			childRunStatus?: NonEmptyArray<WorkflowRunStatus>
+		): Promise<Set<string>> {
+			const conditions = [inArray(workflowRun.parentWorkflowRunId, parentRunIds)];
+			if (childRunStatus) {
+				conditions.push(inArray(workflowRun.status, childRunStatus));
+			}
+
+			const rows = await db
+				.select({ parentWorkflowRunId: workflowRun.parentWorkflowRunId })
+				.from(workflowRun)
+				.where(and(...conditions))
+				.groupBy(workflowRun.parentWorkflowRunId);
+
+			const result = new Set<string>();
+			for (const row of rows) {
+				if (row.parentWorkflowRunId) {
+					result.add(row.parentWorkflowRunId);
+				}
+			}
+			return result;
+		},
+
+		async getByWorkflowAndReferenceId(workflowId: string, referenceId: string): Promise<WorkflowRunRow | null> {
+			const result = await db
+				.select()
+				.from(workflowRun)
+				.where(and(eq(workflowRun.workflowId, workflowId), eq(workflowRun.referenceId, referenceId)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async listByWorkflowAndReferenceIdPairs(filter: {
+			pairs: NonEmptyArray<{ workflowId: string; referenceId: string }>;
+			status?: NonEmptyArray<WorkflowRunStatus>;
+		}): Promise<WorkflowRunRow[]> {
+			const pairConditions = or(
+				...filter.pairs.map(({ workflowId, referenceId }) =>
+					and(eq(workflowRun.workflowId, workflowId), eq(workflowRun.referenceId, referenceId))
+				)
+			);
+			const conditions = filter.status
+				? and(pairConditions, inArray(workflowRun.status, filter.status))
+				: pairConditions;
+
+			return db.select().from(workflowRun).where(conditions);
+		},
+
+		async listByFilters(
+			namespaceId: NamespaceId,
+			filter: {
+				id?: string;
+				scheduleId?: string;
+				status?: NonEmptyArray<WorkflowRunStatus>;
+				workflow?: {
+					ids: NonEmptyArray<string>;
+					referenceId?: string;
+				};
+			},
+			limit: number,
+			offset: number,
+			sort: { order: "asc" | "desc" }
+		) {
+			const conditions = [eq(workflowRun.namespaceId, namespaceId)];
+			if (filter.id) {
+				conditions.push(eq(workflowRun.id, filter.id));
+			}
+			if (filter.scheduleId) {
+				conditions.push(eq(workflowRun.scheduleId, filter.scheduleId));
+			}
+			if (filter.status) {
+				conditions.push(inArray(workflowRun.status, filter.status));
+			}
+			if (filter.workflow) {
+				conditions.push(inArray(workflowRun.workflowId, filter.workflow.ids));
+				if (filter.workflow.referenceId) {
+					conditions.push(eq(workflowRun.referenceId, filter.workflow.referenceId));
+				}
+			}
+
+			const whereClause = and(...conditions);
+			const orderBy = sql`${workflowRun.id} ${sql.raw(sort.order)}`;
+
+			const [rows, countResult] = await Promise.all([
+				db
+					.select({
+						id: workflowRun.id,
+						status: workflowRun.status,
+						referenceId: workflowRun.referenceId,
+						createdAt: workflowRun.createdAt,
+						name: workflow.name,
+						versionId: workflow.versionId,
+					})
+					.from(workflowRun)
+					.innerJoin(workflow, eq(workflowRun.workflowId, workflow.id))
+					.where(whereClause)
+					.orderBy(orderBy)
+					.limit(limit)
+					.offset(offset),
+				db.select({ count: count() }).from(workflowRun).where(whereClause),
+			]);
+
+			return { rows, total: countResult[0]?.count ?? 0 };
+		},
+
+		async getTaskCountsByRunIds(runIds: NonEmptyArray<string>): Promise<Map<string, Record<TaskStatus, number>>> {
+			const rows = await db
+				.select({
+					workflowRunId: task.workflowRunId,
+					status: task.status,
+					count: count(),
+				})
+				.from(task)
+				.where(inArray(task.workflowRunId, runIds))
+				.groupBy(task.workflowRunId, task.status);
+
+			const result = new Map<string, Record<TaskStatus, number>>();
+			for (const row of rows) {
+				let taskCounts = result.get(row.workflowRunId);
+				if (!taskCounts) {
+					taskCounts = { completed: 0, running: 0, failed: 0, awaiting_retry: 0, discarded: 0 };
+					result.set(row.workflowRunId, taskCounts);
+				}
+				taskCounts[row.status] = row.count;
+			}
+			return result;
+		},
+
+		async countByStatus(
+			filter: { namespaceId: NamespaceId } | { workflowIds: NonEmptyArray<string> }
+		): Promise<Array<{ status: WorkflowRunStatus; count: number }>> {
+			const whereClause =
+				"workflowIds" in filter
+					? inArray(workflowRun.workflowId, filter.workflowIds)
+					: eq(workflowRun.namespaceId, filter.namespaceId);
+
+			return db
+				.select({
+					status: workflowRun.status,
+					count: count(),
+				})
+				.from(workflowRun)
+				.where(whereClause)
+				.groupBy(workflowRun.status);
+		},
+
+		async listDueScheduleRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: sql<Date>`${workflowRun.scheduledAt}`.mapWith(workflowRun.scheduledAt),
+				})
+				.from(workflowRun)
+				.where(
+					and(
+						eq(workflowRun.status, "scheduled"),
+						lte(workflowRun.scheduledAt, before),
+						timerStreamCursorFilter(workflowRun.scheduledAt, workflowRun.id, cursor)
+					)
+				)
+				.orderBy(workflowRun.scheduledAt, workflowRun.id)
+				.limit(limit);
+		},
+
+		async listSleepElapsedRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: sql<Date>`${workflowRun.awakeAt}`.mapWith(workflowRun.awakeAt),
+				})
+				.from(workflowRun)
+				.where(
+					and(
+						eq(workflowRun.status, "sleeping"),
+						lte(workflowRun.awakeAt, before),
+						timerStreamCursorFilter(workflowRun.awakeAt, workflowRun.id, cursor)
+					)
+				)
+				.orderBy(workflowRun.awakeAt, workflowRun.id)
+				.limit(limit);
+		},
+
+		async listRetryableRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: sql<Date>`${workflowRun.nextAttemptAt}`.mapWith(workflowRun.nextAttemptAt),
+				})
+				.from(workflowRun)
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_retry"),
+						lte(workflowRun.nextAttemptAt, before),
+						timerStreamCursorFilter(workflowRun.nextAttemptAt, workflowRun.id, cursor)
+					)
+				)
+				.orderBy(workflowRun.nextAttemptAt, workflowRun.id)
+				.limit(limit);
+		},
+
+		async listEventWaitTimedOutRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: sql<Date>`${workflowRun.timeoutAt}`.mapWith(workflowRun.timeoutAt),
+				})
+				.from(workflowRun)
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_event"),
+						lte(workflowRun.timeoutAt, before),
+						timerStreamCursorFilter(workflowRun.timeoutAt, workflowRun.id, cursor)
+					)
+				)
+				.orderBy(workflowRun.timeoutAt, workflowRun.id)
+				.limit(limit);
+		},
+
+		async listChildRunWaitTimedOutRuns(
+			_context: DaemonContext,
+			before: Date,
+			limit: number,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
+			return db
+				.select({
+					id: workflowRun.id,
+					namespaceId: workflowRun.namespaceId,
+					workflowId: workflowRun.workflowId,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					options: workflowRun.options,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: sql<Date>`${workflowRun.timeoutAt}`.mapWith(workflowRun.timeoutAt),
+				})
+				.from(workflowRun)
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_child_workflow"),
+						lte(workflowRun.timeoutAt, before),
+						timerStreamCursorFilter(workflowRun.timeoutAt, workflowRun.id, cursor)
+					)
+				)
+				.orderBy(workflowRun.timeoutAt, workflowRun.id)
+				.limit(limit);
+		},
+
+		async bulkTransitionToQueued(
+			fromStatus:
+				| "scheduled"
+				| "sleeping"
+				| "awaiting_retry"
+				| "awaiting_event"
+				| "awaiting_child_workflow"
+				| "running",
+			runs: NonEmptyArray<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }>,
+			options?: { incrementAttempts?: boolean }
+		): Promise<string[]> {
+			// SQLite has no UPDATE ... FROM (VALUES ...); express the per-row update with CASE.
+			const orConditions = runs.map(
+				({ filter }) => sql`(${workflowRun.id} = ${filter.id} AND ${workflowRun.revision} = ${filter.revision})`
+			);
+			const caseFragments = runs.map(({ filter, update }) => sql`WHEN ${filter.id} THEN ${update.stateTransitionId}`);
+
+			const result = await db
+				.update(workflowRun)
+				.set({
+					status: "queued",
+					revision: sql`${workflowRun.revision} + 1`,
+					attempts: options?.incrementAttempts ? sql`${workflowRun.attempts} + 1` : workflowRun.attempts,
+					scheduledAt: null,
+					awakeAt: null,
+					timeoutAt: null,
+					nextAttemptAt: null,
+					latestStateTransitionId: sql`CASE ${workflowRun.id} ${sql.join(caseFragments, sql` `)} END`,
+				})
+				.where(and(eq(workflowRun.status, fromStatus), or(...orConditions)))
+				.returning({ id: workflowRun.id });
+
+			return result.map((row) => row.id);
+		},
+
+		async bulkTransitionToCancelled(runIds: NonEmptyArray<string>): Promise<string[]> {
+			const result = await db
+				.update(workflowRun)
+				.set({
+					status: "cancelled",
+					revision: sql`${workflowRun.revision} + 1`,
+					scheduledAt: null,
+					awakeAt: null,
+					timeoutAt: null,
+					nextAttemptAt: null,
+				})
+				.where(and(inArray(workflowRun.id, runIds), inArray(workflowRun.status, NON_TERMINAL_WORKFLOW_RUN_STATUSES)))
+				.returning({ id: workflowRun.id });
+
+			return result.map((row) => row.id);
+		},
+
+		async bulkSetLatestStateTransitionId(
+			runs: NonEmptyArray<{ id: string; stateTransitionId: string }>
+		): Promise<void> {
+			const ids: string[] = [];
+			const caseFragments = [];
+
+			for (const run of runs) {
+				ids.push(run.id);
+				caseFragments.push(sql`WHEN ${run.id} THEN ${run.stateTransitionId}`);
+			}
+
+			await db
+				.update(workflowRun)
+				.set({
+					latestStateTransitionId: sql`CASE ${workflowRun.id} ${sql.join(caseFragments, sql` `)} END`,
+				})
+				.where(inArray(workflowRun.id, ids));
+		},
+
+		async getRunCount(scheduleId: string): Promise<number> {
+			const result = await db
+				.select({ count: count() })
+				.from(workflowRun)
+				.where(eq(workflowRun.scheduleId, scheduleId));
+			return result[0]?.count ?? 0;
+		},
+
+		async getRunCounts(scheduleIds: NonEmptyArray<string>): Promise<Map<string, number>> {
+			const rows = await db
+				.select({ scheduleId: workflowRun.scheduleId, count: count() })
+				.from(workflowRun)
+				.where(inArray(workflowRun.scheduleId, scheduleIds))
+				.groupBy(workflowRun.scheduleId);
+
+			const map = new Map<string, number>();
+			for (const row of rows) {
+				if (row.scheduleId) {
+					map.set(row.scheduleId, row.count);
+				}
+			}
+			return map;
+		},
+	};
+}
+
+export type WorkflowRunRepository = ReturnType<typeof createWorkflowRunRepository>;

--- a/sdk/server/src/infra/db/sqlite/repository/workflow.ts
+++ b/sdk/server/src/infra/db/sqlite/repository/workflow.ts
@@ -1,0 +1,224 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { WorkflowListRequestV1, WorkflowListVersionsRequestV1 } from "@aikirun/types/api/workflow";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { WorkflowSource } from "@aikirun/types/workflow";
+import { and, count, eq, inArray, max, or, sql } from "drizzle-orm";
+import { ulid } from "ulidx";
+
+import type { DaemonContext } from "../../../../middleware/context";
+import type { SqliteDb } from "../provider";
+import { workflow, workflowRun } from "../schema";
+
+export type WorkflowRow = typeof workflow.$inferSelect;
+export type WorkflowRowInsert = Omit<typeof workflow.$inferInsert, "id">;
+
+export function createWorkflowRepository(db: SqliteDb) {
+	return {
+		async getById(namespaceId: NamespaceId, id: string): Promise<WorkflowRow | null> {
+			const result = await db
+				.select()
+				.from(workflow)
+				.where(and(eq(workflow.namespaceId, namespaceId), eq(workflow.id, id)))
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async getByIds(namespaceId: NamespaceId, ids: NonEmptyArray<string>): Promise<WorkflowRow[]> {
+			return db
+				.select()
+				.from(workflow)
+				.where(and(eq(workflow.namespaceId, namespaceId), inArray(workflow.id, ids)));
+		},
+
+		async getByIdsGlobal(_context: DaemonContext, ids: NonEmptyArray<string>): Promise<WorkflowRow[]> {
+			return db.select().from(workflow).where(inArray(workflow.id, ids));
+		},
+
+		async getByNameAndVersion(
+			namespaceId: NamespaceId,
+			filter: { name: string; versionId: string; source: WorkflowSource }
+		): Promise<WorkflowRow | null> {
+			const result = await db
+				.select()
+				.from(workflow)
+				.where(
+					and(
+						eq(workflow.namespaceId, namespaceId),
+						eq(workflow.source, filter.source),
+						eq(workflow.name, filter.name),
+						eq(workflow.versionId, filter.versionId)
+					)
+				)
+				.limit(1);
+			return result[0] ?? null;
+		},
+
+		async getOrCreate({ namespaceId, name, versionId, source }: WorkflowRowInsert): Promise<WorkflowRow> {
+			const result = await db
+				.insert(workflow)
+				.values({ id: ulid(), namespaceId, name, versionId, source })
+				.onConflictDoUpdate({
+					target: [workflow.namespaceId, workflow.source, workflow.name, workflow.versionId],
+					set: { name: sql`excluded.name` },
+				})
+				.returning();
+			const row = result[0];
+			if (!row) {
+				throw new Error("Failed to get or create workflow - no row returned");
+			}
+			return row;
+		},
+
+		async getOrCreateBulk(entries: NonEmptyArray<WorkflowRowInsert>): Promise<WorkflowRow[]> {
+			return db
+				.insert(workflow)
+				.values(entries.map((entry) => ({ id: ulid(), ...entry })))
+				.onConflictDoUpdate({
+					target: [workflow.namespaceId, workflow.source, workflow.name, workflow.versionId],
+					set: { name: sql`excluded.name` },
+				})
+				.returning();
+		},
+
+		async listByNameAndVersion(
+			namespaceId: NamespaceId,
+			request: { name: string; versionId?: string; source: WorkflowSource }
+		): Promise<WorkflowRow[]> {
+			const { name, versionId, source } = request;
+			return db
+				.select()
+				.from(workflow)
+				.where(
+					and(
+						eq(workflow.namespaceId, namespaceId),
+						eq(workflow.source, source),
+						eq(workflow.name, name),
+						versionId !== undefined ? eq(workflow.versionId, versionId) : undefined
+					)
+				);
+		},
+
+		async listByNameAndVersionPairs(
+			namespaceId: NamespaceId,
+			pairs: NonEmptyArray<{ name: string; versionId?: string; source: WorkflowSource }>
+		): Promise<WorkflowRow[]> {
+			return db
+				.select()
+				.from(workflow)
+				.where(
+					and(
+						eq(workflow.namespaceId, namespaceId),
+						or(
+							...pairs.map(({ name, versionId, source }) =>
+								and(
+									eq(workflow.source, source),
+									eq(workflow.name, name),
+									versionId ? eq(workflow.versionId, versionId) : undefined
+								)
+							)
+						)
+					)
+				);
+		},
+
+		async listWithStats(
+			namespaceId: NamespaceId,
+			request: WorkflowListRequestV1
+		): Promise<{
+			items: Array<{ name: string; runCount: number; lastRunId: string | null }>;
+			total: number;
+		}> {
+			const { source, limit = 50, offset = 0, namePrefix, sort } = request;
+
+			const sortField = sort?.field ?? "name";
+			const sortOrder = sort?.order ?? "asc";
+
+			const dir = sql.raw(sortOrder);
+
+			const orderByClause =
+				sortField === "name"
+					? sql`${workflow.name} ${dir}`
+					: sortField === "runCount"
+						? sql`count(${workflowRun.id}) ${dir}`
+						: (sortField satisfies "lastRunAt") &&
+							sql`max(${workflowRun.id}) ${dir} nulls ${sql.raw(sortOrder === "asc" ? "first" : "last")}`;
+
+			// SQLite LIKE has no default escape character, so declare one explicitly.
+			const namePrefixCondition =
+				namePrefix !== undefined
+					? sql`${workflow.name} like ${`${namePrefix.replace(/%/g, "\\%").replace(/_/g, "\\_")}%`} escape '\\'`
+					: undefined;
+
+			const items = await db
+				.select({
+					name: workflow.name,
+					runCount: count(workflowRun.id),
+					lastRunId: max(workflowRun.id),
+				})
+				.from(workflow)
+				.leftJoin(workflowRun, eq(workflow.id, workflowRun.workflowId))
+				.where(and(eq(workflow.namespaceId, namespaceId), eq(workflow.source, source), namePrefixCondition))
+				.groupBy(workflow.name)
+				.orderBy(orderByClause)
+				.limit(limit)
+				.offset(offset);
+
+			const totalResult = await db
+				.select({ count: sql`count(distinct ${workflow.name})`.mapWith(Number) })
+				.from(workflow)
+				.where(and(eq(workflow.namespaceId, namespaceId), eq(workflow.source, source), namePrefixCondition));
+
+			return {
+				items,
+				total: totalResult[0]?.count ?? 0,
+			};
+		},
+
+		async listVersionsWithStats(
+			namespaceId: NamespaceId,
+			request: WorkflowListVersionsRequestV1
+		): Promise<{
+			items: Array<{ versionId: string; firstSeenAt: Date; lastRunId: string | null; runCount: number }>;
+			total: number;
+		}> {
+			const { name, source, limit = 50, offset = 0, sort } = request;
+
+			const sortField = sort?.field ?? "firstSeenAt";
+			const sortOrder = sort?.order ?? "desc";
+
+			const dir = sql.raw(sortOrder);
+
+			const orderByClause =
+				sortField === "firstSeenAt"
+					? sql`${workflow.id} ${dir}`
+					: (sortField satisfies "runCount") && sql`count(${workflowRun.id}) ${dir}`;
+
+			const items = await db
+				.select({
+					versionId: workflow.versionId,
+					firstSeenAt: workflow.createdAt,
+					lastRunId: max(workflowRun.id),
+					runCount: count(workflowRun.id),
+				})
+				.from(workflow)
+				.leftJoin(workflowRun, eq(workflow.id, workflowRun.workflowId))
+				.where(and(eq(workflow.namespaceId, namespaceId), eq(workflow.source, source), eq(workflow.name, name)))
+				.groupBy(workflow.id)
+				.orderBy(orderByClause)
+				.limit(limit)
+				.offset(offset);
+
+			const totalResult = await db
+				.select({ count: count() })
+				.from(workflow)
+				.where(and(eq(workflow.namespaceId, namespaceId), eq(workflow.source, source), eq(workflow.name, name)));
+
+			return {
+				items,
+				total: totalResult[0]?.count ?? 0,
+			};
+		},
+	};
+}
+
+export type WorkflowRepository = ReturnType<typeof createWorkflowRepository>;

--- a/sdk/server/src/infra/db/sqlite/schema.ts
+++ b/sdk/server/src/infra/db/sqlite/schema.ts
@@ -1,0 +1,406 @@
+import {
+	SCHEDULE_CONFLICT_POLICIES,
+	SCHEDULE_OVERLAP_POLICIES,
+	SCHEDULE_STATUSES,
+	SCHEDULE_TYPES,
+} from "@aikirun/types/schedule";
+import { WORKFLOW_SOURCES } from "@aikirun/types/workflow";
+import {
+	CHILD_WORKFLOW_RUN_WAIT_STATUSES,
+	EVENT_WAIT_STATUSES,
+	SLEEP_STATUSES,
+	TERMINAL_WORKFLOW_RUN_STATUSES,
+	WORKFLOW_RUN_CONFLICT_POLICIES,
+	WORKFLOW_RUN_STATUSES,
+} from "@aikirun/types/workflow/run";
+import { STATE_TRANSITION_TYPES } from "@aikirun/types/workflow/state-transition";
+import { TASK_STATUSES } from "@aikirun/types/workflow/task";
+import { relations, sql } from "drizzle-orm";
+import { check, foreignKey, index, integer, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+
+import { SQLITE_CURRENT_TIMESTAMP, sqliteJson, sqliteTimestamp } from "./custom-types";
+import { WORKFLOW_RUN_OUTBOX_STATUSES } from "../constants/workflow-run-outbox";
+
+export const workflow = sqliteTable(
+	"workflow",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		source: text("source", { enum: WORKFLOW_SOURCES }).notNull().default("user"),
+		name: text("name").notNull(),
+		versionId: text("version_id").notNull(),
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		uniqueIndex("uqidx_workflow_namespace_source_name_version").on(
+			table.namespaceId,
+			table.source,
+			table.name,
+			table.versionId
+		),
+	]
+);
+
+export const schedule = sqliteTable(
+	"schedule",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		workflowId: text("workflow_id").notNull(),
+
+		status: text("status", { enum: SCHEDULE_STATUSES }).notNull(),
+
+		type: text("type", { enum: SCHEDULE_TYPES }).notNull(),
+		cronExpression: text("cron_expression"),
+		intervalMs: integer("interval_ms"),
+		overlapPolicy: text("overlap_policy", { enum: SCHEDULE_OVERLAP_POLICIES }),
+
+		workflowRunInput: sqliteJson("workflow_run_input"),
+		workflowRunInputHash: text("workflow_run_input_hash").notNull(),
+
+		definitionHash: text("definition_hash").notNull(),
+
+		referenceId: text("reference_id"),
+		conflictPolicy: text("conflict_policy", { enum: SCHEDULE_CONFLICT_POLICIES }),
+
+		lastOccurrence: sqliteTimestamp("last_occurrence"),
+		nextRunAt: sqliteTimestamp("next_run_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+		updatedAt: sqliteTimestamp("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_schedule_workflow_id",
+			columns: [table.workflowId],
+			foreignColumns: [workflow.id],
+		}),
+		uniqueIndex("uqidx_schedule_namespace_definition").on(table.namespaceId, table.definitionHash),
+		uniqueIndex("uqidx_schedule_namespace_reference").on(table.namespaceId, table.referenceId),
+		index("idx_schedule_namespace_workflow").on(table.namespaceId, table.workflowId),
+		index("idx_schedule_status_next_run_at_id").on(table.status, table.nextRunAt, table.id),
+	]
+);
+
+export const workflowRun = sqliteTable(
+	"workflow_run",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		workflowId: text("workflow_id").notNull(),
+		scheduleId: text("schedule_id"),
+		parentWorkflowRunId: text("parent_workflow_run_id"),
+
+		status: text("status", { enum: WORKFLOW_RUN_STATUSES }).notNull(),
+		revision: integer("revision").notNull().default(0),
+		attempts: integer("attempts").notNull().default(1),
+
+		input: sqliteJson("input"),
+		inputHash: text("input_hash").notNull(),
+		options: sqliteJson("options"),
+
+		referenceId: text("reference_id"),
+		conflictPolicy: text("conflict_policy", { enum: WORKFLOW_RUN_CONFLICT_POLICIES }),
+
+		latestStateTransitionId: text("latest_state_transition_id").notNull(),
+		scheduledAt: sqliteTimestamp("scheduled_at"),
+		awakeAt: sqliteTimestamp("awake_at"),
+		timeoutAt: sqliteTimestamp("timeout_at"),
+		nextAttemptAt: sqliteTimestamp("next_attempt_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+		updatedAt: sqliteTimestamp("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_workflow_run_workflow_id",
+			columns: [table.workflowId],
+			foreignColumns: [workflow.id],
+		}),
+		foreignKey({
+			name: "fk_workflow_run_schedule_id",
+			columns: [table.scheduleId],
+			foreignColumns: [schedule.id],
+		}),
+		foreignKey({
+			name: "fk_workflow_run_parent_workflow_run",
+			columns: [table.parentWorkflowRunId],
+			foreignColumns: [table.id],
+		}),
+		uniqueIndex("uqidx_workflow_run_workflow_reference").on(table.workflowId, table.referenceId),
+
+		index("idx_workflow_run_namespace_id").on(table.namespaceId, table.id),
+		index("idx_workflow_run_namespace_status_id").on(table.namespaceId, table.status, table.id),
+
+		index("idx_workflow_run_workflow_id").on(table.workflowId, table.id),
+		index("idx_workflow_run_workflow_status_id").on(table.workflowId, table.status, table.id),
+
+		index("idx_workflow_run_schedule").on(table.scheduleId),
+		index("idx_workflow_run_parent_workflow_run_status").on(table.parentWorkflowRunId, table.status),
+
+		index("idx_workflow_run_status_scheduled_at_id").on(table.status, table.scheduledAt, table.id),
+		index("idx_workflow_run_status_awake_at_id").on(table.status, table.awakeAt, table.id),
+		index("idx_workflow_run_status_timeout_at_id").on(table.status, table.timeoutAt, table.id),
+		index("idx_workflow_run_status_next_attempt_at_id").on(table.status, table.nextAttemptAt, table.id),
+	]
+);
+
+export const task = sqliteTable(
+	"task",
+	{
+		id: text("id").primaryKey(),
+		name: text("name").notNull(),
+		workflowRunId: text("workflow_run_id").notNull(),
+
+		status: text("status", { enum: TASK_STATUSES }).notNull(),
+		attempts: integer("attempts").notNull(),
+
+		input: sqliteJson("input"),
+		inputHash: text("input_hash").notNull(),
+		options: sqliteJson("options"),
+
+		latestStateTransitionId: text("latest_state_transition_id").notNull(),
+		nextAttemptAt: sqliteTimestamp("next_attempt_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+		updatedAt: sqliteTimestamp("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_task_workflow_run",
+			columns: [table.workflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		index("idx_task_workflow_run_id").on(table.workflowRunId, table.id),
+		index("idx_task_workflow_run_status").on(table.workflowRunId, table.status),
+		index("idx_task_status_next_attempt_at_workflow_run").on(table.status, table.nextAttemptAt, table.workflowRunId),
+	]
+);
+
+const workflowRunStatusList = WORKFLOW_RUN_STATUSES.map((s) => `'${s}'`).join(", ");
+const taskStatusList = TASK_STATUSES.map((s) => `'${s}'`).join(", ");
+
+export const stateTransition = sqliteTable(
+	"state_transition",
+	{
+		id: text("id").primaryKey(),
+		workflowRunId: text("workflow_run_id").notNull(),
+		type: text("type", { enum: STATE_TRANSITION_TYPES }).notNull(),
+		taskId: text("task_id"),
+		status: text("status").notNull(),
+		attempt: integer("attempt").notNull(),
+		state: sqliteJson("state").notNull(),
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_state_transition_workflow_run",
+			columns: [table.workflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		foreignKey({
+			name: "fk_state_transition_task",
+			columns: [table.taskId],
+			foreignColumns: [task.id],
+		}),
+		index("idx_state_transition_workflow_run_id").on(table.workflowRunId, table.id),
+		check(
+			"chk_task_state_transition_requires_task_id",
+			sql`(${table.type} = 'task' AND ${table.taskId} IS NOT NULL) OR (${table.type} = 'workflow_run' AND ${table.taskId} IS NULL)`
+		),
+		check(
+			"chk_state_transition_status_matches_type",
+			sql.raw(
+				`(type = 'workflow_run' AND status IN (${workflowRunStatusList}))` +
+					` OR (type = 'task' AND status IN (${taskStatusList}))`
+			)
+		),
+	]
+);
+
+export const sleepQueue = sqliteTable(
+	"sleep_queue",
+	{
+		id: text("id").primaryKey(),
+		workflowRunId: text("workflow_run_id").notNull(),
+
+		name: text("name").notNull(),
+		status: text("status", { enum: SLEEP_STATUSES }).notNull(),
+
+		awakeAt: sqliteTimestamp("awake_at").notNull(),
+		completedAt: sqliteTimestamp("completed_at"),
+		cancelledAt: sqliteTimestamp("cancelled_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_sleep_queue_workflow_run",
+			columns: [table.workflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		uniqueIndex("uqidx_sleep_queue_one_active_per_run")
+			.on(table.workflowRunId)
+			.where(sql`${table.status} = 'sleeping'`),
+		index("idx_sleep_queue_workflow_run_id").on(table.workflowRunId, table.id),
+		check(
+			"chk_sleep_queue_completed_requires_completed_at",
+			sql`${table.status} != 'completed' OR ${table.completedAt} IS NOT NULL`
+		),
+		check(
+			"chk_sleep_queue_cancelled_requires_cancelled_at",
+			sql`${table.status} != 'cancelled' OR ${table.cancelledAt} IS NOT NULL`
+		),
+	]
+);
+
+export const eventWaitQueue = sqliteTable(
+	"event_wait_queue",
+	{
+		id: text("id").primaryKey(),
+		workflowRunId: text("workflow_run_id").notNull(),
+
+		name: text("name").notNull(),
+		status: text("status", { enum: EVENT_WAIT_STATUSES }).notNull(),
+		referenceId: text("reference_id"),
+
+		data: sqliteJson("data"),
+
+		timedOutAt: sqliteTimestamp("timed_out_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_event_wait_queue_workflow_run",
+			columns: [table.workflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		uniqueIndex("uqidx_event_wait_queue_workflow_run_name_reference").on(
+			table.workflowRunId,
+			table.name,
+			table.referenceId
+		),
+		index("idx_event_wait_queue_workflow_run_id").on(table.workflowRunId, table.id),
+		check(
+			"chk_event_wait_queue_timeout_requires_timed_out_at",
+			sql`${table.status} != 'timeout' OR ${table.timedOutAt} IS NOT NULL`
+		),
+	]
+);
+
+export const childWorkflowRunWaitQueue = sqliteTable(
+	"child_workflow_run_wait_queue",
+	{
+		id: text("id").primaryKey(),
+		parentWorkflowRunId: text("parent_workflow_run_id").notNull(),
+		childWorkflowRunId: text("child_workflow_run_id").notNull(),
+		childWorkflowRunStatus: text("child_workflow_run_status", { enum: TERMINAL_WORKFLOW_RUN_STATUSES }).notNull(),
+
+		status: text("status", { enum: CHILD_WORKFLOW_RUN_WAIT_STATUSES }).notNull(),
+		completedAt: sqliteTimestamp("completed_at"),
+		timedOutAt: sqliteTimestamp("timed_out_at"),
+
+		childWorkflowRunStateTransitionId: text("child_workflow_run_state_transition_id"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		foreignKey({
+			name: "fk_child_workflow_run_wait_queue_parent",
+			columns: [table.parentWorkflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		foreignKey({
+			name: "fk_child_workflow_run_wait_queue_child",
+			columns: [table.childWorkflowRunId],
+			foreignColumns: [workflowRun.id],
+		}),
+		foreignKey({
+			name: "fk_child_workflow_run_wait_queue_state_transition",
+			columns: [table.childWorkflowRunStateTransitionId],
+			foreignColumns: [stateTransition.id],
+		}),
+		index("idx_child_workflow_run_wait_queue_parent_id").on(table.parentWorkflowRunId, table.id),
+		check(
+			"chk_child_workflow_run_wait_completed_invariants",
+			sql`${table.status} != 'completed' OR (${table.completedAt} IS NOT NULL AND ${table.childWorkflowRunStateTransitionId} IS NOT NULL)`
+		),
+		check(
+			"chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+			sql`${table.status} != 'timeout' OR ${table.timedOutAt} IS NOT NULL`
+		),
+	]
+);
+
+export const workflowRunOutbox = sqliteTable(
+	"workflow_run_outbox",
+	{
+		id: text("id").primaryKey(),
+		namespaceId: text("namespace_id").notNull(),
+		workflowRunId: text("workflow_run_id").notNull(),
+		workflowName: text("workflow_name").notNull(),
+		workflowVersionId: text("workflow_version_id").notNull(),
+		shard: text("shard"),
+		rank: real("rank").notNull(),
+
+		status: text("status", { enum: WORKFLOW_RUN_OUTBOX_STATUSES }).notNull(),
+
+		publishedAt: sqliteTimestamp("published_at"),
+		claimedAt: sqliteTimestamp("claimed_at"),
+
+		createdAt: sqliteTimestamp("created_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+		updatedAt: sqliteTimestamp("updated_at").notNull().default(SQLITE_CURRENT_TIMESTAMP),
+	},
+	(table) => [
+		uniqueIndex("uqidx_workflow_run_outbox_workflow_run_id").on(table.workflowRunId),
+		index("idx_workflow_run_outbox_status_workflow_rank_id").on(
+			table.namespaceId,
+			table.status,
+			table.workflowName,
+			table.workflowVersionId,
+			table.shard,
+			table.rank,
+			table.id
+		),
+		index("idx_workflow_run_outbox_status_workflow_claimed_rank_id").on(
+			table.namespaceId,
+			table.status,
+			table.workflowName,
+			table.workflowVersionId,
+			table.shard,
+			table.claimedAt,
+			table.rank,
+			table.id
+		),
+		index("idx_workflow_run_outbox_status_rank_id").on(table.status, table.rank, table.id),
+		index("idx_workflow_run_outbox_status_published_id").on(table.status, table.publishedAt, table.id),
+		index("idx_workflow_run_outbox_status_claimed_id").on(table.status, table.claimedAt, table.id),
+		check(
+			"chk_workflow_run_outbox_published_requires_published_at",
+			sql`${table.status} != 'published' OR ${table.publishedAt} IS NOT NULL`
+		),
+		check(
+			"chk_workflow_run_outbox_claimed_requires_claimed_at",
+			sql`${table.status} != 'claimed' OR ${table.claimedAt} IS NOT NULL`
+		),
+	]
+);
+
+export const workflowRunRelations = relations(workflowRun, ({ one }) => ({
+	parentWorkflowRun: one(workflowRun, {
+		fields: [workflowRun.parentWorkflowRunId],
+		references: [workflowRun.id],
+	}),
+	latestStateTransition: one(stateTransition, {
+		fields: [workflowRun.latestStateTransitionId],
+		references: [stateTransition.id],
+	}),
+}));
+
+export const taskRelations = relations(task, ({ one }) => ({
+	latestStateTransition: one(stateTransition, {
+		fields: [task.latestStateTransitionId],
+		references: [stateTransition.id],
+	}),
+}));

--- a/sdk/server/tsup.config.ts
+++ b/sdk/server/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 	clean: true,
 	outDir: "dist",
 	noExternal: ["@aikirun/lib"],
+	external: ["bun:sqlite"],
 	async onSuccess() {
 		for (const provider of DATABASE_PROVIDERS) {
 			const sourceDir = path.join("src", "infra", "db", provider, "migration");


### PR DESCRIPTION
Support SQLite as an alternative to PostgreSQL, enabling the server to run without any external database dependency. Includes schema translation, repository implementations, transaction serialize for safe concurrent access, auto-migration, and documentation updates.