### PR TITLE
Primary/fallback subscriber with scheduled retry

### DIFF
--- a/sdk/transport/http/subscriber.ts
+++ b/sdk/transport/http/subscriber.ts
@@ -52,14 +52,17 @@ export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 
 		return {
 			getNextDelay,
-			async getNextBatch(size: number): Promise<WorkflowRunBatch[]> {
-				const response = await api.workflowRun.claimReadyV1({
-					workerId,
-					workflows: workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId })),
-					shards,
-					limit: size,
-					claimMinIdleTimeMs,
-				});
+			async getNextBatch(size: number, options?: { abortSignal?: AbortSignal }): Promise<WorkflowRunBatch[]> {
+				const response = await api.workflowRun.claimReadyV1(
+					{
+						workerId,
+						workflows: workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId })),
+						shards,
+						limit: size,
+						claimMinIdleTimeMs,
+					},
+					{ signal: options?.abortSignal }
+				);
 
 				return response.runs.map((run) => ({
 					data: { workflowRunId: run.id as WorkflowRunId },

--- a/sdk/transport/redis/subscriber.ts
+++ b/sdk/transport/redis/subscriber.ts
@@ -102,7 +102,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 
 		return {
 			getNextDelay,
-			async getNextBatch(size: number): Promise<WorkflowRunBatch[]> {
+			async getNextBatch(size: number, _options?: { abortSignal?: AbortSignal }): Promise<WorkflowRunBatch[]> {
 				const shuffledQueueNames = shuffleArray(queueNames);
 				const firstItem = (await redis.bzpopmin(...shuffledQueueNames, 0)) as
 					| [key: string, member: WorkflowRunId, score: string]

--- a/sdk/transport/redis/subscriber.ts
+++ b/sdk/transport/redis/subscriber.ts
@@ -95,6 +95,8 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 			connectTimeout: options?.connectTimeoutMs,
 		});
 
+		redis.on("error", () => {});
+
 		const queueNames = getWorkflowQueueNames(workflows, shards);
 		let closed = false;
 

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -316,7 +316,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 
 		if (Date.now() >= this.primarySubscriberNextAttemptAt) {
 			try {
-				const batch = await this.primarySubscriber.getNextBatch(size);
+				const batch = await this.primarySubscriber.getNextBatch(size, { abortSignal });
 				if (this.primarySubscriberFailedAttempts > 0) {
 					this.logger.info("Primary subscriber recovered");
 				}
@@ -352,7 +352,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		}
 
 		try {
-			const batch = await this.fallbackSubscriber.getNextBatch(size);
+			const batch = await this.fallbackSubscriber.getNextBatch(size, { abortSignal });
 			if (this.fallbackSubscriberFailedAttempts > 0) {
 				this.logger.info("Fallback subscriber recovered");
 			}

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -122,9 +122,12 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 	private readonly registry: WorkflowRegistry;
 	private readonly logger: Logger;
 	private abortController: AbortController | undefined;
-	private subscriber: Subscriber | undefined;
+	private primarySubscriber: Subscriber | undefined;
 	private fallbackSubscriber: Subscriber | undefined;
 	private subscriberLoopPromise: Promise<void> | undefined;
+	private primarySubscriberFailedAttempts = 0;
+	private primarySubscriberNextAttemptAt = 0;
+	private fallbackSubscriberFailedAttempts = 0;
 	private availableCapacityLatch = createBinaryLatch();
 	private pendingWorkflowRunIds = new Set<string>();
 	private activeWorkflowRunsById = new Map<string, ActiveWorkflowRun>();
@@ -165,16 +168,20 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		};
 
 		const createSubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
-		const subscriber = createSubscriber(subscriberContext);
-		this.subscriber = subscriber instanceof Promise ? await subscriber : subscriber;
-		this.subscriber.heartbeat = this.withServerHeartbeatForwarding(this.subscriber.heartbeat?.bind(this.subscriber));
-
-		const createFallbackSubscriber = httpSubscriber({ api: this.client.api });
-		const fallbackSubscriber = createFallbackSubscriber(subscriberContext);
-		this.fallbackSubscriber = fallbackSubscriber instanceof Promise ? await fallbackSubscriber : fallbackSubscriber;
-		this.fallbackSubscriber.heartbeat = this.withServerHeartbeatForwarding(
-			this.fallbackSubscriber.heartbeat?.bind(this.fallbackSubscriber)
+		const primarySubscriber = createSubscriber(subscriberContext);
+		this.primarySubscriber = primarySubscriber instanceof Promise ? await primarySubscriber : primarySubscriber;
+		this.primarySubscriber.heartbeat = this.withServerHeartbeatForwarding(
+			this.primarySubscriber.heartbeat?.bind(this.primarySubscriber)
 		);
+
+		if (!this.params.subscriber) {
+			const createFallbackSubscriber = httpSubscriber({ api: this.client.api });
+			const fallbackSubscriber = createFallbackSubscriber(subscriberContext);
+			this.fallbackSubscriber = fallbackSubscriber instanceof Promise ? await fallbackSubscriber : fallbackSubscriber;
+			this.fallbackSubscriber.heartbeat = this.withServerHeartbeatForwarding(
+				this.fallbackSubscriber.heartbeat?.bind(this.fallbackSubscriber)
+			);
+		}
 
 		this.abortController = new AbortController();
 		const abortSignal = this.abortController.signal;
@@ -201,8 +208,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		this.abortController?.abort();
 		this.availableCapacityLatch.signal();
 
-		await this.subscriber?.close?.();
-		await this.fallbackSubscriber?.close?.();
+		await Promise.all([this.primarySubscriber?.close?.(), this.fallbackSubscriber?.close?.()]);
 
 		await this.subscriberLoopPromise;
 
@@ -245,7 +251,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 	}
 
 	private async subscriberLoop(abortSignal: AbortSignal): Promise<void> {
-		if (!this.subscriber) {
+		if (!this.primarySubscriber) {
 			throw new Error("Subscriber not initialized");
 		}
 
@@ -255,9 +261,8 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 
 		const maxConcurrentWorkflowRuns = this.spawnOptions.maxConcurrentWorkflowRuns ?? 1;
 
-		let activeSubscriber: Subscriber = this.subscriber;
+		let activeSubscriber: Subscriber = this.primarySubscriber;
 		let nextDelayMs = activeSubscriber.getNextDelay({ type: "no_work" });
-		let subscriberFailedAttempts = 0;
 
 		while (!abortSignal.aborted) {
 			if (nextDelayMs > 0) {
@@ -271,22 +276,13 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 				continue;
 			}
 
-			const nextBatchResponse = await this.fetchNextWorkflowRunBatch(
-				availableCapacity,
-				subscriberFailedAttempts,
-				abortSignal
-			);
+			const nextBatchResponse = await this.fetchNextWorkflowRunBatch(availableCapacity, abortSignal);
 			if (!nextBatchResponse.success) {
-				subscriberFailedAttempts++;
-				nextDelayMs = activeSubscriber.getNextDelay({
-					type: "retry",
-					attemptNumber: subscriberFailedAttempts,
-				});
+				nextDelayMs = nextBatchResponse.retryDelayMs;
 				continue;
 			}
 
-			subscriberFailedAttempts = 0;
-			activeSubscriber = nextBatchResponse.subscriber;
+			activeSubscriber = nextBatchResponse.activeSubscriber;
 
 			const workflowRunIdsToEnqueue: WorkflowRunId[] = [];
 			for (const { data } of nextBatchResponse.batch) {
@@ -309,37 +305,79 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 
 	private async fetchNextWorkflowRunBatch(
 		size: number,
-		subscriberFailedAttempts: number,
 		abortSignal: AbortSignal
-	): Promise<{ success: true; batch: WorkflowRunBatch[]; subscriber: Subscriber } | { success: false; error: Error }> {
-		if (!this.subscriber) {
+	): Promise<
+		| { success: true; batch: WorkflowRunBatch[]; activeSubscriber: Subscriber }
+		| { success: false; retryDelayMs: number }
+	> {
+		if (!this.primarySubscriber) {
 			throw new Error("Subscriber not initialized");
 		}
 
-		try {
-			const batch = await this.subscriber.getNextBatch(size);
-			return { success: true, batch, subscriber: this.subscriber };
-		} catch (error) {
-			if (abortSignal.aborted) {
-				return { success: false, error: error as Error };
-			}
+		if (Date.now() >= this.primarySubscriberNextAttemptAt) {
+			try {
+				const batch = await this.primarySubscriber.getNextBatch(size);
+				if (this.primarySubscriberFailedAttempts > 0) {
+					this.logger.info("Primary subscriber recovered");
+				}
+				this.primarySubscriberFailedAttempts = 0;
+				this.fallbackSubscriberFailedAttempts = 0;
+				this.primarySubscriberNextAttemptAt = 0;
+				return { success: true, batch, activeSubscriber: this.primarySubscriber };
+			} catch (error) {
+				if (abortSignal.aborted) {
+					return { success: false, retryDelayMs: 0 };
+				}
 
-			this.logger.error("Error getting next workflow runs batch", {
-				"aiki.error": error instanceof Error ? error.message : String(error),
-			});
-
-			if (this.fallbackSubscriber && subscriberFailedAttempts >= 2) {
-				try {
-					const batch = await this.fallbackSubscriber.getNextBatch(size);
-					return { success: true, batch, subscriber: this.fallbackSubscriber };
-				} catch (fallbackError) {
-					this.logger.error("Fallback subscriber also failed to get next workflow runs batch", {
-						"aiki.error": fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+				if (this.primarySubscriberFailedAttempts === 0) {
+					this.logger.error("Primary subscriber failed", {
+						"aiki.error": error instanceof Error ? error.message : String(error),
 					});
 				}
+
+				this.primarySubscriberFailedAttempts++;
+				const retryDelayMs = this.primarySubscriber.getNextDelay({
+					type: "retry",
+					attemptNumber: this.primarySubscriberFailedAttempts,
+				});
+				this.primarySubscriberNextAttemptAt = Date.now() + retryDelayMs;
+			}
+		}
+
+		if (!this.fallbackSubscriber) {
+			return {
+				success: false,
+				retryDelayMs: this.primarySubscriberNextAttemptAt - Date.now(),
+			};
+		}
+
+		try {
+			const batch = await this.fallbackSubscriber.getNextBatch(size);
+			if (this.fallbackSubscriberFailedAttempts > 0) {
+				this.logger.info("Fallback subscriber recovered");
+			}
+			this.fallbackSubscriberFailedAttempts = 0;
+			return { success: true, batch, activeSubscriber: this.fallbackSubscriber };
+		} catch (error) {
+			if (abortSignal.aborted) {
+				return { success: false, retryDelayMs: 0 };
 			}
 
-			return { success: false, error: error as Error };
+			if (this.fallbackSubscriberFailedAttempts === 0) {
+				this.logger.error("Fallback subscriber failed", {
+					"aiki.error": error instanceof Error ? error.message : String(error),
+				});
+			}
+
+			this.fallbackSubscriberFailedAttempts++;
+
+			return {
+				success: false,
+				retryDelayMs: this.fallbackSubscriber.getNextDelay({
+					type: "retry",
+					attemptNumber: this.fallbackSubscriberFailedAttempts,
+				}),
+			};
 		}
 	}
 

--- a/types/client.ts
+++ b/types/client.ts
@@ -20,7 +20,18 @@ export interface Client<AppContext = null> {
 	};
 }
 
+/**
+ * Wraps each method of an API contract with an additional `{ signal }` option,
+ * reflecting orpc's runtime client behaviour. Lets callers cancel in-flight
+ * requests without polluting the wire contract types.
+ */
+type WithClientOptions<T> = {
+	[K in keyof T]: T[K] extends (input: infer I) => Promise<infer O>
+		? (input: I, options?: { signal?: AbortSignal }) => Promise<O>
+		: T[K];
+};
+
 export interface ApiClient {
-	workflowRun: WorkflowRunApi;
-	schedule: ScheduleApi;
+	workflowRun: WithClientOptions<WorkflowRunApi>;
+	schedule: WithClientOptions<ScheduleApi>;
 }

--- a/types/subscriber.ts
+++ b/types/subscriber.ts
@@ -12,7 +12,7 @@ export type SubscriberDelayParams = { type: "no_work" } | { type: "retry"; attem
 
 export interface Subscriber {
 	getNextDelay: (context: SubscriberDelayParams) => number;
-	getNextBatch: (size: number) => Promise<WorkflowRunBatch[]>;
+	getNextBatch: (size: number, options?: { abortSignal?: AbortSignal }) => Promise<WorkflowRunBatch[]>;
 	heartbeat?: (workflowRunId: WorkflowRunId) => Promise<void>;
 	acknowledge?: (workflowRunId: WorkflowRunId) => Promise<void>;
 	close?: () => Promise<void>;


### PR DESCRIPTION
## Motivation

A worker pulls workflow runs from a user-supplied **primary subscriber** (typically Redis-backed, using a blocking pop) and a built-in HTTP **fallback subscriber**. The worker's main loop calls `getNextBatch` on these and dispatches whatever it gets.

The previous loop kept a single counter of **consecutive batch-fetch errors**, reset on any successful response. Inside `fetchNextWorkflowRunBatch`, the fallback was only consulted once that counter (as passed in) was ≥ 2.

When Redis was unreachable, the cycle was:

1. Primary throws → counter `0→1`, fallback not yet tried → delay ≈ rand × 1s.
2. Primary throws → counter `1→2`, fallback not yet tried → delay ≈ rand × 2s.
3. Primary throws, fallback tried this iteration → fallback returns an empty batch (server's fine, just no work) → success → counter resets to 0 → fallback's `no_work` delay (1s).
4. Repeat.

Three primary errors per cycle, ~2–4 seconds per cycle, forever. Exponential backoff never escalated past attempt 2 because the fallback-rescued empty batch reset the counter. The single counter couldn't tell "primary is broken" from "no work right now" — and a fallback-rescued empty batch was the second, so it cleared everything.

## Solution

Track each subscriber separately, and gate primary access on a scheduled retry time:

- `primarySubscriberFailedAttempts` / `fallbackSubscriberFailedAttempts` — per-subscriber consecutive error counts.
- `primarySubscriberNextAttemptAt` — epoch ms; primary is only attempted when `Date.now() >= this`.

Per iteration:

1. If primary is due, try it. On success reset both counters and the timestamp; on failure bump the primary counter and push `nextAttemptAt` out by primary's own retry delay, then fall through.
2. Otherwise (primary not due, or primary failed and fallback exists), try fallback. Success/failure updates the fallback counter; failure also returns its own retry delay.
3. If primary failed and there's no fallback, the failure response returns `nextAttemptAt - now` so the loop sleeps exactly until primary is allowed to retry.

The failure response carries `retryDelayMs`, so the loop just does `nextDelayMs = response.retryDelayMs` without knowing which subscriber it came from. `activeSubscriber` (whoever produced the batch) is still tracked separately so in-flight workflow runs use it for heartbeats and acks.

Resetting *both* counters on primary success matters: otherwise a stale fallback count from an earlier outage would inflate the backoff of the next fresh fallback failure long after primary recovered.

## Cancellable batch fetches

`Subscriber.getNextBatch` now takes an optional `{ abortSignal }` second arg, which the worker loop forwards on every call. The HTTP subscriber threads it into the orpc client (`{ signal }`) so the underlying fetch is cancelled on shutdown. The Redis subscriber accepts it for interface conformance — its existing `close()` / `disconnect()` already cancels in-flight blocking commands.

Without this, an HTTP-primary worker would hang on SIGINT whenever the loop was mid-fetch: the fetch wasn't cancellable, so `_stop` blocked indefinitely if the server was unreachable.

## Other changes bundled here

- **Fallback isn't instantiated** when no custom subscriber is supplied — the primary already is the HTTP subscriber in that case.
- **Logs only on transitions**: each subscriber logs `failed` on `0→1` and `recovered` on `>0→0`. Cuts log spam from per-iteration to two events per outage.
- **`close()` calls run concurrently** in shutdown.
- **Consume ioredis connection-level `error` events** with a no-op listener so ioredis stops logging "Unhandled error event". Command-level errors still propagate as rejected promises, so visibility is preserved.
- Field rename `subscriber` → `primarySubscriber` for symmetry with `fallbackSubscriber`.
