### PR TITLE
Reduce timer latency via Redis sorted sets

### DIFF
--- a/lib/array/utils.ts
+++ b/lib/array/utils.ts
@@ -31,6 +31,28 @@ export function* chunkLazy<T>(items: T[], size: number): Generator<NonEmptyArray
 	}
 }
 
+export const splitArray = <Item, WhenTrue = Item, WhenFalse = Item>(
+	items: Item[],
+	condition: (item: Item) => { meetsCondition: true; item: WhenTrue } | { meetsCondition: false; item: WhenFalse }
+): { whenTrue: WhenTrue[]; whenFalse: WhenFalse[] } => {
+	const itemsThatMeetCondition: WhenTrue[] = [];
+	const itemsThatDoNotMeetCondition: WhenFalse[] = [];
+
+	for (const item of items) {
+		const result = condition(item);
+		if (result.meetsCondition) {
+			itemsThatMeetCondition.push(result.item);
+		} else {
+			itemsThatDoNotMeetCondition.push(result.item);
+		}
+	}
+
+	return {
+		whenTrue: itemsThatMeetCondition,
+		whenFalse: itemsThatDoNotMeetCondition,
+	};
+};
+
 /**
  * Shuffles an array using Fisher-Yates algorithm for better randomness
  * @param array The array to shuffle

--- a/server/crons/due-timers.ts
+++ b/server/crons/due-timers.ts
@@ -50,7 +50,7 @@ export async function queueDueTimers(context: CronContext, deps: QueueDueTimersD
 			promises.push(queueRecurringWorkflows(context, deps, schedules));
 		} else {
 			const runStatus = timerTypeToWorkflowRunStatus[timerType];
-			const runs = await deps.repos.workflowRun.listByIdsAndStatus(ids, runStatus);
+			const runs = await deps.repos.workflowRun.listByIdsAndStatus(context, ids, runStatus);
 			if (!isNonEmptyArray(runs)) {
 				continue;
 			}

--- a/server/crons/due-timers.ts
+++ b/server/crons/due-timers.ts
@@ -1,0 +1,100 @@
+import { groupBy, isNonEmptyArray } from "@aikirun/lib/array";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { WorkflowRunStatus } from "@aikirun/types/workflow-run";
+import type { Repositories } from "server/infra/db/types";
+import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet, TimerType } from "server/infra/messaging/redis-timer-sorted-set";
+import type { CronContext } from "server/middleware/context";
+import type { ChildRunCanceller } from "server/service/cancel-child-runs";
+import { scheduleRowToDomain } from "server/service/schedule";
+
+import { queueChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
+import { queueEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
+import { type DueSchedule, queueRecurringWorkflows } from "./imminent-recurring-workflows";
+import { queueRetryableRuns } from "./imminent-retryable-runs";
+import { queueRetryableTaskRuns } from "./imminent-retryable-task-runs";
+import { queueScheduledRuns } from "./imminent-scheduled-runs";
+import { queueSleepElapsedRuns } from "./imminent-sleep-elapsed-runs";
+
+export interface QueueDueTimersDeps {
+	repos: Repositories;
+	timerSortedSet: TimerSortedSet;
+	childRunCanceller: ChildRunCanceller;
+	workflowRunPublisher?: WorkflowRunPublisher;
+}
+
+export async function queueDueTimers(context: CronContext, deps: QueueDueTimersDeps, options?: { limit?: number }) {
+	const { limit = 100 } = options ?? {};
+
+	const dueTimers = await deps.timerSortedSet.popDue(Date.now(), limit);
+	if (dueTimers.length === 0) {
+		return;
+	}
+
+	const timersByType = groupBy(dueTimers, (timer) => [timer.type, timer.id]);
+
+	const promises: Promise<void>[] = [];
+
+	for (const [timerType, ids] of timersByType) {
+		if (timerType === "recurring") {
+			const rows = await deps.repos.schedule.listActiveByIds(context, ids);
+			const schedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({
+				...scheduleRowToDomain(schedule, workflow),
+				workflowId: schedule.workflowId,
+				namespaceId: schedule.namespaceId as NamespaceId,
+				workflowRunInputHash: schedule.workflowRunInputHash,
+			}));
+			if (!isNonEmptyArray(schedules)) {
+				continue;
+			}
+			promises.push(queueRecurringWorkflows(context, deps, schedules));
+		} else {
+			const runStatus = timerTypeToWorkflowRunStatus[timerType];
+			const runs = await deps.repos.workflowRun.listByIdsAndStatus(ids, runStatus);
+			if (!isNonEmptyArray(runs)) {
+				continue;
+			}
+
+			switch (timerType) {
+				case "sleep": {
+					promises.push(queueSleepElapsedRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				case "retry": {
+					promises.push(queueRetryableRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				case "task_retry": {
+					promises.push(queueRetryableTaskRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				case "event_wait_timeout": {
+					promises.push(queueEventWaitTimedOutRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				case "child_wait_timeout": {
+					promises.push(queueChildRunWaitTimedOutRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				case "scheduled": {
+					promises.push(queueScheduledRuns(context, deps.repos, deps.workflowRunPublisher, runs));
+					break;
+				}
+				default: {
+					timerType satisfies never;
+				}
+			}
+		}
+	}
+
+	await Promise.all(promises);
+}
+
+const timerTypeToWorkflowRunStatus: Record<Exclude<TimerType, "recurring">, WorkflowRunStatus> = {
+	sleep: "sleeping",
+	retry: "awaiting_retry",
+	task_retry: "running",
+	event_wait_timeout: "awaiting_event",
+	child_wait_timeout: "awaiting_child_workflow",
+	scheduled: "scheduled",
+};

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	ChildWorkflowRunWaitQueueRowInsert,
@@ -10,6 +10,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -24,21 +25,51 @@ type Repos = Pick<
 export interface ProcessImminentChildRunWaitTimedOutRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentChildRunWaitTimedOutRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentChildRunWaitTimedOutRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentChildRunWaitTimedOutRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(context, limit);
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	await queueChildRunWaitTimedOutRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	const now = Date.now();
+	const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		if (run.dueAt && run.dueAt.getTime() > now) {
+			return { meetsCondition: false, item: run };
+		}
+		return { meetsCondition: true, item: run };
+	});
+
+	if (isNonEmptyArray(runsDueNow)) {
+		await queueChildRunWaitTimedOutRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
+	}
+
+	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
+		const timers: Array<{ type: "child_wait_timeout"; id: string; dueAt: number }> = [];
+		for (const run of runsDueSoon) {
+			if (!run.dueAt) {
+				context.logger.warn({ runId: run.id }, "Missing dueAt for child-run-wait-timed-out run, skipping promotion");
+				continue;
+			}
+			timers.push({
+				type: "child_wait_timeout",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueChildRunWaitTimedOutRuns(

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -33,7 +33,7 @@ export async function processImminentChildRunWaitTimedOutRuns(
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(limit);
+	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(context, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -2,8 +2,8 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
+	ChildWorkflowRunWaitQueueRowInsert,
 	DueWorkflowRun,
-	EventWaitQueueRowInsert,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -16,25 +16,39 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueEventWaitTimedOutRunsDeps {
-	repos: Pick<
-		Repositories,
-		"workflowRun" | "stateTransition" | "eventWaitQueue" | "workflow" | "workflowRunOutbox" | "transaction"
-	>;
+type Repos = Pick<
+	Repositories,
+	"workflowRun" | "stateTransition" | "childWorkflowRunWaitQueue" | "workflow" | "workflowRunOutbox" | "transaction"
+>;
+
+export interface ProcessImminentChildRunWaitTimedOutRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueEventWaitTimedOutWorkflowRuns(
+export async function processImminentChildRunWaitTimedOutRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueEventWaitTimedOutRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentChildRunWaitTimedOutRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(limit);
+	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
+
+	await queueChildRunWaitTimedOutRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueChildRunWaitTimedOutRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
 
 	const stateTransitionIds: string[] = [];
 	const workflowIdSet = new Set<string>();
@@ -66,7 +80,7 @@ export async function queueEventWaitTimedOutWorkflowRuns(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueEventWaitTimedOutRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
@@ -74,7 +88,7 @@ async function processChunk(
 ): Promise<void> {
 	const timedOutAt = new Date();
 
-	const eventWaitEntries: EventWaitQueueRowInsert[] = [];
+	const childRunWaitEntries: ChildWorkflowRunWaitQueueRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
@@ -91,20 +105,21 @@ async function processChunk(
 			continue;
 		}
 		const fromState = transition.state as WorkflowRunState;
-		if (fromState.status !== "awaiting_event") {
+		if (fromState.status !== "awaiting_child_workflow") {
 			continue;
 		}
 
-		eventWaitEntries.push({
+		childRunWaitEntries.push({
 			id: ulid(),
-			workflowRunId: run.id,
-			name: fromState.eventName,
+			parentWorkflowRunId: run.id,
+			childWorkflowRunId: fromState.childWorkflowRunId,
+			childWorkflowRunStatus: fromState.childWorkflowRunStatus,
 			status: "timeout",
 			timedOutAt,
 		});
 
 		const stateTransitionId = ulid();
-		const toState: WorkflowRunStateQueued = { status: "queued", reason: "event" };
+		const toState: WorkflowRunStateQueued = { status: "queued", reason: "child_workflow" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,
@@ -122,7 +137,6 @@ async function processChunk(
 				stateTransitionId,
 			},
 		});
-
 		outboxEntries.push({
 			id: ulid(),
 			namespaceId: run.namespaceId,
@@ -135,7 +149,7 @@ async function processChunk(
 	}
 
 	if (
-		!isNonEmptyArray(eventWaitEntries) ||
+		!isNonEmptyArray(childRunWaitEntries) ||
 		!isNonEmptyArray(stateTransitionEntries) ||
 		!isNonEmptyArray(workflowRunUpdates)
 	) {
@@ -143,9 +157,12 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.eventWaitQueue.insert(eventWaitEntries);
+		await txRepos.childWorkflowRunWaitQueue.insert(childRunWaitEntries);
 		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_event", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			"awaiting_child_workflow",
+			workflowRunUpdates
+		);
 		const transitionedRunIdsSet = new Set(transitionedRunIds);
 		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
 		if (!isNonEmptyArray(outboxEntriesToInsert)) {

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -33,7 +33,7 @@ export async function processImminentEventWaitTimedOutRuns(
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(limit);
+	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(context, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
@@ -10,6 +10,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -24,21 +25,51 @@ type Repos = Pick<
 export interface ProcessImminentEventWaitTimedOutRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentEventWaitTimedOutRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentEventWaitTimedOutRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentEventWaitTimedOutRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(context, limit);
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	await queueEventWaitTimedOutRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	const now = Date.now();
+	const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		if (run.dueAt && run.dueAt.getTime() > now) {
+			return { meetsCondition: false, item: run };
+		}
+		return { meetsCondition: true, item: run };
+	});
+
+	if (isNonEmptyArray(runsDueNow)) {
+		await queueEventWaitTimedOutRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
+	}
+
+	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
+		const timers: Array<{ type: "event_wait_timeout"; id: string; dueAt: number }> = [];
+		for (const run of runsDueSoon) {
+			if (!run.dueAt) {
+				context.logger.warn({ runId: run.id }, "Missing dueAt for event-wait-timed-out run, skipping promotion");
+				continue;
+			}
+			timers.push({
+				type: "event_wait_timeout",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueEventWaitTimedOutRuns(

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -1,8 +1,9 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
-import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
+	EventWaitQueueRowInsert,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -15,36 +16,62 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueRetryableRunsDeps {
-	repos: Pick<
-		Repositories,
-		"workflowRun" | "stateTransition" | "task" | "workflow" | "workflowRunOutbox" | "transaction"
-	>;
+type Repos = Pick<
+	Repositories,
+	"workflowRun" | "stateTransition" | "eventWaitQueue" | "workflow" | "workflowRunOutbox" | "transaction"
+>;
+
+export interface ProcessImminentEventWaitTimedOutRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueRetryableWorkflowRuns(
+export async function processImminentEventWaitTimedOutRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueRetryableRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentEventWaitTimedOutRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listRetryableRuns(limit);
+	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId)));
-	if (!isNonEmptyArray(workflowIds)) {
+	await queueEventWaitTimedOutRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueEventWaitTimedOutRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
+
+	const stateTransitionIds: string[] = [];
+	const workflowIdSet = new Set<string>();
+	for (const run of runs) {
+		stateTransitionIds.push(run.latestStateTransitionId);
+		workflowIdSet.add(run.workflowId);
+	}
+	const workflowIds = Array.from(workflowIdSet);
+
+	if (!isNonEmptyArray(stateTransitionIds) || !isNonEmptyArray(workflowIds)) {
 		return;
 	}
-	const workflows = await repos.workflow.getByIdsGlobal(context, workflowIds);
+
+	const [stateTransitions, workflows] = await Promise.all([
+		repos.stateTransition.getByIds(stateTransitionIds),
+		repos.workflow.getByIdsGlobal(context, workflowIds),
+	]);
+	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
-			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
+			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
 		} catch (error) {
 			spanCtx.logger.warn({ err: error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
 		}
@@ -53,13 +80,15 @@ export async function queueRetryableWorkflowRuns(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueRetryableRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
+	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
-	const workflowRunIds = runs.map((run) => run.id);
+	const timedOutAt = new Date();
 
+	const eventWaitEntries: EventWaitQueueRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
@@ -71,15 +100,32 @@ async function processChunk(
 			continue;
 		}
 
+		const transition = stateTransitionsById.get(run.latestStateTransitionId);
+		if (!transition) {
+			continue;
+		}
+		const fromState = transition.state as WorkflowRunState;
+		if (fromState.status !== "awaiting_event") {
+			continue;
+		}
+
+		eventWaitEntries.push({
+			id: ulid(),
+			workflowRunId: run.id,
+			name: fromState.eventName,
+			status: "timeout",
+			timedOutAt,
+		});
+
 		const stateTransitionId = ulid();
-		const state: WorkflowRunStateQueued = { status: "queued", reason: "retry" };
+		const toState: WorkflowRunStateQueued = { status: "queued", reason: "event" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
 			status: "queued",
 			attempt: run.attempts,
-			state,
+			state: toState,
 		});
 		workflowRunUpdates.push({
 			filter: {
@@ -103,7 +149,7 @@ async function processChunk(
 	}
 
 	if (
-		!isNonEmptyArray(workflowRunIds) ||
+		!isNonEmptyArray(eventWaitEntries) ||
 		!isNonEmptyArray(stateTransitionEntries) ||
 		!isNonEmptyArray(workflowRunUpdates)
 	) {
@@ -111,9 +157,9 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.task.deleteStaleByWorkflowRunIds(workflowRunIds);
+		await txRepos.eventWaitQueue.insert(eventWaitEntries);
 		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_retry", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_event", workflowRunUpdates);
 		const transitionedRunIdsSet = new Set(transitionedRunIds);
 		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
 		if (!isNonEmptyArray(outboxEntriesToInsert)) {

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -26,30 +26,44 @@ import { publishRuns } from "./publish-ready-runs";
 
 export interface QueueRecurringWorkflowsDeps {
 	repos: Pick<Repositories, "workflowRun" | "stateTransition" | "schedule" | "workflowRunOutbox" | "transaction">;
-	scheduleService: ScheduleService;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-type DueSchedule = Schedule & {
+export interface ProcessImminentRecurringWorkflowsDeps extends QueueRecurringWorkflowsDeps {
+	scheduleService: ScheduleService;
+}
+
+export type DueSchedule = Schedule & {
 	workflowId: string;
 	namespaceId: NamespaceId;
 	workflowRunInputHash: string;
 };
 
-export async function queueRecurringWorkflows(context: CronContext, deps: QueueRecurringWorkflowsDeps) {
-	const now = Date.now();
-
-	const dueSchedules = await deps.scheduleService.getDueSchedules(now);
+export async function processImminentRecurringWorkflows(
+	context: CronContext,
+	deps: ProcessImminentRecurringWorkflowsDeps
+) {
+	const dueSchedules = await deps.scheduleService.getDueSchedules(Date.now());
 	if (!isNonEmptyArray(dueSchedules)) {
 		return;
 	}
+
+	await queueRecurringWorkflows(context, deps, dueSchedules);
+}
+
+export async function queueRecurringWorkflows(
+	context: CronContext,
+	deps: QueueRecurringWorkflowsDeps,
+	schedules: NonEmptyArray<DueSchedule>
+) {
+	const now = Date.now();
 
 	const allowSchedules: DueSchedule[] = [];
 	const skipSchedules: DueSchedule[] = [];
 	const cancelPreviousSchedules: DueSchedule[] = [];
 
-	for (const schedule of dueSchedules) {
+	for (const schedule of schedules) {
 		const overlapPolicy: ScheduleOverlapPolicy = schedule.spec.overlapPolicy ?? "skip";
 		if (overlapPolicy === "allow") {
 			allowSchedules.push(schedule);

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -18,20 +18,15 @@ import type {
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
 import type { CronContext } from "server/middleware/context";
 import type { CancelledParentRun, ChildRunCanceller } from "server/service/cancel-child-runs";
-import type { ScheduleService } from "server/service/schedule";
-import { getDueOccurrences, getNextOccurrence, getReferenceId } from "server/service/schedule";
+import { getDueOccurrences, getNextOccurrence, getReferenceId, scheduleRowToDomain } from "server/service/schedule";
 import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueRecurringWorkflowsDeps {
+export interface ProcessImminentRecurringWorkflowsDeps {
 	repos: Pick<Repositories, "workflowRun" | "stateTransition" | "schedule" | "workflowRunOutbox" | "transaction">;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunPublisher?: WorkflowRunPublisher;
-}
-
-export interface ProcessImminentRecurringWorkflowsDeps extends QueueRecurringWorkflowsDeps {
-	scheduleService: ScheduleService;
 }
 
 export type DueSchedule = Schedule & {
@@ -44,7 +39,13 @@ export async function processImminentRecurringWorkflows(
 	context: CronContext,
 	deps: ProcessImminentRecurringWorkflowsDeps
 ) {
-	const dueSchedules = await deps.scheduleService.getDueSchedules(Date.now());
+	const rows = await deps.repos.schedule.listDueSchedules(context, new Date());
+	const dueSchedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({
+		...scheduleRowToDomain(schedule, workflow),
+		workflowId: schedule.workflowId,
+		namespaceId: schedule.namespaceId as NamespaceId,
+		workflowRunInputHash: schedule.workflowRunInputHash,
+	}));
 	if (!isNonEmptyArray(dueSchedules)) {
 		return;
 	}
@@ -54,7 +55,7 @@ export async function processImminentRecurringWorkflows(
 
 export async function queueRecurringWorkflows(
 	context: CronContext,
-	deps: QueueRecurringWorkflowsDeps,
+	deps: ProcessImminentRecurringWorkflowsDeps,
 	schedules: NonEmptyArray<DueSchedule>
 ) {
 	const now = Date.now();
@@ -96,7 +97,7 @@ export async function queueRecurringWorkflows(
 
 async function processOverlapAllowSchedules(
 	context: CronContext,
-	repos: QueueRecurringWorkflowsDeps["repos"],
+	repos: ProcessImminentRecurringWorkflowsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>,
 	now: number,
 	workflowRunPublisher?: WorkflowRunPublisher
@@ -183,7 +184,7 @@ async function processOverlapAllowSchedules(
 
 async function processOverlapSkipSchedules(
 	context: CronContext,
-	repos: QueueRecurringWorkflowsDeps["repos"],
+	repos: ProcessImminentRecurringWorkflowsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>,
 	now: number,
 	workflowRunPublisher?: WorkflowRunPublisher
@@ -274,7 +275,7 @@ async function processOverlapSkipSchedules(
 
 async function processOverlapCancelPreviousSchedules(
 	context: CronContext,
-	deps: QueueRecurringWorkflowsDeps,
+	deps: ProcessImminentRecurringWorkflowsDeps,
 	schedules: NonEmptyArray<DueSchedule>,
 	now: number
 ) {
@@ -411,7 +412,7 @@ async function processOverlapCancelPreviousSchedules(
 }
 
 async function fetchActiveRunsBySchedule(
-	repos: QueueRecurringWorkflowsDeps["repos"],
+	repos: ProcessImminentRecurringWorkflowsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>
 ) {
 	const workflowAndReferenceIdPairs: { workflowId: string; referenceId: string }[] = [];

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { Schedule, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
 import {
@@ -16,6 +16,8 @@ import type {
 	WorkflowRunRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import type { CancelledParentRun, ChildRunCanceller } from "server/service/cancel-child-runs";
 import { getDueOccurrences, getNextOccurrence, getReferenceId, scheduleRowToDomain } from "server/service/schedule";
@@ -27,6 +29,7 @@ export interface ProcessImminentRecurringWorkflowsDeps {
 	repos: Pick<Repositories, "workflowRun" | "stateTransition" | "schedule" | "workflowRunOutbox" | "transaction">;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export type DueSchedule = Schedule & {
@@ -37,20 +40,49 @@ export type DueSchedule = Schedule & {
 
 export async function processImminentRecurringWorkflows(
 	context: CronContext,
-	deps: ProcessImminentRecurringWorkflowsDeps
+	deps: ProcessImminentRecurringWorkflowsDeps,
+	options?: { imminenceThresholdMs?: number; chunkSize?: number }
 ) {
-	const rows = await deps.repos.schedule.listDueSchedules(context, new Date());
-	const dueSchedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({
+	const { imminenceThresholdMs = 1_000, chunkSize = 50 } = options ?? {};
+
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const rows = await deps.repos.schedule.listDueSchedules(context, dueBefore);
+	const schedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({
 		...scheduleRowToDomain(schedule, workflow),
 		workflowId: schedule.workflowId,
 		namespaceId: schedule.namespaceId as NamespaceId,
 		workflowRunInputHash: schedule.workflowRunInputHash,
 	}));
-	if (!isNonEmptyArray(dueSchedules)) {
+	if (!isNonEmptyArray(schedules)) {
 		return;
 	}
 
-	await queueRecurringWorkflows(context, deps, dueSchedules);
+	const now = Date.now();
+	const { whenTrue: schedulesDueNow, whenFalse: schedulesDueSoon } = splitArray(schedules, (schedule) => {
+		if (schedule.nextRunAt > now) {
+			return { meetsCondition: false, item: schedule };
+		}
+		return { meetsCondition: true, item: schedule };
+	});
+
+	if (isNonEmptyArray(schedulesDueNow)) {
+		await queueRecurringWorkflows(context, deps, schedulesDueNow);
+	}
+
+	const { timerSortedSet } = deps;
+	if (timerSortedSet && isNonEmptyArray(schedulesDueSoon)) {
+		const timers: Array<{ type: "recurring"; id: string; dueAt: number }> = [];
+		for (const schedule of schedulesDueSoon) {
+			timers.push({
+				type: "recurring",
+				id: schedule.id,
+				dueAt: schedule.nextRunAt,
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueRecurringWorkflows(

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -32,7 +32,7 @@ export async function processImminentRetryableRuns(
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listRetryableRuns(limit);
+	const runs = await repos.workflowRun.listRetryableRuns(context, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
@@ -9,6 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -23,21 +24,51 @@ type Repos = Pick<
 export interface ProcessImminentRetryableRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentRetryableRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentRetryableRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentRetryableRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const runs = await repos.workflowRun.listRetryableRuns(context, limit);
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const runs = await repos.workflowRun.listRetryableRuns(context, dueBefore, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	await queueRetryableRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	const now = Date.now();
+	const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		if (run.dueAt && run.dueAt.getTime() > now) {
+			return { meetsCondition: false, item: run };
+		}
+		return { meetsCondition: true, item: run };
+	});
+
+	if (isNonEmptyArray(runsDueNow)) {
+		await queueRetryableRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
+	}
+
+	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
+		const timers: Array<{ type: "retry"; id: string; dueAt: number }> = [];
+		for (const run of runsDueSoon) {
+			if (!run.dueAt) {
+				context.logger.warn({ runId: run.id }, "Missing dueAt for retryable run, skipping promotion");
+				continue;
+			}
+			timers.push({
+				type: "retry",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueRetryableRuns(

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -15,30 +15,39 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueRetryableTaskRunsDeps {
-	repos: Pick<
-		Repositories,
-		"task" | "workflowRun" | "stateTransition" | "workflow" | "workflowRunOutbox" | "transaction"
-	>;
+type Repos = Pick<
+	Repositories,
+	"workflowRun" | "stateTransition" | "task" | "workflow" | "workflowRunOutbox" | "transaction"
+>;
+
+export interface ProcessImminentRetryableRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueWorkflowRunsWithRetryableTask(
+export async function processImminentRetryableRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueRetryableTaskRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentRetryableRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const workflowRunIds = await repos.task.listRetryableTaskWorkflowRunIds(limit);
-	if (!isNonEmptyArray(workflowRunIds)) {
-		return;
-	}
-
-	const runs = await repos.workflowRun.listByIdsAndStatus(workflowRunIds, "running");
+	const runs = await repos.workflowRun.listRetryableRuns(limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
+
+	await queueRetryableRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueRetryableRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId)));
 	if (!isNonEmptyArray(workflowIds)) {
@@ -58,11 +67,13 @@ export async function queueWorkflowRunsWithRetryableTask(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueRetryableTaskRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
+	const workflowRunIds = runs.map((run) => run.id);
+
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
@@ -75,7 +86,7 @@ async function processChunk(
 		}
 
 		const stateTransitionId = ulid();
-		const state: WorkflowRunStateQueued = { status: "queued", reason: "task_retry" };
+		const state: WorkflowRunStateQueued = { status: "queued", reason: "retry" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,
@@ -105,13 +116,18 @@ async function processChunk(
 		});
 	}
 
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
+	if (
+		!isNonEmptyArray(workflowRunIds) ||
+		!isNonEmptyArray(stateTransitionEntries) ||
+		!isNonEmptyArray(workflowRunUpdates)
+	) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+		await txRepos.task.deleteStaleByWorkflowRunIds(workflowRunIds);
 		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("running", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_retry", workflowRunUpdates);
 		const transitionedRunIdsSet = new Set(transitionedRunIds);
 		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
 		if (!isNonEmptyArray(outboxEntriesToInsert)) {

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -37,7 +37,7 @@ export async function processImminentRetryableTaskRuns(
 		return;
 	}
 
-	const runs = await repos.workflowRun.listByIdsAndStatus(workflowRunIds, "running");
+	const runs = await repos.workflowRun.listByIdsAndStatus(context, workflowRunIds, "running");
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
@@ -9,6 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -23,26 +24,60 @@ type Repos = Pick<
 export interface ProcessImminentRetryableTaskRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentRetryableTaskRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentRetryableTaskRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentRetryableTaskRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const workflowRunIds = await repos.task.listRetryableTaskWorkflowRunIds(limit);
-	if (!isNonEmptyArray(workflowRunIds)) {
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const retryableTasks = await repos.task.listRetryableTaskWorkflowRuns(context, dueBefore, limit);
+	if (!isNonEmptyArray(retryableTasks)) {
 		return;
 	}
 
-	const runs = await repos.workflowRun.listByIdsAndStatus(context, workflowRunIds, "running");
-	if (!isNonEmptyArray(runs)) {
-		return;
+	const now = Date.now();
+	const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } = splitArray(retryableTasks, (task) => {
+		if (task.dueAt && new Date(task.dueAt).getTime() > now) {
+			return { meetsCondition: false, item: task };
+		}
+		return { meetsCondition: true, item: task };
+	});
+
+	if (isNonEmptyArray(tasksDueNow)) {
+		const workflowRunIds = tasksDueNow.map((task) => task.workflowRunId);
+		if (isNonEmptyArray(workflowRunIds)) {
+			const runs = await repos.workflowRun.listByIdsAndStatus(context, workflowRunIds, "running");
+			if (isNonEmptyArray(runs)) {
+				await queueRetryableTaskRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+			}
+		}
 	}
 
-	await queueRetryableTaskRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	if (timerSortedSet && isNonEmptyArray(tasksDueSoon)) {
+		const timers: Array<{ type: "task_retry"; id: string; dueAt: number }> = [];
+		for (const task of tasksDueSoon) {
+			if (!task.dueAt) {
+				context.logger.warn(
+					{ workflowRunId: task.workflowRunId },
+					"Missing dueAt for retryable task run, skipping promotion"
+				);
+				continue;
+			}
+			timers.push({
+				type: "task_retry",
+				id: task.workflowRunId,
+				dueAt: new Date(task.dueAt).getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueRetryableTaskRuns(

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
-import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
 	Repositories,
@@ -15,44 +15,55 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueScheduledRunsDeps {
-	repos: Pick<Repositories, "workflowRun" | "workflow" | "stateTransition" | "workflowRunOutbox" | "transaction">;
+type Repos = Pick<
+	Repositories,
+	"task" | "workflowRun" | "stateTransition" | "workflow" | "workflowRunOutbox" | "transaction"
+>;
+
+export interface ProcessImminentRetryableTaskRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueScheduledWorkflowRuns(
+export async function processImminentRetryableTaskRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueScheduledRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentRetryableTaskRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listDueScheduleRuns(limit);
+	const workflowRunIds = await repos.task.listRetryableTaskWorkflowRunIds(limit);
+	if (!isNonEmptyArray(workflowRunIds)) {
+		return;
+	}
+
+	const runs = await repos.workflowRun.listByIdsAndStatus(workflowRunIds, "running");
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	const stateTransitionIds: string[] = [];
-	const workflowIdSet = new Set<string>();
-	for (const run of runs) {
-		stateTransitionIds.push(run.latestStateTransitionId);
-		workflowIdSet.add(run.workflowId);
-	}
-	const workflowIds = Array.from(workflowIdSet);
-	if (!isNonEmptyArray(stateTransitionIds) || !isNonEmptyArray(workflowIds)) {
+	await queueRetryableTaskRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueRetryableTaskRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
+
+	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId)));
+	if (!isNonEmptyArray(workflowIds)) {
 		return;
 	}
-
-	const [stateTransitions, workflows] = await Promise.all([
-		repos.stateTransition.getByIds(stateTransitionIds),
-		repos.workflow.getByIdsGlobal(context, workflowIds),
-	]);
-	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
+	const workflows = await repos.workflow.getByIdsGlobal(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
-			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
+			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
 		} catch (error) {
 			spanCtx.logger.warn({ err: error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
 		}
@@ -61,10 +72,9 @@ export async function queueScheduledWorkflowRuns(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueScheduledRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
-	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
@@ -78,24 +88,15 @@ async function processChunk(
 			continue;
 		}
 
-		const transition = stateTransitionsById.get(run.latestStateTransitionId);
-		if (!transition) {
-			continue;
-		}
-		const fromState = transition.state as WorkflowRunState;
-		if (fromState.status !== "scheduled") {
-			continue;
-		}
-
 		const stateTransitionId = ulid();
-		const toState: WorkflowRunStateQueued = { status: "queued", reason: fromState.reason };
+		const state: WorkflowRunStateQueued = { status: "queued", reason: "task_retry" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
 			status: "queued",
 			attempt: run.attempts,
-			state: toState,
+			state,
 		});
 		workflowRunUpdates.push({
 			filter: {
@@ -106,6 +107,7 @@ async function processChunk(
 				stateTransitionId,
 			},
 		});
+
 		outboxEntries.push({
 			id: ulid(),
 			namespaceId: run.namespaceId,
@@ -123,7 +125,7 @@ async function processChunk(
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
 		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("scheduled", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("running", workflowRunUpdates);
 		const transitionedRunIdsSet = new Set(transitionedRunIds);
 		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
 		if (!isNonEmptyArray(outboxEntriesToInsert)) {

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -2,7 +2,6 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
-	ChildWorkflowRunWaitQueueRowInsert,
 	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
@@ -16,25 +15,36 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueChildRunWaitTimedOutRunsDeps {
-	repos: Pick<
-		Repositories,
-		"workflowRun" | "stateTransition" | "childWorkflowRunWaitQueue" | "workflow" | "workflowRunOutbox" | "transaction"
-	>;
+type Repos = Pick<Repositories, "workflowRun" | "workflow" | "stateTransition" | "workflowRunOutbox" | "transaction">;
+
+export interface ProcessImminentScheduledRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueChildRunWaitTimedOutWorkflowRuns(
+export async function processImminentScheduledRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueChildRunWaitTimedOutRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentScheduledRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(limit);
+	const runs = await repos.workflowRun.listDueScheduleRuns(limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
+
+	await queueScheduledRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueScheduledRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
 
 	const stateTransitionIds: string[] = [];
 	const workflowIdSet = new Set<string>();
@@ -66,15 +76,12 @@ export async function queueChildRunWaitTimedOutWorkflowRuns(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueChildRunWaitTimedOutRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
-	const timedOutAt = new Date();
-
-	const childRunWaitEntries: ChildWorkflowRunWaitQueueRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
@@ -91,21 +98,12 @@ async function processChunk(
 			continue;
 		}
 		const fromState = transition.state as WorkflowRunState;
-		if (fromState.status !== "awaiting_child_workflow") {
+		if (fromState.status !== "scheduled") {
 			continue;
 		}
 
-		childRunWaitEntries.push({
-			id: ulid(),
-			parentWorkflowRunId: run.id,
-			childWorkflowRunId: fromState.childWorkflowRunId,
-			childWorkflowRunStatus: fromState.childWorkflowRunStatus,
-			status: "timeout",
-			timedOutAt,
-		});
-
 		const stateTransitionId = ulid();
-		const toState: WorkflowRunStateQueued = { status: "queued", reason: "child_workflow" };
+		const toState: WorkflowRunStateQueued = { status: "queued", reason: fromState.reason };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,
@@ -134,21 +132,13 @@ async function processChunk(
 		});
 	}
 
-	if (
-		!isNonEmptyArray(childRunWaitEntries) ||
-		!isNonEmptyArray(stateTransitionEntries) ||
-		!isNonEmptyArray(workflowRunUpdates)
-	) {
+	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.childWorkflowRunWaitQueue.insert(childRunWaitEntries);
 		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
-			"awaiting_child_workflow",
-			workflowRunUpdates
-		);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("scheduled", workflowRunUpdates);
 		const transitionedRunIdsSet = new Set(transitionedRunIds);
 		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
 		if (!isNonEmptyArray(outboxEntriesToInsert)) {

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -29,7 +29,7 @@ export async function processImminentScheduledRuns(
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listDueScheduleRuns(limit);
+	const runs = await repos.workflowRun.listDueScheduleRuns(context, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
@@ -9,6 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -20,21 +21,51 @@ type Repos = Pick<Repositories, "workflowRun" | "workflow" | "stateTransition" |
 export interface ProcessImminentScheduledRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentScheduledRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentScheduledRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentScheduledRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const runs = await repos.workflowRun.listDueScheduleRuns(context, limit);
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const runs = await repos.workflowRun.listDueScheduleRuns(context, dueBefore, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	await queueScheduledRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	const now = Date.now();
+	const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		if (run.dueAt && run.dueAt.getTime() > now) {
+			return { meetsCondition: false, item: run };
+		}
+		return { meetsCondition: true, item: run };
+	});
+
+	if (isNonEmptyArray(runsDueNow)) {
+		await queueScheduledRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
+	}
+
+	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
+		const timers: Array<{ type: "scheduled"; id: string; dueAt: number }> = [];
+		for (const run of runsDueSoon) {
+			if (!run.dueAt) {
+				context.logger.warn({ runId: run.id }, "Missing dueAt for scheduled run, skipping promotion");
+				continue;
+			}
+			timers.push({
+				type: "scheduled",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueScheduledRuns(

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -1,4 +1,4 @@
-import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray, splitArray } from "@aikirun/lib/array";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
 	DueWorkflowRun,
@@ -8,6 +8,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -22,21 +23,51 @@ type Repos = Pick<
 export interface ProcessImminentSleepElapsedRunsDeps {
 	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 }
 
 export async function processImminentSleepElapsedRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: ProcessImminentSleepElapsedRunsDeps,
-	options?: { limit?: number; chunkSize?: number }
+	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentSleepElapsedRunsDeps,
+	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
 
-	const runs = await repos.workflowRun.listSleepElapsedRuns(context, limit);
+	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
+	const runs = await repos.workflowRun.listSleepElapsedRuns(context, dueBefore, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
 
-	await queueSleepElapsedRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+	const now = Date.now();
+	const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		if (run.dueAt && run.dueAt.getTime() > now) {
+			return { meetsCondition: false, item: run };
+		}
+		return { meetsCondition: true, item: run };
+	});
+
+	if (isNonEmptyArray(runsDueNow)) {
+		await queueSleepElapsedRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
+	}
+
+	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
+		const timers: Array<{ type: "sleep"; id: string; dueAt: number }> = [];
+		for (const run of runsDueSoon) {
+			if (!run.dueAt) {
+				context.logger.warn({ runId: run.id }, "Missing dueAt for sleep-elapsed run, skipping promotion");
+				continue;
+			}
+			timers.push({
+				type: "sleep",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			});
+		}
+		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {
+			await timerSortedSet.add(chunk);
+		});
+	}
 }
 
 export async function queueSleepElapsedRuns(

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -14,17 +14,19 @@ import { ulid } from "ulidx";
 
 import { publishRuns } from "./publish-ready-runs";
 
-export interface QueueSleepElapsedRunsDeps {
-	repos: Pick<
-		Repositories,
-		"workflowRun" | "stateTransition" | "sleepQueue" | "workflow" | "workflowRunOutbox" | "transaction"
-	>;
+type Repos = Pick<
+	Repositories,
+	"workflowRun" | "stateTransition" | "sleepQueue" | "workflow" | "workflowRunOutbox" | "transaction"
+>;
+
+export interface ProcessImminentSleepElapsedRunsDeps {
+	repos: Repos;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueSleepElapsedWorkflowRuns(
+export async function processImminentSleepElapsedRuns(
 	context: CronContext,
-	{ repos, workflowRunPublisher }: QueueSleepElapsedRunsDeps,
+	{ repos, workflowRunPublisher }: ProcessImminentSleepElapsedRunsDeps,
 	options?: { limit?: number; chunkSize?: number }
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
@@ -33,6 +35,18 @@ export async function queueSleepElapsedWorkflowRuns(
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}
+
+	await queueSleepElapsedRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
+}
+
+export async function queueSleepElapsedRuns(
+	context: CronContext,
+	repos: Repos,
+	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	runs: NonEmptyArray<DueWorkflowRun>,
+	options?: { chunkSize?: number }
+) {
+	const { chunkSize = 50 } = options ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId)));
 	if (!isNonEmptyArray(workflowIds)) {
@@ -52,7 +66,7 @@ export async function queueSleepElapsedWorkflowRuns(
 
 async function processChunk(
 	context: CronContext,
-	repos: QueueSleepElapsedRunsDeps["repos"],
+	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
 	runs: NonEmptyArray<DueWorkflowRun>,
 	workflowsById: Map<string, WorkflowRow>

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -31,7 +31,7 @@ export async function processImminentSleepElapsedRuns(
 ) {
 	const { limit = 100, chunkSize = 50 } = options ?? {};
 
-	const runs = await repos.workflowRun.listSleepElapsedRuns(limit);
+	const runs = await repos.workflowRun.listSleepElapsedRuns(context, limit);
 	if (!isNonEmptyArray(runs)) {
 		return;
 	}

--- a/server/crons/index.ts
+++ b/server/crons/index.ts
@@ -1,11 +1,12 @@
 import type { Repositories } from "server/infra/db/types";
 import type { Logger } from "server/infra/logger";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
+import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import type { CronContext } from "server/middleware/context";
 import { createCronContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
-import type { ScheduleService } from "server/service/schedule";
 
+import { queueDueTimers } from "./due-timers";
 import { processImminentChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
 import { processImminentEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
 import { processImminentRecurringWorkflows } from "./imminent-recurring-workflows";
@@ -19,8 +20,8 @@ import { republishStaleRuns } from "./republish-stale-runs";
 export interface InitCronsDeps {
 	repos: Repositories;
 	workflowRunPublisher?: WorkflowRunPublisher;
+	timerSortedSet?: TimerSortedSet;
 	childRunCanceller: ChildRunCanceller;
-	scheduleService: ScheduleService;
 }
 
 export interface CronHandle {
@@ -70,18 +71,6 @@ function initCron<Deps, Options>(
 
 export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 	const crons = [
-		...(deps.workflowRunPublisher
-			? [
-					initCron(logger, 1_000, publishReadyRuns, {
-						repos: deps.repos,
-						workflowRunPublisher: deps.workflowRunPublisher,
-					}),
-					initCron(logger, 1_000, republishStaleRuns, {
-						repos: deps.repos,
-						workflowRunPublisher: deps.workflowRunPublisher,
-					}),
-				]
-			: []),
 		initCron(logger, 1_000, processImminentScheduledRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
@@ -108,11 +97,36 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 		}),
 		initCron(logger, 1_000, processImminentRecurringWorkflows, {
 			repos: deps.repos,
-			scheduleService: deps.scheduleService,
 			childRunCanceller: deps.childRunCanceller,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
 	];
+
+	if (deps.timerSortedSet) {
+		crons.push(
+			initCron(logger, 50, queueDueTimers, {
+				repos: deps.repos,
+				timerSortedSet: deps.timerSortedSet,
+				childRunCanceller: deps.childRunCanceller,
+				workflowRunPublisher: deps.workflowRunPublisher,
+			})
+		);
+	}
+
+	if (deps.workflowRunPublisher) {
+		crons.push(
+			...[
+				initCron(logger, 1_000, publishReadyRuns, {
+					repos: deps.repos,
+					workflowRunPublisher: deps.workflowRunPublisher,
+				}),
+				initCron(logger, 1_000, republishStaleRuns, {
+					repos: deps.repos,
+					workflowRunPublisher: deps.workflowRunPublisher,
+				}),
+			]
+		);
+	}
 
 	return {
 		shutdown() {

--- a/server/crons/index.ts
+++ b/server/crons/index.ts
@@ -6,14 +6,14 @@ import { createCronContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
 import type { ScheduleService } from "server/service/schedule";
 
+import { processImminentChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
+import { processImminentEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
+import { processImminentRecurringWorkflows } from "./imminent-recurring-workflows";
+import { processImminentRetryableRuns } from "./imminent-retryable-runs";
+import { processImminentRetryableTaskRuns } from "./imminent-retryable-task-runs";
+import { processImminentScheduledRuns } from "./imminent-scheduled-runs";
+import { processImminentSleepElapsedRuns } from "./imminent-sleep-elapsed-runs";
 import { publishReadyRuns } from "./publish-ready-runs";
-import { queueChildRunWaitTimedOutWorkflowRuns } from "./queue-child-workflow-run-wait-timed-out-runs";
-import { queueEventWaitTimedOutWorkflowRuns } from "./queue-event-wait-timed-out-runs";
-import { queueRecurringWorkflows } from "./queue-recurring-workflows";
-import { queueRetryableWorkflowRuns } from "./queue-retryable-runs";
-import { queueWorkflowRunsWithRetryableTask } from "./queue-retryable-task-runs";
-import { queueScheduledWorkflowRuns } from "./queue-scheduled-runs";
-import { queueSleepElapsedWorkflowRuns } from "./queue-sleep-elapsed-runs";
 import { republishStaleRuns } from "./republish-stale-runs";
 
 export interface InitCronsDeps {
@@ -82,31 +82,31 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 					}),
 				]
 			: []),
-		initCron(logger, 1_000, queueScheduledWorkflowRuns, {
+		initCron(logger, 1_000, processImminentScheduledRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueSleepElapsedWorkflowRuns, {
+		initCron(logger, 1_000, processImminentSleepElapsedRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueRetryableWorkflowRuns, {
+		initCron(logger, 1_000, processImminentRetryableRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueWorkflowRunsWithRetryableTask, {
+		initCron(logger, 1_000, processImminentRetryableTaskRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueEventWaitTimedOutWorkflowRuns, {
+		initCron(logger, 1_000, processImminentEventWaitTimedOutRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueChildRunWaitTimedOutWorkflowRuns, {
+		initCron(logger, 1_000, processImminentChildRunWaitTimedOutRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 		}),
-		initCron(logger, 1_000, queueRecurringWorkflows, {
+		initCron(logger, 1_000, processImminentRecurringWorkflows, {
 			repos: deps.repos,
 			scheduleService: deps.scheduleService,
 			childRunCanceller: deps.childRunCanceller,

--- a/server/crons/index.ts
+++ b/server/crons/index.ts
@@ -74,31 +74,38 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 		initCron(logger, 1_000, processImminentScheduledRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentSleepElapsedRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentRetryableRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentRetryableTaskRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentEventWaitTimedOutRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentChildRunWaitTimedOutRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 		initCron(logger, 1_000, processImminentRecurringWorkflows, {
 			repos: deps.repos,
 			childRunCanceller: deps.childRunCanceller,
 			workflowRunPublisher: deps.workflowRunPublisher,
+			timerSortedSet: deps.timerSortedSet,
 		}),
 	];
 

--- a/server/crons/publish-ready-runs.ts
+++ b/server/crons/publish-ready-runs.ts
@@ -11,7 +11,7 @@ export interface PublishReadyRunsDeps {
 export async function publishReadyRuns(context: CronContext, deps: PublishReadyRunsDeps, options?: { limit?: number }) {
 	const { limit = 100 } = options ?? {};
 
-	const pendingEntries = await deps.repos.workflowRunOutbox.listPending(limit);
+	const pendingEntries = await deps.repos.workflowRunOutbox.listPending(context, limit);
 	if (!isNonEmptyArray(pendingEntries)) {
 		return;
 	}

--- a/server/crons/republish-stale-runs.ts
+++ b/server/crons/republish-stale-runs.ts
@@ -15,7 +15,7 @@ export async function republishStaleRuns(
 ) {
 	const { claimMinIdleTimeMs = 30_000, limit = 50 } = options ?? {};
 
-	const staleEntries = await deps.repos.workflowRunOutbox.listStalePublished(claimMinIdleTimeMs, limit);
+	const staleEntries = await deps.repos.workflowRunOutbox.listStalePublished(context, claimMinIdleTimeMs, limit);
 	const staleEntryIds = staleEntries.map((entry) => entry.id);
 	if (!isNonEmptyArray(staleEntryIds)) {
 		return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,8 @@ import { initCrons } from "./crons";
 import { UnauthorizedError } from "./errors";
 import { createDatabase } from "./infra/db";
 import { createLogger } from "./infra/logger";
-import { createWorkflowRunPublisher } from "./infra/messaging/redis-publisher";
+import { createWorkflowRunPublisher, type WorkflowRunPublisher } from "./infra/messaging/redis-publisher";
+import { createTimerSortedSet, type TimerSortedSet } from "./infra/messaging/redis-timer-sorted-set";
 import { createAuthorizer } from "./middleware/authorization";
 import {
 	createNamespaceRequestContext,
@@ -34,7 +35,8 @@ if (import.meta.main) {
 	const { repos, conn, betterAuthSchema } = createDatabase(config.database);
 
 	let redis: Redis | undefined;
-	let workflowRunPublisher: ReturnType<typeof createWorkflowRunPublisher> | undefined;
+	let timerSortedSet: TimerSortedSet | undefined;
+	let workflowRunPublisher: WorkflowRunPublisher | undefined;
 
 	if (config.redis) {
 		redis = new Redis({
@@ -45,6 +47,7 @@ if (import.meta.main) {
 		redis.on("error", (err: Error) => {
 			logger.error({ err }, "Redis connection error");
 		});
+		timerSortedSet = createTimerSortedSet(redis, "timers");
 		workflowRunPublisher = createWorkflowRunPublisher(redis);
 	}
 
@@ -83,8 +86,8 @@ if (import.meta.main) {
 	const crons = initCrons(logger, {
 		repos,
 		workflowRunPublisher,
+		timerSortedSet,
 		childRunCanceller,
-		scheduleService,
 	});
 
 	const organizationAuthedRouter = createOrganizationAuthedRouter(namespaceService);

--- a/server/infra/db/pg/repository/schedule.ts
+++ b/server/infra/db/pg/repository/schedule.ts
@@ -149,7 +149,7 @@ export function createScheduleRepository(db: PgDb) {
 				.where(and(eq(schedule.status, "active"), inArray(schedule.id, ids)));
 		},
 
-		async listDueSchedules(before: Date, limit = 100) {
+		async listDueSchedules(_context: CronContext, before: Date, limit = 100) {
 			return db
 				.select({
 					schedule: getTableColumns(schedule),

--- a/server/infra/db/pg/repository/schedule.ts
+++ b/server/infra/db/pg/repository/schedule.ts
@@ -1,6 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import { and, count, eq, getTableColumns, inArray, lte, sql } from "drizzle-orm";
+import type { CronContext } from "server/middleware/context";
 
 import type { PgDb } from "../provider";
 import { schedule, workflow } from "../schema";
@@ -135,6 +136,17 @@ export function createScheduleRepository(db: PgDb) {
 			]);
 
 			return { rows, total: countResult[0]?.count ?? 0 };
+		},
+
+		async listActiveByIds(_context: CronContext, ids: NonEmptyArray<string>) {
+			return db
+				.select({
+					schedule: getTableColumns(schedule),
+					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
+				})
+				.from(schedule)
+				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
+				.where(and(eq(schedule.status, "active"), inArray(schedule.id, ids)));
 		},
 
 		async listDueSchedules(before: Date, limit = 100) {

--- a/server/infra/db/pg/repository/task.ts
+++ b/server/infra/db/pg/repository/task.ts
@@ -1,5 +1,6 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { and, eq, inArray, lte, min } from "drizzle-orm";
+import type { CronContext } from "server/middleware/context";
 
 import type { PgDb } from "../provider";
 import { task } from "../schema";
@@ -34,15 +35,17 @@ export function createTaskRepository(db: PgDb) {
 			return db.select().from(task).where(eq(task.workflowRunId, workflowRunId)).orderBy(task.id).limit(10_000);
 		},
 
-		async listRetryableTaskWorkflowRunIds(limit = 100): Promise<string[]> {
-			const rows = await db
-				.select({ workflowRunId: task.workflowRunId })
+		async listRetryableTaskWorkflowRuns(_context: CronContext, before: Date, limit = 100) {
+			return db
+				.select({
+					workflowRunId: task.workflowRunId,
+					dueAt: min(task.nextAttemptAt),
+				})
 				.from(task)
-				.where(and(eq(task.status, "awaiting_retry"), lte(task.nextAttemptAt, new Date())))
+				.where(and(eq(task.status, "awaiting_retry"), lte(task.nextAttemptAt, before)))
 				.groupBy(task.workflowRunId)
 				.orderBy(min(task.nextAttemptAt))
 				.limit(limit);
-			return rows.map((row) => row.workflowRunId);
 		},
 
 		async deleteStaleByWorkflowRunIds(workflowRunIds: string | NonEmptyArray<string>): Promise<void> {

--- a/server/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/server/infra/db/pg/repository/workflow-run-outbox.ts
@@ -2,6 +2,7 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunId } from "@aikirun/types/workflow-run";
 import { and, eq, inArray, lt, sql } from "drizzle-orm";
+import type { CronContext } from "server/middleware/context";
 
 import type { PgDb } from "../provider";
 import { workflowRunOutbox } from "../schema";
@@ -15,7 +16,7 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			await db.insert(workflowRunOutbox).values(rows);
 		},
 
-		async listPending(limit = 100): Promise<WorkflowRunOutboxRow[]> {
+		async listPending(_context: CronContext, limit = 100): Promise<WorkflowRunOutboxRow[]> {
 			return db
 				.select()
 				.from(workflowRunOutbox)
@@ -38,7 +39,11 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 				.where(and(eq(workflowRunOutbox.status, "published"), inArray(workflowRunOutbox.id, ids)));
 		},
 
-		async listStalePublished(claimMinIdleTimeMs: number, limit: number): Promise<WorkflowRunOutboxRow[]> {
+		async listStalePublished(
+			_context: CronContext,
+			claimMinIdleTimeMs: number,
+			limit: number
+		): Promise<WorkflowRunOutboxRow[]> {
 			const now = Date.now();
 			const staleThreshold = new Date(now - claimMinIdleTimeMs);
 

--- a/server/infra/db/pg/repository/workflow-run.ts
+++ b/server/infra/db/pg/repository/workflow-run.ts
@@ -4,6 +4,7 @@ import type { TaskStatus } from "@aikirun/types/task";
 import type { WorkflowRunId, WorkflowRunState, WorkflowRunStatus } from "@aikirun/types/workflow-run";
 import { NON_TERMINAL_WORKFLOW_RUN_STATUSES } from "@aikirun/types/workflow-run";
 import { and, count, eq, inArray, lte, or, sql } from "drizzle-orm";
+import type { CronContext } from "server/middleware/context";
 
 import { toWorkflowRunState } from "./state-transition";
 import type { PgDb } from "../provider";
@@ -109,7 +110,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 			return row as Omit<typeof row, "state"> & { state: WorkflowRunState };
 		},
 
-		async listByIdsAndStatus(ids: NonEmptyArray<string>, status: WorkflowRunStatus) {
+		async listByIdsAndStatus(_context: CronContext, ids: NonEmptyArray<string>, status: WorkflowRunStatus) {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -287,7 +288,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.groupBy(workflowRun.status);
 		},
 
-		async listDueScheduleRuns(limit = 100): Promise<DueWorkflowRun[]> {
+		async listDueScheduleRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -304,7 +305,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.limit(limit);
 		},
 
-		async listSleepElapsedRuns(limit = 100): Promise<DueWorkflowRun[]> {
+		async listSleepElapsedRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -321,7 +322,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.limit(limit);
 		},
 
-		async listRetryableRuns(limit = 100): Promise<DueWorkflowRun[]> {
+		async listRetryableRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -338,7 +339,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.limit(limit);
 		},
 
-		async listEventWaitTimedOutRuns(limit = 100): Promise<DueWorkflowRun[]> {
+		async listEventWaitTimedOutRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -355,7 +356,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.limit(limit);
 		},
 
-		async listChildRunWaitTimedOutRuns(limit = 100): Promise<DueWorkflowRun[]> {
+		async listChildRunWaitTimedOutRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,

--- a/server/infra/db/pg/repository/workflow-run.ts
+++ b/server/infra/db/pg/repository/workflow-run.ts
@@ -19,10 +19,16 @@ type WorkflowRunRowUpdate = Partial<
 	>
 >;
 
-export type DueWorkflowRun = Pick<
-	WorkflowRunRow,
-	"id" | "namespaceId" | "workflowId" | "revision" | "attempts" | "options" | "latestStateTransitionId"
->;
+export interface DueWorkflowRun {
+	id: string;
+	namespaceId: string;
+	workflowId: string;
+	revision: number;
+	attempts: number;
+	options: unknown;
+	latestStateTransitionId: string;
+	dueAt?: Date | null;
+}
 
 export function createWorkflowRunRepository(db: PgDb) {
 	return {
@@ -288,7 +294,7 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.groupBy(workflowRun.status);
 		},
 
-		async listDueScheduleRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
+		async listDueScheduleRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -298,14 +304,15 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: workflowRun.scheduledAt,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "scheduled"), lte(workflowRun.scheduledAt, new Date())))
+				.where(and(eq(workflowRun.status, "scheduled"), lte(workflowRun.scheduledAt, before)))
 				.orderBy(workflowRun.scheduledAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listSleepElapsedRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
+		async listSleepElapsedRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -315,14 +322,15 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: workflowRun.awakeAt,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "sleeping"), lte(workflowRun.awakeAt, new Date())))
+				.where(and(eq(workflowRun.status, "sleeping"), lte(workflowRun.awakeAt, before)))
 				.orderBy(workflowRun.awakeAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listRetryableRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
+		async listRetryableRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -332,14 +340,15 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: workflowRun.nextAttemptAt,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_retry"), lte(workflowRun.nextAttemptAt, new Date())))
+				.where(and(eq(workflowRun.status, "awaiting_retry"), lte(workflowRun.nextAttemptAt, before)))
 				.orderBy(workflowRun.nextAttemptAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listEventWaitTimedOutRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
+		async listEventWaitTimedOutRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -349,14 +358,15 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: workflowRun.timeoutAt,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_event"), lte(workflowRun.timeoutAt, new Date())))
+				.where(and(eq(workflowRun.status, "awaiting_event"), lte(workflowRun.timeoutAt, before)))
 				.orderBy(workflowRun.timeoutAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listChildRunWaitTimedOutRuns(_context: CronContext, limit = 100): Promise<DueWorkflowRun[]> {
+		async listChildRunWaitTimedOutRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -366,9 +376,10 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					dueAt: workflowRun.timeoutAt,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_child_workflow"), lte(workflowRun.timeoutAt, new Date())))
+				.where(and(eq(workflowRun.status, "awaiting_child_workflow"), lte(workflowRun.timeoutAt, before)))
 				.orderBy(workflowRun.timeoutAt, workflowRun.id)
 				.limit(limit);
 		},

--- a/server/infra/messaging/redis-timer-sorted-set.ts
+++ b/server/infra/messaging/redis-timer-sorted-set.ts
@@ -1,0 +1,78 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { Redis } from "ioredis";
+
+const MAX_PRIORITY = 10;
+const DEFAULT_PRIORITY = 0;
+
+export type TimerType =
+	| "scheduled"
+	| "sleep"
+	| "retry"
+	| "task_retry"
+	| "event_wait_timeout"
+	| "child_wait_timeout"
+	| "recurring";
+
+export interface TimerEntry {
+	type: TimerType;
+	id: string;
+	dueAt: number;
+	priority?: number;
+}
+
+export interface DueTimer {
+	type: TimerType;
+	id: string;
+}
+
+function computeScore(timestampMs: number, priority: number = DEFAULT_PRIORITY): number {
+	return timestampMs * MAX_PRIORITY + priority;
+}
+
+function encodeMember(type: TimerType, id: string): string {
+	return `${type}:${id}`;
+}
+
+function decodeMember(member: string): DueTimer {
+	const colonIndex = member.indexOf(":");
+	return {
+		type: member.substring(0, colonIndex) as TimerType,
+		id: member.substring(colonIndex + 1),
+	};
+}
+
+const POP_DUE_TIMERS_SCRIPT = `
+local due = redis.call('ZRANGEBYSCORE', KEYS[1], 0, ARGV[1], 'LIMIT', 0, ARGV[2])
+if #due > 0 then
+  redis.call('ZREM', KEYS[1], unpack(due))
+end
+return due
+`;
+
+export function createTimerSortedSet(redis: Redis, key: string) {
+	return {
+		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
+			const args: (string | number)[] = [];
+			for (const timer of timers) {
+				const score = computeScore(timer.dueAt, timer.priority);
+				const member = encodeMember(timer.type, timer.id);
+				args.push(score, member);
+			}
+
+			await redis.zadd(key, ...args);
+		},
+
+		async popDue(now: number, limit: number): Promise<DueTimer[]> {
+			const maxScore = now * MAX_PRIORITY + (MAX_PRIORITY - 1);
+
+			const members = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxScore, limit)) as string[];
+			if (members.length === 0) {
+				return [];
+			}
+
+			return members.map(decodeMember);
+		},
+	};
+}
+
+export type TimerSortedSet = ReturnType<typeof createTimerSortedSet>;

--- a/server/service/schedule.ts
+++ b/server/service/schedule.ts
@@ -106,16 +106,6 @@ export interface ScheduleServiceDeps {
 export function createScheduleService(deps: ScheduleServiceDeps) {
 	const { repos } = deps;
 
-	async function getDueSchedules(now: number) {
-		const rows = await repos.schedule.listDueSchedules(new Date(now));
-		return rows.map(({ schedule, workflow }) => ({
-			...scheduleRowToDomain(schedule, workflow),
-			workflowId: schedule.workflowId,
-			namespaceId: schedule.namespaceId as NamespaceId,
-			workflowRunInputHash: schedule.workflowRunInputHash,
-		}));
-	}
-
 	async function updateSchedule(
 		namespaceId: NamespaceId,
 		id: string,
@@ -303,7 +293,6 @@ export function createScheduleService(deps: ScheduleServiceDeps) {
 	}
 
 	return {
-		getDueSchedules: getDueSchedules,
 		updateSchedule: updateSchedule,
 		activateSchedule: activateSchedule,
 		getScheduleById: getScheduleById,


### PR DESCRIPTION
## Summary
                                                                                                                       
  Builds on #8 which collapsed the scheduled state transition and added immediate publishing.                          
                                                                                                                       
  ### Problem                                                                                                          
                  
  Timer crons poll the database at a fixed interval to find due timers. This has two limitations:                      
                  
  **Timer precision is bounded by poll frequency.** Timers can only fire as fast as the cron interval. Reducing the    
  interval increases database load linearly — every cron instance scans the same tables on every tick, even when
  nothing is due.                                                                                                      
                  
  **All timers hit the database.** A timer due in 50ms and a timer due in 3 hours both live in the same tables, polled 
  at the same frequency. Near-term timers pay the same query cost as far-future timers.
                                                                                                                       
  ### Solution    

  This PR introduces a Redis sorted set as an intermediate tier between the database and the stream. The database      
  remains the durable source of truth. The sorted set stages near-term timers for high-frequency, low-cost detection.
  The stream continues to handle work distribution to workers.                                                         
                  
  **Imminent crons replace timer crons.** Each timer cron is refactored to look ahead by a configurable window         
  (`imminenceThresholdMs`, default 1s). Runs within the window are split into two paths:
  - **Due now** → fast path: transition to `queued`, create outbox entry, publish to stream immediately.               
  - **Due soon** → add to the Redis sorted set with a composite score encoding timestamp and priority.                 
                                                                                                                       
  **Sorted set consumer.** A new cron (`queueDueTimers`) polls the sorted set at 50ms, atomically pops due entries via 
  a Lua script, and dispatches to the same fast-path functions the imminent crons use.                                 
                                                                                                                       
  **Composite score.** `score = timestamp_ms * MAX_PRIORITY + priority` where `MAX_PRIORITY = 10` and priority 0 is    
  highest. Time always dominates — a lower-priority timer due at T always fires before a higher-priority timer due at
  T+1. Priority is hardcoded to 0 for now.                                                                             
                  
  **Far-future timers stay in the database.** Only timers within the promotion window occupy sorted set entries,       
  bounding Redis memory usage regardless of how many scheduled workflows exist.
                                                                                                                       
  ### Fault tolerance

  - If Redis goes down after ZADD, the imminent crons re-discover due timers on their next tick (~1s) and fast-path    
  them directly.
  - If the sorted set consumer crashes after popping entries, same recovery — the imminent crons see the runs still in 
  their original state.                                                                                                
  - If publishing fails after the DB transaction, outbox entries stay `pending` and `publishReadyRuns` catches them.
  - If the imminent cron and sorted set consumer race on the same run, revision-based optimistic locking ensures only  
  one succeeds.                                                                                                                                   