### PR TITLE
Cleanly break timer consumer loop on abort signal

### DIFF
--- a/server/crons/due-timers-consumer.ts
+++ b/server/crons/due-timers-consumer.ts
@@ -1,10 +1,11 @@
 import { groupBy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
+import { withRetry } from "@aikirun/lib/retry";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStatus } from "@aikirun/types/workflow-run";
 import type { Repositories } from "server/infra/db/types";
 import type { Logger } from "server/infra/logger";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
-import type { TimerSortedSet, TimerType } from "server/infra/messaging/redis-timer-sorted-set";
+import type { TimerSignalWaiter, TimerSortedSet, TimerType } from "server/infra/messaging/redis-timer-sorted-set";
 import type { CronContext } from "server/middleware/context";
 import { createCronContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
@@ -31,7 +32,7 @@ export interface DueTimersConsumerOptions {
 }
 
 export interface DueTimersConsumerHandle {
-	stop(): void;
+	stop(): Promise<void>;
 }
 
 export function spawnDueTimersConsumer(
@@ -42,15 +43,32 @@ export function spawnDueTimersConsumer(
 	const abortController = new AbortController();
 	const { signal: abortSignal } = abortController;
 
-	dueTimersConsumerLoop(logger, deps, abortSignal, options).catch((error) => {
-		if (!abortSignal.aborted) {
-			logger.error({ error }, "Due timers consumer crashed unexpectedly");
-		}
-	});
+	let timerSignalWaiter: TimerSignalWaiter | undefined;
+
+	withRetry(
+		async () => {
+			timerSignalWaiter = deps.timerSortedSet.createSignalWaiter();
+			try {
+				await dueTimersConsumerLoop(logger, deps, timerSignalWaiter, abortSignal, options);
+			} finally {
+				await timerSignalWaiter.close();
+				timerSignalWaiter = undefined;
+			}
+		},
+		{ type: "jittered", maxAttempts: Number.POSITIVE_INFINITY, baseDelayMs: 1_000, maxDelayMs: 30_000 },
+		{ abortSignal }
+	)
+		.run()
+		.catch((error) => {
+			if (!abortSignal.aborted) {
+				logger.error({ error }, "Due timers consumer crashed unexpectedly");
+			}
+		});
 
 	return {
-		stop() {
+		async stop() {
 			abortController.abort();
+			await timerSignalWaiter?.close();
 		},
 	};
 }
@@ -58,6 +76,7 @@ export function spawnDueTimersConsumer(
 async function dueTimersConsumerLoop(
 	logger: Logger,
 	deps: DueTimersConsumerDeps,
+	timerSignalWaiter: TimerSignalWaiter,
 	abortSignal: AbortSignal,
 	options?: DueTimersConsumerOptions
 ): Promise<void> {
@@ -70,11 +89,11 @@ async function dueTimersConsumerLoop(
 		let signal = 0;
 
 		if (nextTimerDueAt === null) {
-			signal = await deps.timerSortedSet.waitForSignal(0);
+			signal = await timerSignalWaiter.wait(0);
 		} else {
 			const waitMs = nextTimerDueAt - Date.now() + overshootMs;
 			if (waitMs > 0) {
-				signal = await deps.timerSortedSet.waitForSignal(waitMs / 1000);
+				signal = await timerSignalWaiter.wait(waitMs / 1000);
 			}
 		}
 
@@ -91,17 +110,17 @@ async function dueTimersConsumerLoop(
 
 		const context = createCronContext({ name: "dueTimersConsumer", logger, signal: abortSignal });
 
-		try {
-			let hasDueTimers = true;
-			while (hasDueTimers && !abortSignal.aborted) {
-				const dueTimers = await deps.timerSortedSet.popDue(Date.now(), limit);
-				if (isNonEmptyArray(dueTimers)) {
+		let hasDueTimers = true;
+		while (hasDueTimers && !abortSignal.aborted) {
+			const dueTimers = await deps.timerSortedSet.popDue(Date.now(), limit);
+			if (isNonEmptyArray(dueTimers)) {
+				try {
 					await processDueTimers(context, deps, dueTimers);
+				} catch (error) {
+					context.logger.error({ error }, "Failed to process due timers batch");
 				}
-				hasDueTimers = dueTimers.length >= limit;
 			}
-		} catch (error) {
-			context.logger.error({ error }, "Failed to process due timers batch");
+			hasDueTimers = dueTimers.length >= limit;
 		}
 
 		nextTimerDueAt = await deps.timerSortedSet.peek();

--- a/server/crons/index.ts
+++ b/server/crons/index.ts
@@ -25,7 +25,7 @@ export interface InitCronsDeps {
 }
 
 export interface CronHandle {
-	shutdown(): void;
+	shutdown(): Promise<void>;
 }
 
 function initCron<Deps, Options>(
@@ -133,12 +133,12 @@ export function initCrons(logger: Logger, deps: InitCronsDeps): CronHandle {
 	}
 
 	return {
-		shutdown() {
+		async shutdown() {
 			for (const { abortController, interval } of crons) {
 				abortController.abort();
 				clearInterval(interval);
 			}
-			dueTimersConsumer?.stop();
+			await dueTimersConsumer?.stop();
 		},
 	};
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -181,7 +181,7 @@ if (import.meta.main) {
 	});
 
 	const shutdown = async () => {
-		crons.shutdown();
+		await crons.shutdown();
 		if (redis) {
 			await redis.quit();
 		}

--- a/server/infra/messaging/redis-timer-sorted-set.ts
+++ b/server/infra/messaging/redis-timer-sorted-set.ts
@@ -25,6 +25,11 @@ export interface DueTimer {
 	id: string;
 }
 
+export interface TimerSignalWaiter {
+	wait(timeoutSeconds: number): Promise<number>;
+	close(): Promise<void>;
+}
+
 function computeScore(timestampMs: number, priority: number = DEFAULT_PRIORITY): number {
 	return timestampMs * PRIORITY_LEVELS + priority;
 }
@@ -122,25 +127,40 @@ export function createTimerSortedSet(redis: Redis, key: string) {
 			return Math.floor(score / PRIORITY_LEVELS);
 		},
 
-		/**
-		 * Blocks on the signal list, then drains any remaining signals.
-		 * Returns the minimum signal observed (combining BRPOP value with drained values).
-		 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
-		 * peek-after-pop will rediscover them.
-		 */
-		async waitForSignal(timeoutSeconds: number): Promise<number> {
-			const result = await redis.brpop(signalKey, timeoutSeconds);
-			if (result === null) {
-				await redis.del(signalKey);
-				return 0;
-			}
+		createSignalWaiter(): TimerSignalWaiter {
+			const redisDuplicate = redis.duplicate();
+			let closed = false;
 
-			const signal = Number(result[1]);
-			const minSignal = (await redis.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
-			if (minSignal === null) {
-				return signal;
-			}
-			return Math.min(signal, minSignal);
+			return {
+				/**
+				 * Blocks on the signal list, then drains any remaining signals.
+				 * Returns the minimum signal observed (combining BRPOP value with drained values).
+				 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
+				 * peek-after-pop will rediscover them.
+				 */
+				async wait(timeoutSeconds: number): Promise<number> {
+					const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
+					if (result === null) {
+						await redis.del(signalKey);
+						return 0;
+					}
+
+					const signal = Number(result[1]);
+					const minSignal = (await redis.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
+					if (minSignal === null) {
+						return signal;
+					}
+					return Math.min(signal, minSignal);
+				},
+
+				async close(): Promise<void> {
+					if (closed) {
+						return;
+					}
+					closed = true;
+					redisDuplicate.disconnect();
+				},
+			};
 		},
 	};
 }


### PR DESCRIPTION
There were a couple of issues with dueTimerConsumerLoop:
* the signal waiter re-uses the same redis connection as other operations. It gets worse if multiple consumer loops are spawned, each will block on the same connection.
* on shutdown, the abort signal is set, but since the loop is likely blocked on the signal list, it doesn't see the abortion. If we attempt to close the redis connection to unblock the loop, other loops/operations that share the connection will be broken also
* any failure caused the loop to break, even if it was a transient failure

These have been fixed.

Each consumer loop now gets their own separate redis connection upon which they can block for signal. On shutdown, the connection is closed, which unblocks the signal waiter, and lets it see the abort signal.

Finally, the entire consumer loop has been wrapped in a retry with backoff to catch network failures, so that connections can be re-established on failures