### PR TITLE
Event driven timers

### DIFF
--- a/server/crons/due-timers-consumer.ts
+++ b/server/crons/due-timers-consumer.ts
@@ -42,10 +42,9 @@ export function spawnDueTimersConsumer(
 	const abortController = new AbortController();
 	const { signal: abortSignal } = abortController;
 
-	const promise = dueTimersConsumerLoop(logger, deps, abortSignal, options);
-	promise.catch((error) => {
+	dueTimersConsumerLoop(logger, deps, abortSignal, options).catch((error) => {
 		if (!abortSignal.aborted) {
-			logger.error({ err: error }, "Due timers consumer crashed unexpectedly");
+			logger.error({ error }, "Due timers consumer crashed unexpectedly");
 		}
 	});
 
@@ -95,14 +94,14 @@ async function dueTimersConsumerLoop(
 		try {
 			let hasDueTimers = true;
 			while (hasDueTimers && !abortSignal.aborted) {
-				const dueTimers = await deps.timerSortedSet.popDue(limit);
+				const dueTimers = await deps.timerSortedSet.popDue(Date.now(), limit);
 				if (isNonEmptyArray(dueTimers)) {
 					await processDueTimers(context, deps, dueTimers);
 				}
 				hasDueTimers = dueTimers.length >= limit;
 			}
 		} catch (error) {
-			context.logger.error({ err: error }, "Failed to process due timers batch");
+			context.logger.error({ error }, "Failed to process due timers batch");
 		}
 
 		nextTimerDueAt = await deps.timerSortedSet.peek();

--- a/server/crons/due-timers-consumer.ts
+++ b/server/crons/due-timers-consumer.ts
@@ -1,10 +1,12 @@
-import { groupBy, isNonEmptyArray } from "@aikirun/lib/array";
+import { groupBy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStatus } from "@aikirun/types/workflow-run";
 import type { Repositories } from "server/infra/db/types";
+import type { Logger } from "server/infra/logger";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
 import type { TimerSortedSet, TimerType } from "server/infra/messaging/redis-timer-sorted-set";
 import type { CronContext } from "server/middleware/context";
+import { createCronContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
 import { scheduleRowToDomain } from "server/service/schedule";
 
@@ -16,21 +18,102 @@ import { queueRetryableTaskRuns } from "./imminent-retryable-task-runs";
 import { queueScheduledRuns } from "./imminent-scheduled-runs";
 import { queueSleepElapsedRuns } from "./imminent-sleep-elapsed-runs";
 
-export interface QueueDueTimersDeps {
+export interface DueTimersConsumerDeps {
 	repos: Repositories;
 	timerSortedSet: TimerSortedSet;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunPublisher?: WorkflowRunPublisher;
 }
 
-export async function queueDueTimers(context: CronContext, deps: QueueDueTimersDeps, options?: { limit?: number }) {
-	const { limit = 100 } = options ?? {};
+export interface DueTimersConsumerOptions {
+	limit?: number;
+	overshootMs?: number;
+}
 
-	const dueTimers = await deps.timerSortedSet.popDue(Date.now(), limit);
-	if (dueTimers.length === 0) {
-		return;
+export interface DueTimersConsumerHandle {
+	stop(): void;
+}
+
+export function spawnDueTimersConsumer(
+	logger: Logger,
+	deps: DueTimersConsumerDeps,
+	options?: DueTimersConsumerOptions
+): DueTimersConsumerHandle {
+	const abortController = new AbortController();
+	const { signal: abortSignal } = abortController;
+
+	const promise = dueTimersConsumerLoop(logger, deps, abortSignal, options);
+	promise.catch((error) => {
+		if (!abortSignal.aborted) {
+			logger.error({ err: error }, "Due timers consumer crashed unexpectedly");
+		}
+	});
+
+	return {
+		stop() {
+			abortController.abort();
+		},
+	};
+}
+
+async function dueTimersConsumerLoop(
+	logger: Logger,
+	deps: DueTimersConsumerDeps,
+	abortSignal: AbortSignal,
+	options?: DueTimersConsumerOptions
+): Promise<void> {
+	const { limit = 100, overshootMs = 30 } = options ?? {};
+
+	// Peek on startup to discover any entries left over from a previous consumer's lifecycle.
+	let nextTimerDueAt = await deps.timerSortedSet.peek();
+
+	while (!abortSignal.aborted) {
+		let signal = 0;
+
+		if (nextTimerDueAt === null) {
+			signal = await deps.timerSortedSet.waitForSignal(0);
+		} else {
+			const waitMs = nextTimerDueAt - Date.now() + overshootMs;
+			if (waitMs > 0) {
+				signal = await deps.timerSortedSet.waitForSignal(waitMs / 1000);
+			}
+		}
+
+		if (abortSignal.aborted) {
+			break;
+		}
+
+		if (signal > Date.now()) {
+			if (nextTimerDueAt === null || signal < nextTimerDueAt) {
+				nextTimerDueAt = signal;
+			}
+			continue;
+		}
+
+		const context = createCronContext({ name: "dueTimersConsumer", logger, signal: abortSignal });
+
+		try {
+			let hasDueTimers = true;
+			while (hasDueTimers && !abortSignal.aborted) {
+				const dueTimers = await deps.timerSortedSet.popDue(limit);
+				if (isNonEmptyArray(dueTimers)) {
+					await processDueTimers(context, deps, dueTimers);
+				}
+				hasDueTimers = dueTimers.length >= limit;
+			}
+		} catch (error) {
+			context.logger.error({ err: error }, "Failed to process due timers batch");
+		}
+
+		nextTimerDueAt = await deps.timerSortedSet.peek();
 	}
+}
 
+async function processDueTimers(
+	context: CronContext,
+	deps: DueTimersConsumerDeps,
+	dueTimers: NonEmptyArray<{ type: TimerType; id: string }>
+): Promise<void> {
 	const timersByType = groupBy(dueTimers, (timer) => [timer.type, timer.id]);
 
 	const promises: Promise<void>[] = [];

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -10,7 +10,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -33,7 +33,7 @@ export async function processImminentChildRunWaitTimedOutRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentChildRunWaitTimedOutRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const runs = await repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, limit);
@@ -54,7 +54,7 @@ export async function processImminentChildRunWaitTimedOutRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-		const timers: Array<{ type: "child_wait_timeout"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const run of runsDueSoon) {
 			if (!run.dueAt) {
 				context.logger.warn({ runId: run.id }, "Missing dueAt for child-run-wait-timed-out run, skipping promotion");

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -10,7 +10,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -33,7 +33,7 @@ export async function processImminentEventWaitTimedOutRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentEventWaitTimedOutRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const runs = await repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, limit);
@@ -54,7 +54,7 @@ export async function processImminentEventWaitTimedOutRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-		const timers: Array<{ type: "event_wait_timeout"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const run of runsDueSoon) {
 			if (!run.dueAt) {
 				context.logger.warn({ runId: run.id }, "Missing dueAt for event-wait-timed-out run, skipping promotion");

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -16,7 +16,7 @@ import type {
 	WorkflowRunRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import type { CancelledParentRun, ChildRunCanceller } from "server/service/cancel-child-runs";
@@ -43,7 +43,7 @@ export async function processImminentRecurringWorkflows(
 	deps: ProcessImminentRecurringWorkflowsDeps,
 	options?: { imminenceThresholdMs?: number; chunkSize?: number }
 ) {
-	const { imminenceThresholdMs = 1_000, chunkSize = 50 } = options ?? {};
+	const { imminenceThresholdMs = 2_000, chunkSize = 50 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const rows = await deps.repos.schedule.listDueSchedules(context, dueBefore);
@@ -71,7 +71,7 @@ export async function processImminentRecurringWorkflows(
 
 	const { timerSortedSet } = deps;
 	if (timerSortedSet && isNonEmptyArray(schedulesDueSoon)) {
-		const timers: Array<{ type: "recurring"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const schedule of schedulesDueSoon) {
 			timers.push({
 				type: "recurring",

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -9,7 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -32,7 +32,7 @@ export async function processImminentRetryableRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentRetryableRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const runs = await repos.workflowRun.listRetryableRuns(context, dueBefore, limit);
@@ -53,7 +53,7 @@ export async function processImminentRetryableRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-		const timers: Array<{ type: "retry"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const run of runsDueSoon) {
 			if (!run.dueAt) {
 				context.logger.warn({ runId: run.id }, "Missing dueAt for retryable run, skipping promotion");

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -9,7 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -32,7 +32,7 @@ export async function processImminentRetryableTaskRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentRetryableTaskRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const retryableTasks = await repos.task.listRetryableTaskWorkflowRuns(context, dueBefore, limit);
@@ -59,7 +59,7 @@ export async function processImminentRetryableTaskRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(tasksDueSoon)) {
-		const timers: Array<{ type: "task_retry"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const task of tasksDueSoon) {
 			if (!task.dueAt) {
 				context.logger.warn(
@@ -71,7 +71,7 @@ export async function processImminentRetryableTaskRuns(
 			timers.push({
 				type: "task_retry",
 				id: task.workflowRunId,
-				dueAt: new Date(task.dueAt).getTime(),
+				dueAt: task.dueAt.getTime(),
 			});
 		}
 		await runConcurrently(context, chunkLazy(timers, chunkSize), async (chunk) => {

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -9,7 +9,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -29,7 +29,7 @@ export async function processImminentScheduledRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentScheduledRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const runs = await repos.workflowRun.listDueScheduleRuns(context, dueBefore, limit);
@@ -50,7 +50,7 @@ export async function processImminentScheduledRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-		const timers: Array<{ type: "scheduled"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const run of runsDueSoon) {
 			if (!run.dueAt) {
 				context.logger.warn({ runId: run.id }, "Missing dueAt for scheduled run, skipping promotion");

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -8,7 +8,7 @@ import type {
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerEntry, TimerSortedSet } from "server/infra/messaging/redis-timer-sorted-set";
 import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
@@ -31,7 +31,7 @@ export async function processImminentSleepElapsedRuns(
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentSleepElapsedRunsDeps,
 	options?: { limit?: number; chunkSize?: number; imminenceThresholdMs?: number }
 ) {
-	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 1_000 } = options ?? {};
+	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
 	const runs = await repos.workflowRun.listSleepElapsedRuns(context, dueBefore, limit);
@@ -52,7 +52,7 @@ export async function processImminentSleepElapsedRuns(
 	}
 
 	if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-		const timers: Array<{ type: "sleep"; id: string; dueAt: number }> = [];
+		const timers: TimerEntry[] = [];
 		for (const run of runsDueSoon) {
 			if (!run.dueAt) {
 				context.logger.warn({ runId: run.id }, "Missing dueAt for sleep-elapsed run, skipping promotion");

--- a/server/crons/index.ts
+++ b/server/crons/index.ts
@@ -6,7 +6,7 @@ import type { CronContext } from "server/middleware/context";
 import { createCronContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
 
-import { queueDueTimers } from "./due-timers";
+import { type DueTimersConsumerHandle, spawnDueTimersConsumer } from "./due-timers-consumer";
 import { processImminentChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
 import { processImminentEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
 import { processImminentRecurringWorkflows } from "./imminent-recurring-workflows";
@@ -109,29 +109,26 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 		}),
 	];
 
+	let dueTimersConsumer: DueTimersConsumerHandle | undefined;
 	if (deps.timerSortedSet) {
-		crons.push(
-			initCron(logger, 50, queueDueTimers, {
-				repos: deps.repos,
-				timerSortedSet: deps.timerSortedSet,
-				childRunCanceller: deps.childRunCanceller,
-				workflowRunPublisher: deps.workflowRunPublisher,
-			})
-		);
+		dueTimersConsumer = spawnDueTimersConsumer(logger, {
+			repos: deps.repos,
+			timerSortedSet: deps.timerSortedSet,
+			childRunCanceller: deps.childRunCanceller,
+			workflowRunPublisher: deps.workflowRunPublisher,
+		});
 	}
 
 	if (deps.workflowRunPublisher) {
 		crons.push(
-			...[
-				initCron(logger, 1_000, publishReadyRuns, {
-					repos: deps.repos,
-					workflowRunPublisher: deps.workflowRunPublisher,
-				}),
-				initCron(logger, 1_000, republishStaleRuns, {
-					repos: deps.repos,
-					workflowRunPublisher: deps.workflowRunPublisher,
-				}),
-			]
+			initCron(logger, 1_000, publishReadyRuns, {
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+			}),
+			initCron(logger, 1_000, republishStaleRuns, {
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+			})
 		);
 	}
 
@@ -141,6 +138,7 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 				abortController.abort();
 				clearInterval(interval);
 			}
+			dueTimersConsumer?.stop();
 		},
 	};
 }

--- a/server/infra/messaging/redis-timer-sorted-set.ts
+++ b/server/infra/messaging/redis-timer-sorted-set.ts
@@ -102,8 +102,8 @@ export function createTimerSortedSet(redis: Redis, key: string) {
 			await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minDueAt, ...args);
 		},
 
-		async popDue(limit: number): Promise<DueTimer[]> {
-			const maxScore = Date.now() * PRIORITY_LEVELS + (PRIORITY_LEVELS - 1);
+		async popDue(before: number, limit: number): Promise<DueTimer[]> {
+			const maxScore = before * PRIORITY_LEVELS + (PRIORITY_LEVELS - 1);
 
 			const members = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxScore, limit)) as string[];
 			if (members.length === 0) {

--- a/server/infra/messaging/redis-timer-sorted-set.ts
+++ b/server/infra/messaging/redis-timer-sorted-set.ts
@@ -1,8 +1,8 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import type { Redis } from "ioredis";
 
-const MAX_PRIORITY = 10;
-const DEFAULT_PRIORITY = 0;
+const PRIORITY_LEVELS = 10;
+const DEFAULT_PRIORITY = PRIORITY_LEVELS - 1;
 
 export type TimerType =
 	| "scheduled"
@@ -26,7 +26,7 @@ export interface DueTimer {
 }
 
 function computeScore(timestampMs: number, priority: number = DEFAULT_PRIORITY): number {
-	return timestampMs * MAX_PRIORITY + priority;
+	return timestampMs * PRIORITY_LEVELS + priority;
 }
 
 function encodeMember(type: TimerType, id: string): string {
@@ -41,6 +41,23 @@ function decodeMember(member: string): DueTimer {
 	};
 }
 
+/**
+ * Atomically adds entries to the sorted set and pushes a signal carrying the
+ * minimum dueAt timestamp of the batch. ARGV[1] is the minDueAt; subsequent
+ * pairs are score/member.
+ */
+const ADD_AND_SIGNAL_SCRIPT = `
+local minDueAt = ARGV[1]
+for i = 2, #ARGV - 1, 2 do
+  redis.call('ZADD', KEYS[1], ARGV[i], ARGV[i + 1])
+end
+redis.call('LPUSH', KEYS[2], minDueAt)
+return 1
+`;
+
+/**
+ * Atomically pops all entries with scores <= the given max score.
+ */
 const POP_DUE_TIMERS_SCRIPT = `
 local due = redis.call('ZRANGEBYSCORE', KEYS[1], 0, ARGV[1], 'LIMIT', 0, ARGV[2])
 if #due > 0 then
@@ -49,21 +66,44 @@ end
 return due
 `;
 
+/**
+ * Atomically reads all signals from the list, deletes the list, and returns the
+ * minimum signal value. Returns nil if the list was empty.
+ */
+const DRAIN_SIGNALS_SCRIPT = `
+local values = redis.call('LRANGE', KEYS[1], 0, -1)
+redis.call('DEL', KEYS[1])
+local minSignal
+for _, value in ipairs(values) do
+  local n = tonumber(value)
+  if not minSignal or n < minSignal then
+    minSignal = n
+  end
+end
+return minSignal
+`;
+
 export function createTimerSortedSet(redis: Redis, key: string) {
+	const signalKey = `${key}:signal`;
+
 	return {
 		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
+			let minDueAt = timers[0].dueAt;
 			const args: (string | number)[] = [];
 			for (const timer of timers) {
+				if (timer.dueAt < minDueAt) {
+					minDueAt = timer.dueAt;
+				}
 				const score = computeScore(timer.dueAt, timer.priority);
 				const member = encodeMember(timer.type, timer.id);
 				args.push(score, member);
 			}
 
-			await redis.zadd(key, ...args);
+			await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minDueAt, ...args);
 		},
 
-		async popDue(now: number, limit: number): Promise<DueTimer[]> {
-			const maxScore = now * MAX_PRIORITY + (MAX_PRIORITY - 1);
+		async popDue(limit: number): Promise<DueTimer[]> {
+			const maxScore = Date.now() * PRIORITY_LEVELS + (PRIORITY_LEVELS - 1);
 
 			const members = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxScore, limit)) as string[];
 			if (members.length === 0) {
@@ -71,6 +111,36 @@ export function createTimerSortedSet(redis: Redis, key: string) {
 			}
 
 			return members.map(decodeMember);
+		},
+
+		async peek(): Promise<number | null> {
+			const result = await redis.zrangebyscore(key, "-inf", "+inf", "WITHSCORES", "LIMIT", 0, 1);
+			if (result.length < 2) {
+				return null;
+			}
+			const score = Number(result[1]);
+			return Math.floor(score / PRIORITY_LEVELS);
+		},
+
+		/**
+		 * Blocks on the signal list, then drains any remaining signals.
+		 * Returns the minimum signal observed (combining BRPOP value with drained values).
+		 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
+		 * peek-after-pop will rediscover them.
+		 */
+		async waitForSignal(timeoutSeconds: number): Promise<number> {
+			const result = await redis.brpop(signalKey, timeoutSeconds);
+			if (result === null) {
+				await redis.del(signalKey);
+				return 0;
+			}
+
+			const signal = Number(result[1]);
+			const minSignal = (await redis.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
+			if (minSignal === null) {
+				return signal;
+			}
+			return Math.min(signal, minSignal);
 		},
 	};
 }


### PR DESCRIPTION
### Problem

Builds on PR #9 

In #9, DB load and timer latency were reduced with the introduction of Redis sorted sets that store imminent timers. But the sorted set is still polled, therefore generating a lot of pointless traffic when the system is idle i.e no due timers. Futhermore, the timer precision is bound by the poll interval (50ms). 

### Solution

The timers consumer now blocks on a Redis list (the signal list) instead of polling the sorted set. The signal carries the minimum `dueAt` of each promoted batch — a hint that wakes the consumer on demand.

**Atomic add + signal.** Producers (the imminent crons) atomically `ZADD` to the sorted set and `LPUSH` the minimum `dueAt` of the batch via a Lua script. There is no window where an entry exists without a corresponding signal.

**Block + drain + pop + peek.** The consumer loop: 
  1. `BRPOP` the signal list with a timeout calculated from the next-due entry (or 0 to block indefinitely if the sorted set is empty)
  2. Drain accumulated signals via an atomic `LRANGE` + `DEL` Lua script, taking the minimum signal across BRPOP value and drained values 
  3. If the resulting signal is in the future (a new entry was added but not yet due), update `nextTimerDueAt` and loop back
  4. Otherwise (timeout, past signal, or skipped wait), pop all due entries from the sorted set and process them                                                                                            
  5. Peek the sorted set to compute the next wait

  **Configurable overshoot.** Default 30ms. Entries due within the overshoot window batch together in a single sweep instead of triggering one wake cycle each.

  **0 as timeout sentinel.** `waitForSignal` returns 0 on BRPOP timeout. The consumer's check `signal > Date.now()` naturally handles all cases without explicit null checks: timeout (0), past signal (≤ now), and future signal (> now, optimization path). 

  **Startup peek.** The consumer peeks the sorted set on startup to discover any entries stranded from a previous consumer's lifecycle (e.g., after a deployment), avoiding indefinite block when the signal list is empty but the sorted set is not. 

  ### Result
  - **Idle cost: zero.** Consumers blocked on BRPOP consume only a connection. Redis command volume scales with actual timer activity, not consumer count. 1 BRPOP per wake, plus a drain script
  - **Precision: ~30ms (tunable).** Independent of Redis load. Reducing the overshoot improves precision at no idle cost. 
  - **Safety net unchanged.** The DB Promoter (imminent crons) recovers from any signal loss within ~1s by fast-pathing overdue entries directly.