### PR TITLE
Fix cursor-less cron streaming

### DIFF
--- a/lib/array/utils.ts
+++ b/lib/array/utils.ts
@@ -31,7 +31,7 @@ export function* chunkLazy<T>(items: T[], size: number): Generator<NonEmptyArray
 	}
 }
 
-export const splitArray = <Item, WhenTrue = Item, WhenFalse = Item>(
+export const partitionArray = <Item, WhenTrue = Item, WhenFalse = Item>(
 	items: Item[],
 	condition: (item: Item) => { meetsCondition: true; item: WhenTrue } | { meetsCondition: false; item: WhenFalse }
 ): { whenTrue: WhenTrue[]; whenFalse: WhenFalse[] } => {

--- a/lib/async/stream.ts
+++ b/lib/async/stream.ts
@@ -1,16 +1,57 @@
+import type { OptionalProp } from "@aikirun/types/property";
+
 import { isNonEmptyArray, type NonEmptyArray } from "../array";
 
-export async function* streamChunks<T>(
-	next: () => T[] | Promise<T[]>,
-	until?: (chunk: NonEmptyArray<T>) => boolean
-): AsyncGenerator<NonEmptyArray<T>> {
+export interface StreamChunksOptions<Item, Cursor> {
+	advanceCursor?: (current: Cursor | undefined, item: Item) => Cursor;
+	until?: (chunk: NonEmptyArray<Item>) => boolean;
+}
+
+export interface StreamChunkPartitionsOptions<Item, Cursor> extends StreamChunksOptions<Item, Cursor> {
+	partition: (item: Item) => boolean;
+}
+
+export function streamChunks<Item, Cursor>(
+	next: (cursor?: Cursor) => Item[] | Promise<Item[]>,
+	options: StreamChunksOptions<Item, Cursor>
+): AsyncGenerator<NonEmptyArray<Item>>;
+export function streamChunks<Item, Cursor>(
+	next: (cursor?: Cursor) => Item[] | Promise<Item[]>,
+	options: StreamChunkPartitionsOptions<Item, Cursor>
+): AsyncGenerator<{ whenTrue: Item[]; whenFalse: Item[] }>;
+export async function* streamChunks<Item, Cursor>(
+	next: (cursor?: Cursor) => Item[] | Promise<Item[]>,
+	options: OptionalProp<StreamChunkPartitionsOptions<Item, Cursor>, "partition">
+): AsyncGenerator<NonEmptyArray<Item> | { whenTrue: Item[]; whenFalse: Item[] }> {
+	let cursor: Cursor | undefined;
+	const { advanceCursor, until, partition } = options;
+
 	while (true) {
-		const response = next();
+		const response = next(cursor);
 		const chunk = response instanceof Promise ? await response : response;
 		if (!isNonEmptyArray(chunk)) {
 			return;
 		}
-		yield chunk;
+
+		if (partition) {
+			const whenTrue: Item[] = [];
+			const whenFalse: Item[] = [];
+			for (const item of chunk) {
+				if (advanceCursor) {
+					cursor = advanceCursor(cursor, item);
+				}
+				(partition(item) ? whenTrue : whenFalse).push(item);
+			}
+			yield { whenTrue, whenFalse };
+		} else {
+			if (advanceCursor) {
+				for (const item of chunk) {
+					cursor = advanceCursor(cursor, item);
+				}
+			}
+			yield chunk;
+		}
+
 		if (until?.(chunk)) {
 			return;
 		}

--- a/server/crons/due-timers-consumer.ts
+++ b/server/crons/due-timers-consumer.ts
@@ -106,7 +106,7 @@ async function dueTimersConsumerLoop(
 
 		const next = () => deps.timerSortedSet.popDue(Date.now(), limit);
 
-		for await (const dueTimers of streamChunks(next, (chunk) => chunk.length < limit)) {
+		for await (const dueTimers of streamChunks(next, { until: (chunk) => chunk.length < limit })) {
 			try {
 				await processDueTimers(context, deps, dueTimers);
 			} catch (error) {

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -41,7 +41,7 @@ export async function processImminentChildRunWaitTimedOutRuns(
 
 	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
 			if (run.dueAt && run.dueAt.getTime() > now) {
 				return { meetsCondition: false, item: run };
 			}

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -1,6 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
-import { streamChunks } from "@aikirun/lib/async";
+import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -16,6 +15,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { streamTimers } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<
@@ -37,34 +37,21 @@ export async function processImminentChildRunWaitTimedOutRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, limit);
 
-	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
-			if (run.dueAt && run.dueAt.getTime() > now) {
-				return { meetsCondition: false, item: run };
-			}
-			return { meetsCondition: true, item: run };
-		});
-
+	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
+		(cursor) => repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, limit, cursor),
+		(chunk) => chunk.length < limit
+	)) {
 		if (isNonEmptyArray(runsDueNow)) {
 			await queueChildRunWaitTimedOutRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
 		}
 
 		if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const run of runsDueSoon) {
-				if (!run.dueAt) {
-					context.logger.warn({ runId: run.id }, "Missing dueAt for child-run-wait-timed-out run, skipping promotion");
-					continue;
-				}
-				timers.push({
-					type: "child_wait_timeout",
-					id: run.id,
-					dueAt: run.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
+				type: "child_wait_timeout",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/crons/imminent-child-run-wait-timed-out-runs.ts
@@ -2,9 +2,9 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
 	ChildWorkflowRunWaitQueueRowInsert,
-	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -76,7 +76,7 @@ export async function queueChildRunWaitTimedOutRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -113,7 +113,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -41,7 +41,7 @@ export async function processImminentEventWaitTimedOutRuns(
 
 	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
 			if (run.dueAt && run.dueAt.getTime() > now) {
 				return { meetsCondition: false, item: run };
 			}

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -1,6 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
-import { streamChunks } from "@aikirun/lib/async";
+import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -16,6 +15,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { streamTimers } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<
@@ -37,34 +37,21 @@ export async function processImminentEventWaitTimedOutRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, limit);
 
-	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
-			if (run.dueAt && run.dueAt.getTime() > now) {
-				return { meetsCondition: false, item: run };
-			}
-			return { meetsCondition: true, item: run };
-		});
-
+	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
+		(cursor) => repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, limit, cursor),
+		(chunk) => chunk.length < limit
+	)) {
 		if (isNonEmptyArray(runsDueNow)) {
 			await queueEventWaitTimedOutRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
 		}
 
 		if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const run of runsDueSoon) {
-				if (!run.dueAt) {
-					context.logger.warn({ runId: run.id }, "Missing dueAt for event-wait-timed-out run, skipping promotion");
-					continue;
-				}
-				timers.push({
-					type: "event_wait_timeout",
-					id: run.id,
-					dueAt: run.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
+				type: "event_wait_timeout",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/imminent-event-wait-timed-out-runs.ts
+++ b/server/crons/imminent-event-wait-timed-out-runs.ts
@@ -2,8 +2,8 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
-	DueWorkflowRun,
 	EventWaitQueueRowInsert,
 	Repositories,
 	StateTransitionRowInsert,
@@ -76,7 +76,7 @@ export async function queueEventWaitTimedOutRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -113,7 +113,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { Schedule, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
@@ -57,7 +57,7 @@ export async function processImminentRecurringWorkflows(
 		}));
 
 		const now = Date.now();
-		const { whenTrue: schedulesDueNow, whenFalse: schedulesDueSoon } = splitArray(schedules, (schedule) => {
+		const { whenTrue: schedulesDueNow, whenFalse: schedulesDueSoon } = partitionArray(schedules, (schedule) => {
 			if (schedule.nextRunAt > now) {
 				return { meetsCondition: false, item: schedule };
 			}

--- a/server/crons/imminent-recurring-workflows.ts
+++ b/server/crons/imminent-recurring-workflows.ts
@@ -23,6 +23,7 @@ import type { CancelledParentRun, ChildRunCanceller } from "server/service/cance
 import { getDueOccurrences, getNextOccurrence, getReferenceId, scheduleRowToDomain } from "server/service/schedule";
 import { ulid } from "ulidx";
 
+import { createTimerStreamCursorAdvancer } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 export interface ProcessImminentRecurringWorkflowsDeps {
@@ -38,6 +39,11 @@ export type DueSchedule = Schedule & {
 	workflowRunInputHash: string;
 };
 
+const advanceScheduleCursor = createTimerStreamCursorAdvancer<{ schedule: { id: string; nextRunAt: Date } }>({
+	getDueAt: (row) => row.schedule.nextRunAt,
+	getId: (row) => row.schedule.id,
+});
+
 export async function processImminentRecurringWorkflows(
 	context: CronContext,
 	deps: ProcessImminentRecurringWorkflowsDeps,
@@ -46,9 +52,14 @@ export async function processImminentRecurringWorkflows(
 	const { limit = 100, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => deps.repos.schedule.listDueSchedules(context, dueBefore, limit);
 
-	for await (const rows of streamChunks(next, (chunk) => chunk.length < limit)) {
+	for await (const rows of streamChunks(
+		(cursor) => deps.repos.schedule.listDueSchedules(context, dueBefore, limit, cursor),
+		{
+			advanceCursor: advanceScheduleCursor,
+			until: (chunk) => chunk.length < limit,
+		}
+	)) {
 		const schedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({
 			...scheduleRowToDomain(schedule, workflow),
 			workflowId: schedule.workflowId,

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -1,6 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
-import { streamChunks } from "@aikirun/lib/async";
+import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -15,6 +14,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { streamTimers } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<
@@ -36,34 +36,21 @@ export async function processImminentRetryableRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.workflowRun.listRetryableRuns(context, dueBefore, limit);
 
-	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
-			if (run.dueAt && run.dueAt.getTime() > now) {
-				return { meetsCondition: false, item: run };
-			}
-			return { meetsCondition: true, item: run };
-		});
-
+	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
+		(cursor) => repos.workflowRun.listRetryableRuns(context, dueBefore, limit, cursor),
+		(chunk) => chunk.length < limit
+	)) {
 		if (isNonEmptyArray(runsDueNow)) {
 			await queueRetryableRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
 		}
 
 		if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const run of runsDueSoon) {
-				if (!run.dueAt) {
-					context.logger.warn({ runId: run.id }, "Missing dueAt for retryable run, skipping promotion");
-					continue;
-				}
-				timers.push({
-					type: "retry",
-					id: run.id,
-					dueAt: run.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
+				type: "retry",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -40,7 +40,7 @@ export async function processImminentRetryableRuns(
 
 	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
 			if (run.dueAt && run.dueAt.getTime() > now) {
 				return { meetsCondition: false, item: run };
 			}

--- a/server/crons/imminent-retryable-runs.ts
+++ b/server/crons/imminent-retryable-runs.ts
@@ -2,8 +2,8 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
-	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -75,7 +75,7 @@ export async function queueRetryableRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -100,7 +100,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
 	const workflowRunIds = runs.map((run) => run.id);

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -40,7 +40,7 @@ export async function processImminentRetryableTaskRuns(
 
 	for await (const retryableTasks of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } = splitArray(retryableTasks, (task) => {
+		const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } = partitionArray(retryableTasks, (task) => {
 			if (task.dueAt && new Date(task.dueAt).getTime() > now) {
 				return { meetsCondition: false, item: task };
 			}

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -2,8 +2,8 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
-	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -82,7 +82,7 @@ export async function queueRetryableTaskRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -107,7 +107,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];

--- a/server/crons/imminent-retryable-task-runs.ts
+++ b/server/crons/imminent-retryable-task-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
@@ -15,6 +15,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { createTimerStreamCursorAdvancer } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<
@@ -28,6 +29,11 @@ export interface ProcessImminentRetryableTaskRunsDeps {
 	timerSortedSet?: TimerSortedSet;
 }
 
+const advanceTaskCursor = createTimerStreamCursorAdvancer<{ workflowRunId: string; dueAt: Date }>({
+	getDueAt: (entry) => entry.dueAt,
+	getId: (entry) => entry.workflowRunId,
+});
+
 export async function processImminentRetryableTaskRuns(
 	context: CronContext,
 	{ repos, workflowRunPublisher, timerSortedSet }: ProcessImminentRetryableTaskRunsDeps,
@@ -36,41 +42,30 @@ export async function processImminentRetryableTaskRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.task.listRetryableTaskWorkflowRuns(context, dueBefore, limit);
 
-	for await (const retryableTasks of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } = partitionArray(retryableTasks, (task) => {
-			if (task.dueAt && new Date(task.dueAt).getTime() > now) {
-				return { meetsCondition: false, item: task };
-			}
-			return { meetsCondition: true, item: task };
-		});
-
+	const now = Date.now();
+	for await (const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } of streamChunks(
+		(cursor) => repos.task.listRetryableTaskWorkflowRuns(context, dueBefore, limit, cursor),
+		{
+			advanceCursor: advanceTaskCursor,
+			until: (chunk) => chunk.length < limit,
+			partition: (task: { dueAt: Date }) => task.dueAt.getTime() <= now,
+		}
+	)) {
 		if (isNonEmptyArray(tasksDueNow)) {
-			const workflowRunIds = tasksDueNow.map((task) => task.workflowRunId) as NonEmptyArray<string>;
-			const runs = await repos.workflowRun.listByIdsAndStatus(context, workflowRunIds, "running");
+			const runIds = tasksDueNow.map((task) => task.workflowRunId) as NonEmptyArray<string>;
+			const runs = await repos.workflowRun.listByIdsAndStatus(context, runIds, "running");
 			if (isNonEmptyArray(runs)) {
 				await queueRetryableTaskRuns(context, repos, workflowRunPublisher, runs, { chunkSize });
 			}
 		}
 
 		if (timerSortedSet && isNonEmptyArray(tasksDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const task of tasksDueSoon) {
-				if (!task.dueAt) {
-					context.logger.warn(
-						{ workflowRunId: task.workflowRunId },
-						"Missing dueAt for retryable task run, skipping promotion"
-					);
-					continue;
-				}
-				timers.push({
-					type: "task_retry",
-					id: task.workflowRunId,
-					dueAt: task.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = tasksDueSoon.map((task) => ({
+				type: "task_retry",
+				id: task.workflowRunId,
+				dueAt: task.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -37,7 +37,7 @@ export async function processImminentScheduledRuns(
 
 	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
 			if (run.dueAt && run.dueAt.getTime() > now) {
 				return { meetsCondition: false, item: run };
 			}

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -2,8 +2,8 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
-	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -72,7 +72,7 @@ export async function queueScheduledRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -109,7 +109,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/crons/imminent-scheduled-runs.ts
+++ b/server/crons/imminent-scheduled-runs.ts
@@ -1,6 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
-import { streamChunks } from "@aikirun/lib/async";
+import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -15,6 +14,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { streamTimers } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<Repositories, "workflowRun" | "workflow" | "stateTransition" | "workflowRunOutbox" | "transaction">;
@@ -33,34 +33,21 @@ export async function processImminentScheduledRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.workflowRun.listDueScheduleRuns(context, dueBefore, limit);
 
-	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
-			if (run.dueAt && run.dueAt.getTime() > now) {
-				return { meetsCondition: false, item: run };
-			}
-			return { meetsCondition: true, item: run };
-		});
-
+	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
+		(cursor) => repos.workflowRun.listDueScheduleRuns(context, dueBefore, limit, cursor),
+		(chunk) => chunk.length < limit
+	)) {
 		if (isNonEmptyArray(runsDueNow)) {
 			await queueScheduledRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
 		}
 
 		if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const run of runsDueSoon) {
-				if (!run.dueAt) {
-					context.logger.warn({ runId: run.id }, "Missing dueAt for scheduled run, skipping promotion");
-					continue;
-				}
-				timers.push({
-					type: "scheduled",
-					id: run.id,
-					dueAt: run.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
+				type: "scheduled",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -1,4 +1,4 @@
-import { chunkLazy, isNonEmptyArray, type NonEmptyArray, splitArray } from "@aikirun/lib/array";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type {
@@ -39,7 +39,7 @@ export async function processImminentSleepElapsedRuns(
 
 	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
 		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = splitArray(runs, (run) => {
+		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
 			if (run.dueAt && run.dueAt.getTime() > now) {
 				return { meetsCondition: false, item: run };
 			}

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -1,8 +1,8 @@
 import { chunkLazy, isNonEmptyArray, type NonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
+import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
-	DueWorkflowRun,
 	Repositories,
 	StateTransitionRowInsert,
 	WorkflowRow,
@@ -74,7 +74,7 @@ export async function queueSleepElapsedRuns(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	options?: { chunkSize?: number }
 ) {
 	const { chunkSize = 50 } = options ?? {};
@@ -99,7 +99,7 @@ async function processChunk(
 	context: CronContext,
 	repos: Repos,
 	workflowRunPublisher: WorkflowRunPublisher | undefined,
-	runs: NonEmptyArray<DueWorkflowRun>,
+	runs: NonEmptyArray<WorkflowRunMeta>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
 	const completedAt = new Date();

--- a/server/crons/imminent-sleep-elapsed-runs.ts
+++ b/server/crons/imminent-sleep-elapsed-runs.ts
@@ -1,5 +1,4 @@
-import { chunkLazy, isNonEmptyArray, type NonEmptyArray, partitionArray } from "@aikirun/lib/array";
-import { streamChunks } from "@aikirun/lib/async";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -14,6 +13,7 @@ import { runConcurrently } from "server/lib/concurrency";
 import type { CronContext } from "server/middleware/context";
 import { ulid } from "ulidx";
 
+import { streamTimers } from "./lib/timer-stream";
 import { publishRuns } from "./publish-ready-runs";
 
 type Repos = Pick<
@@ -35,34 +35,21 @@ export async function processImminentSleepElapsedRuns(
 	const { limit = 100, chunkSize = 50, imminenceThresholdMs = 2_000 } = options ?? {};
 
 	const dueBefore = new Date(Date.now() + imminenceThresholdMs);
-	const next = () => repos.workflowRun.listSleepElapsedRuns(context, dueBefore, limit);
 
-	for await (const runs of streamChunks(next, (chunk) => chunk.length < limit)) {
-		const now = Date.now();
-		const { whenTrue: runsDueNow, whenFalse: runsDueSoon } = partitionArray(runs, (run) => {
-			if (run.dueAt && run.dueAt.getTime() > now) {
-				return { meetsCondition: false, item: run };
-			}
-			return { meetsCondition: true, item: run };
-		});
-
+	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
+		(cursor) => repos.workflowRun.listSleepElapsedRuns(context, dueBefore, limit, cursor),
+		(chunk) => chunk.length < limit
+	)) {
 		if (isNonEmptyArray(runsDueNow)) {
 			await queueSleepElapsedRuns(context, repos, workflowRunPublisher, runsDueNow, { chunkSize });
 		}
 
 		if (timerSortedSet && isNonEmptyArray(runsDueSoon)) {
-			const timers: TimerEntry[] = [];
-			for (const run of runsDueSoon) {
-				if (!run.dueAt) {
-					context.logger.warn({ runId: run.id }, "Missing dueAt for sleep-elapsed run, skipping promotion");
-					continue;
-				}
-				timers.push({
-					type: "sleep",
-					id: run.id,
-					dueAt: run.dueAt.getTime(),
-				});
-			}
+			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
+				type: "sleep",
+				id: run.id,
+				dueAt: run.dueAt.getTime(),
+			}));
 			if (isNonEmptyArray(timers)) {
 				await timerSortedSet.add(timers);
 			}

--- a/server/crons/lib/timer-stream.ts
+++ b/server/crons/lib/timer-stream.ts
@@ -1,0 +1,57 @@
+import type { NonEmptyArray } from "@aikirun/lib/array";
+import { streamChunks } from "@aikirun/lib/async";
+
+interface Timer {
+	dueAt: Date;
+	id: string;
+}
+
+export interface TimerStreamCursor {
+	dueAt: Date;
+	id: string;
+	maxId: string;
+}
+
+export function createTimerStreamCursorAdvancer<Item>(options: {
+	getDueAt: (item: Item) => Date;
+	getId: (item: Item) => string;
+}): (cursor: TimerStreamCursor | undefined, item: Item) => TimerStreamCursor {
+	const { getDueAt, getId } = options;
+
+	return (cursor, item) => {
+		const dueAt = getDueAt(item);
+		const id = getId(item);
+
+		if (!cursor) {
+			return { dueAt, id, maxId: id };
+		}
+
+		const { maxId: cursorMaxId } = cursor;
+		const maxId = id > cursorMaxId ? id : cursorMaxId;
+
+		if (dueAt.getTime() >= cursor.dueAt.getTime()) {
+			return { dueAt, id, maxId };
+		} else {
+			return { dueAt: cursor.dueAt, id: cursor.id, maxId };
+		}
+	};
+}
+
+const advanceTimerStreamCursor = createTimerStreamCursorAdvancer<Timer>({
+	getDueAt: (timer) => timer.dueAt,
+	getId: (timer) => timer.id,
+});
+
+export async function* streamTimers<Item extends Timer>(
+	next: (cursor: TimerStreamCursor | undefined) => Item[] | Promise<Item[]>,
+	until?: (chunk: NonEmptyArray<Item>) => boolean
+): AsyncGenerator<{ dueNow: Item[]; dueSoon: Item[] }> {
+	const now = Date.now();
+	for await (const { whenTrue, whenFalse } of streamChunks(next, {
+		advanceCursor: advanceTimerStreamCursor,
+		until,
+		partition: (timer: Item) => timer.dueAt.getTime() <= now,
+	})) {
+		yield { dueNow: whenTrue, dueSoon: whenFalse };
+	}
+}

--- a/server/crons/publish-ready-runs.ts
+++ b/server/crons/publish-ready-runs.ts
@@ -4,17 +4,28 @@ import type { Repositories, WorkflowRunOutboxRowInsert } from "server/infra/db/t
 import type { WorkflowRunPublisher, WorkflowRunReadyMessage } from "server/infra/messaging/redis-publisher";
 import type { CronContext } from "server/middleware/context";
 
+import { createTimerStreamCursorAdvancer } from "./lib/timer-stream";
+
 export interface PublishReadyRunsDeps {
 	repos: Pick<Repositories, "workflowRunOutbox">;
 	workflowRunPublisher: WorkflowRunPublisher;
 }
 
+const advanceOutboxCursor = createTimerStreamCursorAdvancer<{ id: string; createdAt: Date }>({
+	getDueAt: (entry) => entry.createdAt,
+	getId: (entry) => entry.id,
+});
+
 export async function publishReadyRuns(context: CronContext, deps: PublishReadyRunsDeps, options?: { limit?: number }) {
 	const { limit = 100 } = options ?? {};
 
-	const next = () => deps.repos.workflowRunOutbox.listPending(context, limit);
-
-	for await (const pendingEntries of streamChunks(next, (chunk) => chunk.length < limit)) {
+	for await (const pendingEntries of streamChunks(
+		(cursor) => deps.repos.workflowRunOutbox.listPending(context, limit, cursor),
+		{
+			advanceCursor: advanceOutboxCursor,
+			until: (chunk) => chunk.length < limit,
+		}
+	)) {
 		await publishRuns(context, deps.repos, deps.workflowRunPublisher, pendingEntries);
 	}
 }

--- a/server/crons/republish-stale-runs.ts
+++ b/server/crons/republish-stale-runs.ts
@@ -4,10 +4,17 @@ import type { Repositories } from "server/infra/db/types";
 import type { WorkflowRunPublisher } from "server/infra/messaging/redis-publisher";
 import type { CronContext } from "server/middleware/context";
 
+import { createTimerStreamCursorAdvancer } from "./lib/timer-stream";
+
 export interface RepublishStaleRuns {
 	repos: Pick<Repositories, "workflowRunOutbox">;
 	workflowRunPublisher: WorkflowRunPublisher;
 }
+
+const advanceOutboxCursor = createTimerStreamCursorAdvancer<{ id: string; updatedAt: Date }>({
+	getDueAt: (entry) => entry.updatedAt,
+	getId: (entry) => entry.id,
+});
 
 export async function republishStaleRuns(
 	context: CronContext,
@@ -16,9 +23,13 @@ export async function republishStaleRuns(
 ) {
 	const { claimMinIdleTimeMs = 90_000, limit = 50 } = options ?? {};
 
-	const next = () => deps.repos.workflowRunOutbox.listStalePublished(context, claimMinIdleTimeMs, limit);
-
-	for await (const staleEntries of streamChunks(next, (chunk) => chunk.length < limit)) {
+	for await (const staleEntries of streamChunks(
+		(cursor) => deps.repos.workflowRunOutbox.listStalePublished(context, claimMinIdleTimeMs, limit, cursor),
+		{
+			advanceCursor: advanceOutboxCursor,
+			until: (chunk) => chunk.length < limit,
+		}
+	)) {
 		context.logger.info({ count: staleEntries.length }, "Republishing stale published outbox entries");
 
 		await deps.workflowRunPublisher.publishReadyRuns(

--- a/server/infra/db/pg/migration/0003_strong_lily_hollister.sql
+++ b/server/infra/db/pg/migration/0003_strong_lily_hollister.sql
@@ -1,0 +1,16 @@
+DROP INDEX "idx_schedule_status_next_run_at";--> statement-breakpoint
+DROP INDEX "idx_task_status_workflow_run_next_attempt_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_status_scheduled_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_status_awake_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_status_timeout_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_status_next_attempt_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_outbox_status_created";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_outbox_status_updated";--> statement-breakpoint
+CREATE INDEX "idx_schedule_status_next_run_at_id" ON "schedule" USING btree ("status","next_run_at","id");--> statement-breakpoint
+CREATE INDEX "idx_task_status_next_attempt_at_workflow_run" ON "task" USING btree ("status","next_attempt_at","workflow_run_id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_status_scheduled_at_id" ON "workflow_run" USING btree ("status","scheduled_at","id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_status_awake_at_id" ON "workflow_run" USING btree ("status","awake_at","id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_status_timeout_at_id" ON "workflow_run" USING btree ("status","timeout_at","id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_status_next_attempt_at_id" ON "workflow_run" USING btree ("status","next_attempt_at","id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_outbox_status_created_id" ON "workflow_run_outbox" USING btree ("status","created_at","id");--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_outbox_status_updated_id" ON "workflow_run_outbox" USING btree ("status","updated_at","id");

--- a/server/infra/db/pg/migration/meta/0003_snapshot.json
+++ b/server/infra/db/pg/migration/meta/0003_snapshot.json
@@ -1,0 +1,2836 @@
+{
+	"id": "995bc4cd-46b1-4568-ae05-09dcd54068c5",
+	"prevId": "237e9a0d-fc67-48af-8d27-5fbfbb538889",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_namespace_id": {
+					"name": "fk_schedule_namespace_id",
+					"tableFrom": "schedule",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_namespace_id": {
+					"name": "fk_workflow_namespace_id",
+					"tableFrom": "workflow",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_awake_at_id": {
+					"name": "idx_workflow_run_status_awake_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "awake_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_namespace_id": {
+					"name": "fk_workflow_run_namespace_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_publish": {
+					"name": "idx_workflow_run_outbox_publish",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_stale": {
+					"name": "idx_workflow_run_outbox_claim_stale",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_created_id": {
+					"name": "idx_workflow_run_outbox_status_created_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_updated_id": {
+					"name": "idx_workflow_run_outbox_status_updated_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_account_user_provider": {
+					"name": "uqidx_account_user_provider",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "provider_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_account_user_id": {
+					"name": "fk_account_user_id",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_key": {
+			"name": "api_key",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "api_key_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_api_key_namespace_created_by_user_name": {
+					"name": "uqidx_api_key_namespace_created_by_user_name",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_by_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_api_key_namespace_name": {
+					"name": "idx_api_key_namespace_name",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_api_key_namespace_id": {
+					"name": "fk_api_key_namespace_id",
+					"tableFrom": "api_key",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"fk_api_key_organization_id": {
+					"name": "fk_api_key_organization_id",
+					"tableFrom": "api_key",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"fk_api_key_created_by_user_id": {
+					"name": "fk_api_key_created_by_user_id",
+					"tableFrom": "api_key",
+					"tableTo": "user",
+					"columnsFrom": ["created_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"uq_api_key_key_hash": {
+					"name": "uq_api_key_key_hash",
+					"nullsNotDistinct": false,
+					"columns": ["key_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.namespace": {
+			"name": "namespace",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "namespace_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_namespace_org_name": {
+					"name": "uqidx_namespace_org_name",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_namespace_org_id": {
+					"name": "fk_namespace_org_id",
+					"tableFrom": "namespace",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.namespace_member": {
+			"name": "namespace_member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "namespace_role",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'viewer'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_namespace_member_namespace_user": {
+					"name": "uqidx_namespace_member_namespace_user",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_namespace_member_user_id": {
+					"name": "idx_namespace_member_user_id",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_namespace_member_namespace_id": {
+					"name": "fk_namespace_member_namespace_id",
+					"tableFrom": "namespace_member",
+					"tableTo": "namespace",
+					"columnsFrom": ["namespace_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_namespace_member_user_id": {
+					"name": "fk_namespace_member_user_id",
+					"tableFrom": "namespace_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organization": {
+			"name": "organization",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "organization_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "organization_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"uq_organization_slug": {
+					"name": "uq_organization_slug",
+					"nullsNotDistinct": false,
+					"columns": ["slug"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organization_invitation": {
+			"name": "organization_invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "organization_role",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "organization_invitation_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_org_invitation_pending_email_org_namespace": {
+					"name": "uqidx_org_invitation_pending_email_org_namespace",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"organization_invitation\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_org_invitation_inviter_id": {
+					"name": "fk_org_invitation_inviter_id",
+					"tableFrom": "organization_invitation",
+					"tableTo": "user",
+					"columnsFrom": ["inviter_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_org_invitation_organization_id": {
+					"name": "fk_org_invitation_organization_id",
+					"tableFrom": "organization_invitation",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.organization_member": {
+			"name": "organization_member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "organization_role",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_org_member_org_user": {
+					"name": "uqidx_org_member_org_user",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_org_member_user_id": {
+					"name": "idx_org_member_user_id",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_org_member_user_id": {
+					"name": "fk_org_member_user_id",
+					"tableFrom": "organization_member",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_org_member_org_id": {
+					"name": "fk_org_member_org_id",
+					"tableFrom": "organization_member",
+					"tableTo": "organization",
+					"columnsFrom": ["organization_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_namespace_id": {
+					"name": "active_namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_session_active_namespace_id": {
+					"name": "idx_session_active_namespace_id",
+					"columns": [
+						{
+							"expression": "active_namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_session_user_id": {
+					"name": "fk_session_user_id",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"uq_session_token": {
+					"name": "uq_session_token",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "user_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"uq_user_email": {
+					"name": "uq_user_email",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["upsert", "error"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "deleted"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_failure_cause": {
+			"name": "workflow_run_failure_cause",
+			"schema": "public",
+			"values": ["task", "child_workflow", "self"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published"]
+		},
+		"public.workflow_run_scheduled_reason": {
+			"name": "workflow_run_scheduled_reason",
+			"schema": "public",
+			"values": ["new", "retry", "task_retry", "awake", "awake_early", "resume", "event", "child_workflow"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		},
+		"public.api_key_status": {
+			"name": "api_key_status",
+			"schema": "public",
+			"values": ["active", "revoked", "expired"]
+		},
+		"public.namespace_role": {
+			"name": "namespace_role",
+			"schema": "public",
+			"values": ["admin", "member", "viewer"]
+		},
+		"public.namespace_status": {
+			"name": "namespace_status",
+			"schema": "public",
+			"values": ["active", "suspended", "deleted"]
+		},
+		"public.organization_invitation_status": {
+			"name": "organization_invitation_status",
+			"schema": "public",
+			"values": ["pending", "accepted", "rejected", "expired", "canceled"]
+		},
+		"public.organization_role": {
+			"name": "organization_role",
+			"schema": "public",
+			"values": ["owner", "admin", "member"]
+		},
+		"public.organization_status": {
+			"name": "organization_status",
+			"schema": "public",
+			"values": ["active", "suspended", "deleted"]
+		},
+		"public.organization_type": {
+			"name": "organization_type",
+			"schema": "public",
+			"values": ["personal", "team"]
+		},
+		"public.user_status": {
+			"name": "user_status",
+			"schema": "public",
+			"values": ["active", "suspended", "deleted"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/server/infra/db/pg/migration/meta/_journal.json
+++ b/server/infra/db/pg/migration/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1774054654467,
 			"tag": "0002_chief_zemo",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1778449611299,
+			"tag": "0003_strong_lily_hollister",
+			"breakpoints": true
 		}
 	]
 }

--- a/server/infra/db/pg/repository/lib/timer-stream.ts
+++ b/server/infra/db/pg/repository/lib/timer-stream.ts
@@ -1,0 +1,18 @@
+import { and, gt, or, type SQL, sql } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+import type { TimerStreamCursor } from "server/crons/lib/timer-stream";
+
+export function timerStreamCursorFilter(
+	dueAtCol: PgColumn | SQL,
+	idCol: PgColumn,
+	cursor: TimerStreamCursor | undefined
+): SQL | undefined {
+	if (!cursor) {
+		return undefined;
+	}
+	return or(
+		sql`${dueAtCol} > ${cursor.dueAt}`,
+		and(sql`${dueAtCol} = ${cursor.dueAt}`, gt(idCol, cursor.id)),
+		and(sql`${dueAtCol} < ${cursor.dueAt}`, gt(idCol, cursor.maxId))
+	);
+}

--- a/server/infra/db/pg/repository/schedule.ts
+++ b/server/infra/db/pg/repository/schedule.ts
@@ -1,8 +1,10 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import { and, count, eq, getTableColumns, inArray, lte, sql } from "drizzle-orm";
+import type { TimerStreamCursor } from "server/crons/lib/timer-stream";
 import type { CronContext } from "server/middleware/context";
 
+import { timerStreamCursorFilter } from "./lib/timer-stream";
 import type { PgDb } from "../provider";
 import { schedule, workflow } from "../schema";
 
@@ -149,15 +151,24 @@ export function createScheduleRepository(db: PgDb) {
 				.where(and(eq(schedule.status, "active"), inArray(schedule.id, ids)));
 		},
 
-		async listDueSchedules(_context: CronContext, before: Date, limit = 100) {
+		async listDueSchedules(_context: CronContext, before: Date, limit = 100, cursor?: TimerStreamCursor) {
 			return db
 				.select({
-					schedule: getTableColumns(schedule),
+					schedule: {
+						...getTableColumns(schedule),
+						nextRunAt: sql<Date>`${schedule.nextRunAt}`,
+					},
 					workflow: { workflowName: workflow.name, workflowVersionId: workflow.versionId },
 				})
 				.from(schedule)
 				.innerJoin(workflow, eq(schedule.workflowId, workflow.id))
-				.where(and(eq(schedule.status, "active"), lte(schedule.nextRunAt, before)))
+				.where(
+					and(
+						eq(schedule.status, "active"),
+						lte(schedule.nextRunAt, before),
+						timerStreamCursorFilter(schedule.nextRunAt, schedule.id, cursor)
+					)
+				)
 				.orderBy(schedule.nextRunAt, schedule.id)
 				.limit(limit);
 		},

--- a/server/infra/db/pg/repository/task.ts
+++ b/server/infra/db/pg/repository/task.ts
@@ -1,7 +1,9 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import { and, eq, inArray, lte, min } from "drizzle-orm";
+import { and, eq, inArray, lte, min, sql } from "drizzle-orm";
+import type { TimerStreamCursor } from "server/crons/lib/timer-stream";
 import type { CronContext } from "server/middleware/context";
 
+import { timerStreamCursorFilter } from "./lib/timer-stream";
 import type { PgDb } from "../provider";
 import { task } from "../schema";
 
@@ -35,16 +37,19 @@ export function createTaskRepository(db: PgDb) {
 			return db.select().from(task).where(eq(task.workflowRunId, workflowRunId)).orderBy(task.id).limit(10_000);
 		},
 
-		async listRetryableTaskWorkflowRuns(_context: CronContext, before: Date, limit = 100) {
+		async listRetryableTaskWorkflowRuns(_context: CronContext, before: Date, limit = 100, cursor?: TimerStreamCursor) {
+			const dueAtExpr = min(task.nextAttemptAt);
+
 			return db
 				.select({
 					workflowRunId: task.workflowRunId,
-					dueAt: min(task.nextAttemptAt),
+					dueAt: sql<Date>`${dueAtExpr}`,
 				})
 				.from(task)
 				.where(and(eq(task.status, "awaiting_retry"), lte(task.nextAttemptAt, before)))
 				.groupBy(task.workflowRunId)
-				.orderBy(min(task.nextAttemptAt))
+				.having(timerStreamCursorFilter(dueAtExpr, task.workflowRunId, cursor))
+				.orderBy(dueAtExpr, task.workflowRunId)
 				.limit(limit);
 		},
 

--- a/server/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/server/infra/db/pg/repository/workflow-run-outbox.ts
@@ -2,8 +2,10 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { isNonEmptyArray } from "@aikirun/lib/array";
 import type { WorkflowRunId } from "@aikirun/types/workflow-run";
 import { and, eq, inArray, lt, sql } from "drizzle-orm";
+import type { TimerStreamCursor } from "server/crons/lib/timer-stream";
 import type { CronContext } from "server/middleware/context";
 
+import { timerStreamCursorFilter } from "./lib/timer-stream";
 import type { PgDb } from "../provider";
 import { workflowRunOutbox } from "../schema";
 
@@ -16,12 +18,17 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			await db.insert(workflowRunOutbox).values(rows);
 		},
 
-		async listPending(_context: CronContext, limit = 100): Promise<WorkflowRunOutboxRow[]> {
+		async listPending(_context: CronContext, limit = 100, cursor?: TimerStreamCursor): Promise<WorkflowRunOutboxRow[]> {
 			return db
 				.select()
 				.from(workflowRunOutbox)
-				.where(eq(workflowRunOutbox.status, "pending"))
-				.orderBy(workflowRunOutbox.createdAt)
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "pending"),
+						timerStreamCursorFilter(workflowRunOutbox.createdAt, workflowRunOutbox.id, cursor)
+					)
+				)
+				.orderBy(workflowRunOutbox.createdAt, workflowRunOutbox.id)
 				.limit(limit);
 		},
 
@@ -42,7 +49,8 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 		async listStalePublished(
 			_context: CronContext,
 			claimMinIdleTimeMs: number,
-			limit: number
+			limit: number,
+			cursor?: TimerStreamCursor
 		): Promise<WorkflowRunOutboxRow[]> {
 			const now = Date.now();
 			const staleThreshold = new Date(now - claimMinIdleTimeMs);
@@ -50,8 +58,14 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			return db
 				.select()
 				.from(workflowRunOutbox)
-				.where(and(eq(workflowRunOutbox.status, "published"), lt(workflowRunOutbox.updatedAt, staleThreshold)))
-				.orderBy(workflowRunOutbox.updatedAt)
+				.where(
+					and(
+						eq(workflowRunOutbox.status, "published"),
+						lt(workflowRunOutbox.updatedAt, staleThreshold),
+						timerStreamCursorFilter(workflowRunOutbox.updatedAt, workflowRunOutbox.id, cursor)
+					)
+				)
+				.orderBy(workflowRunOutbox.updatedAt, workflowRunOutbox.id)
 				.limit(limit);
 		},
 

--- a/server/infra/db/pg/repository/workflow-run.ts
+++ b/server/infra/db/pg/repository/workflow-run.ts
@@ -4,8 +4,10 @@ import type { TaskStatus } from "@aikirun/types/task";
 import type { WorkflowRunId, WorkflowRunState, WorkflowRunStatus } from "@aikirun/types/workflow-run";
 import { NON_TERMINAL_WORKFLOW_RUN_STATUSES } from "@aikirun/types/workflow-run";
 import { and, count, eq, inArray, lte, or, sql } from "drizzle-orm";
+import type { TimerStreamCursor } from "server/crons/lib/timer-stream";
 import type { CronContext } from "server/middleware/context";
 
+import { timerStreamCursorFilter } from "./lib/timer-stream";
 import { toWorkflowRunState } from "./state-transition";
 import type { PgDb } from "../provider";
 import { stateTransition, task, workflow, workflowRun } from "../schema";
@@ -30,7 +32,7 @@ export interface WorkflowRunMeta {
 }
 
 export interface DueWorkflowRun extends WorkflowRunMeta {
-	dueAt: Date | null;
+	dueAt: Date;
 }
 
 export function createWorkflowRunRepository(db: PgDb) {
@@ -297,7 +299,12 @@ export function createWorkflowRunRepository(db: PgDb) {
 				.groupBy(workflowRun.status);
 		},
 
-		async listDueScheduleRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
+		async listDueScheduleRuns(
+			_context: CronContext,
+			before: Date,
+			limit = 100,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -307,15 +314,26 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					dueAt: workflowRun.scheduledAt,
+					dueAt: sql<Date>`${workflowRun.scheduledAt}`,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "scheduled"), lte(workflowRun.scheduledAt, before)))
+				.where(
+					and(
+						eq(workflowRun.status, "scheduled"),
+						lte(workflowRun.scheduledAt, before),
+						timerStreamCursorFilter(workflowRun.scheduledAt, workflowRun.id, cursor)
+					)
+				)
 				.orderBy(workflowRun.scheduledAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listSleepElapsedRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
+		async listSleepElapsedRuns(
+			_context: CronContext,
+			before: Date,
+			limit = 100,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -325,15 +343,26 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					dueAt: workflowRun.awakeAt,
+					dueAt: sql<Date>`${workflowRun.awakeAt}`,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "sleeping"), lte(workflowRun.awakeAt, before)))
+				.where(
+					and(
+						eq(workflowRun.status, "sleeping"),
+						lte(workflowRun.awakeAt, before),
+						timerStreamCursorFilter(workflowRun.awakeAt, workflowRun.id, cursor)
+					)
+				)
 				.orderBy(workflowRun.awakeAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listRetryableRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
+		async listRetryableRuns(
+			_context: CronContext,
+			before: Date,
+			limit = 100,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -343,15 +372,26 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					dueAt: workflowRun.nextAttemptAt,
+					dueAt: sql<Date>`${workflowRun.nextAttemptAt}`,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_retry"), lte(workflowRun.nextAttemptAt, before)))
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_retry"),
+						lte(workflowRun.nextAttemptAt, before),
+						timerStreamCursorFilter(workflowRun.nextAttemptAt, workflowRun.id, cursor)
+					)
+				)
 				.orderBy(workflowRun.nextAttemptAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listEventWaitTimedOutRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
+		async listEventWaitTimedOutRuns(
+			_context: CronContext,
+			before: Date,
+			limit = 100,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -361,15 +401,26 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					dueAt: workflowRun.timeoutAt,
+					dueAt: sql<Date>`${workflowRun.timeoutAt}`,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_event"), lte(workflowRun.timeoutAt, before)))
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_event"),
+						lte(workflowRun.timeoutAt, before),
+						timerStreamCursorFilter(workflowRun.timeoutAt, workflowRun.id, cursor)
+					)
+				)
 				.orderBy(workflowRun.timeoutAt, workflowRun.id)
 				.limit(limit);
 		},
 
-		async listChildRunWaitTimedOutRuns(_context: CronContext, before: Date, limit = 100): Promise<DueWorkflowRun[]> {
+		async listChildRunWaitTimedOutRuns(
+			_context: CronContext,
+			before: Date,
+			limit = 100,
+			cursor?: TimerStreamCursor
+		): Promise<DueWorkflowRun[]> {
 			return db
 				.select({
 					id: workflowRun.id,
@@ -379,10 +430,16 @@ export function createWorkflowRunRepository(db: PgDb) {
 					attempts: workflowRun.attempts,
 					options: workflowRun.options,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					dueAt: workflowRun.timeoutAt,
+					dueAt: sql<Date>`${workflowRun.timeoutAt}`,
 				})
 				.from(workflowRun)
-				.where(and(eq(workflowRun.status, "awaiting_child_workflow"), lte(workflowRun.timeoutAt, before)))
+				.where(
+					and(
+						eq(workflowRun.status, "awaiting_child_workflow"),
+						lte(workflowRun.timeoutAt, before),
+						timerStreamCursorFilter(workflowRun.timeoutAt, workflowRun.id, cursor)
+					)
+				)
 				.orderBy(workflowRun.timeoutAt, workflowRun.id)
 				.limit(limit);
 		},

--- a/server/infra/db/pg/repository/workflow-run.ts
+++ b/server/infra/db/pg/repository/workflow-run.ts
@@ -19,7 +19,7 @@ type WorkflowRunRowUpdate = Partial<
 	>
 >;
 
-export interface DueWorkflowRun {
+export interface WorkflowRunMeta {
 	id: string;
 	namespaceId: string;
 	workflowId: string;
@@ -27,7 +27,10 @@ export interface DueWorkflowRun {
 	attempts: number;
 	options: unknown;
 	latestStateTransitionId: string;
-	dueAt?: Date | null;
+}
+
+export interface DueWorkflowRun extends WorkflowRunMeta {
+	dueAt: Date | null;
 }
 
 export function createWorkflowRunRepository(db: PgDb) {

--- a/server/infra/db/pg/schema/aiki.ts
+++ b/server/infra/db/pg/schema/aiki.ts
@@ -128,7 +128,7 @@ export const schedule = pgTable(
 		uniqueIndex("uqidx_schedule_namespace_reference").on(table.namespaceId, table.referenceId),
 		index("idx_schedule_namespace_workflow").on(table.namespaceId, table.workflowId),
 		// TODO: how to prevent certain namespaces from starving others
-		index("idx_schedule_status_next_run_at").on(table.status, table.nextRunAt),
+		index("idx_schedule_status_next_run_at_id").on(table.status, table.nextRunAt, table.id),
 	]
 );
 
@@ -196,10 +196,10 @@ export const workflowRun = pgTable(
 
 		// TODO: will adding an index on input hash make conflict resolution faster?
 
-		index("idx_workflow_run_status_scheduled_at").on(table.status, table.scheduledAt),
-		index("idx_workflow_run_status_awake_at").on(table.status, table.awakeAt),
-		index("idx_workflow_run_status_timeout_at").on(table.status, table.timeoutAt),
-		index("idx_workflow_run_status_next_attempt_at").on(table.status, table.nextAttemptAt),
+		index("idx_workflow_run_status_scheduled_at_id").on(table.status, table.scheduledAt, table.id),
+		index("idx_workflow_run_status_awake_at_id").on(table.status, table.awakeAt, table.id),
+		index("idx_workflow_run_status_timeout_at_id").on(table.status, table.timeoutAt, table.id),
+		index("idx_workflow_run_status_next_attempt_at_id").on(table.status, table.nextAttemptAt, table.id),
 	]
 );
 
@@ -231,7 +231,7 @@ export const task = pgTable(
 		}),
 		index("idx_task_workflow_run_id").on(table.workflowRunId, table.id),
 		index("idx_task_workflow_run_status").on(table.workflowRunId, table.status),
-		index("idx_task_status_workflow_run_next_attempt_at").on(table.status, table.workflowRunId, table.nextAttemptAt),
+		index("idx_task_status_next_attempt_at_workflow_run").on(table.status, table.nextAttemptAt, table.workflowRunId),
 	]
 );
 
@@ -418,8 +418,8 @@ export const workflowRunOutbox = pgTable(
 			table.workflowVersionId,
 			table.shard
 		),
-		index("idx_workflow_run_outbox_status_created").on(table.status, table.createdAt),
-		index("idx_workflow_run_outbox_status_updated").on(table.status, table.updatedAt),
+		index("idx_workflow_run_outbox_status_created_id").on(table.status, table.createdAt, table.id),
+		index("idx_workflow_run_outbox_status_updated_id").on(table.status, table.updatedAt, table.id),
 	]
 );
 


### PR DESCRIPTION
## The bug

The cron processors stream chunks of data (workflow runs, schedules, outbox entries) but never advance a cursor between iterations. The same chunk gets returned over and over, and the `chunk.length < limit` termination condition only fires if everything is processed and transitions out of the WHERE clause between calls.

## The fix: cursor pagination

Items are loaded in `(dueAt, id)` order. The cursor filter is a 3-branched OR:

- `dueAt > cursor.dueAt` — forward progress: newer than the last processed item.
- `dueAt = cursor.dueAt AND id > cursor.id` — tiebreaker: continue from the last `id` processed at the same `dueAt`.
- `dueAt < cursor.dueAt AND id > cursor.maxId` — catches items injected into the DB at an earlier `dueAt` *after* this drain pass started. The cursor's `dueAt` and `id` are **not** moved backward when handling this branch; only `maxId` advances. This keeps the cursor monotonic so previously-visited items are never re-fetched.

See `createTimerStreamCursorAdvancer` and `timerStreamCursorFilter`.

## Helper changes

- `streamChunks` now accepts a caller-provided `advanceCursor` function for threading the cursor between iterations.
- It also accepts an optional `partition` function so a chunk can be split (e.g. "due now" vs. "due soon") in the same pass.

## Index changes

The cursor filter compares `(dueAt, id)`, so the existing `(status, dueAt)` indexes weren't optimal. Appended `id` to the relevant indexes so the `ORDER BY (dueAt, id)` is index-served and the `id` filter is applied in-index:

- `idx_schedule_status_next_run_at` → `idx_schedule_status_next_run_at_id`
- `idx_workflow_run_status_scheduled_at` → `..._id`
- `idx_workflow_run_status_awake_at` → `..._id`
- `idx_workflow_run_status_timeout_at` → `..._id`
- `idx_workflow_run_status_next_attempt_at` → `..._id`
- `idx_workflow_run_outbox_status_created` → `..._id`
- `idx_workflow_run_outbox_status_updated` → `..._id`

Also reordered the task index from `(status, workflowRunId, nextAttemptAt)` to `(status, nextAttemptAt, workflowRunId)` so `listRetryableTaskWorkflowRuns` can seek directly to the imminent slice instead of scanning the whole `status = 'awaiting_retry'` section. Verified no other query depends on the previous column order.