### PR TITLE
Watchdog reconnect for stuck Redis connections

### DIFF
--- a/docs/architecture/subscribers.md
+++ b/docs/architecture/subscribers.md
@@ -181,9 +181,9 @@ Work stealing is safe. Re-executing a workflow doesn't cause duplicate side effe
 
 **Choosing `claimMinIdleTimeMs`**: Set this higher than the heartbeat interval. Workers refresh their claim every heartbeat, so a run only becomes "idle" when a worker stops heartbeating (crashes or hangs). The default of 90 seconds with 30-second heartbeats gives plenty of margin.
 
-### Fallback Subscriber
+### Backup Subscriber
 
-Workers automatically create a fallback DB subscriber alongside the primary subscriber. If the primary subscriber fails repeatedly (2+ consecutive errors), the worker switches to the DB fallback to maintain availability. This ensures workflow execution continues even if an external dependency like Redis goes down.
+Workers automatically create a backup http subscriber alongside the primary subscriber. If the primary subscriber fails, the worker switches to the backup to maintain availability. This ensures workflow execution continues even if an external dependency like Redis goes down.
 
 ## Next Steps
 

--- a/sdk/transport/redis/subscriber.ts
+++ b/sdk/transport/redis/subscriber.ts
@@ -59,17 +59,19 @@ return results
 
 export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber {
 	const { options } = params;
+	const intervalMs = 1_000;
 	const maxRetryIntervalMs = options?.maxRetryIntervalMs ?? 30_000;
+	const connectTimeoutMs = options?.connectTimeoutMs ?? 5_000;
 
 	const getNextDelay = (delayParams: SubscriberDelayParams) => {
 		switch (delayParams.type) {
 			case "no_work":
-				return 0;
+				return intervalMs;
 			case "retry": {
 				const retryParams = getRetryParams(delayParams.attemptNumber, {
 					type: "jittered",
 					maxAttempts: Number.POSITIVE_INFINITY,
-					baseDelayMs: 1_000,
+					baseDelayMs: intervalMs,
 					maxDelayMs: maxRetryIntervalMs,
 				});
 				if (!retryParams.retriesLeft) {
@@ -83,7 +85,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 	};
 
 	return (context: SubscriberContext): Subscriber => {
-		const { workflows, shards } = context;
+		const { workflows, shards, logger } = context;
 
 		const redis = new Redis({
 			host: params.host,
@@ -92,17 +94,52 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 			db: params.db,
 			maxRetriesPerRequest: 0,
 			enableOfflineQueue: false,
-			connectTimeout: options?.connectTimeoutMs,
+			connectTimeout: connectTimeoutMs,
 		});
 
+		type State =
+			| { status: "disconnected" }
+			| { status: "awaiting_ready"; readyWatchdog: ReturnType<typeof setTimeout> }
+			| { status: "connected" }
+			| { status: "closed" };
+
+		let currentState: State = { status: "disconnected" };
+
+		const transitionTo = (nextStatus: State["status"]) => {
+			if (currentState.status === "closed") {
+				return;
+			}
+			if (currentState.status === "awaiting_ready") {
+				clearTimeout(currentState.readyWatchdog);
+			}
+			if (nextStatus === "awaiting_ready") {
+				currentState = { status: "awaiting_ready", readyWatchdog: setTimeout(onReadyCheckTimeout, connectTimeoutMs) };
+			} else {
+				currentState = { status: nextStatus };
+			}
+			if (nextStatus === "closed") {
+				redis.disconnect();
+			}
+		};
+
+		const onReadyCheckTimeout = () => {
+			logger.warn("Redis ready check timed out, forcing reconnect");
+			redis.disconnect(true);
+		};
+
 		redis.on("error", () => {});
+		redis.on("connect", () => transitionTo("awaiting_ready"));
+		redis.on("ready", () => {
+			logger.info("Redis connection established");
+			transitionTo("connected");
+		});
+		redis.on("close", () => transitionTo("disconnected"));
 
 		const queueNames = getWorkflowQueueNames(workflows, shards);
-		let closed = false;
 
 		return {
 			getNextDelay,
-			async getNextBatch(size: number, _options?: { abortSignal?: AbortSignal }): Promise<WorkflowRunBatch[]> {
+			async getNextBatch(size: number): Promise<WorkflowRunBatch[]> {
 				const shuffledQueueNames = shuffleArray(queueNames);
 				const firstItem = (await redis.bzpopmin(...shuffledQueueNames, 0)) as
 					| [key: string, member: WorkflowRunId, score: string]
@@ -130,11 +167,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 				return batch;
 			},
 			async close(): Promise<void> {
-				if (closed) {
-					return;
-				}
-				closed = true;
-				redis.disconnect();
+				transitionTo("closed");
 			},
 		};
 	};

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -4,7 +4,7 @@ import { createBinaryLatch, delay } from "@aikirun/lib/async";
 import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
 import type { Client } from "@aikirun/types/client";
 import type { Logger } from "@aikirun/types/logger";
-import type { CreateSubscriber, Subscriber, SubscriberContext, WorkflowRunBatch } from "@aikirun/types/subscriber";
+import type { CreateSubscriber, Subscriber, WorkflowRunBatch } from "@aikirun/types/subscriber";
 import type { WorkerId } from "@aikirun/types/worker";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRun, WorkflowRunId } from "@aikirun/types/workflow-run";
@@ -123,11 +123,11 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 	private readonly logger: Logger;
 	private abortController: AbortController | undefined;
 	private primarySubscriber: Subscriber | undefined;
-	private fallbackSubscriber: Subscriber | undefined;
+	private backupSubscriber: Subscriber | undefined;
 	private subscriberLoopPromise: Promise<void> | undefined;
 	private primarySubscriberFailedAttempts = 0;
 	private primarySubscriberNextAttemptAt = 0;
-	private fallbackSubscriberFailedAttempts = 0;
+	private backupSubscriberFailedAttempts = 0;
 	private availableCapacityLatch = createBinaryLatch();
 	private pendingWorkflowRunIds = new Set<string>();
 	private activeWorkflowRunsById = new Map<string, ActiveWorkflowRun>();
@@ -160,26 +160,29 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 			throw new Error("No workflow registered");
 		}
 
-		const subscriberContext: SubscriberContext = {
+		const createSubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
+		const primarySubscriber = createSubscriber({
 			workerId: this.id,
 			workflows,
 			shards: this.spawnOptions.shards,
-			logger: this.logger,
-		};
-
-		const createSubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
-		const primarySubscriber = createSubscriber(subscriberContext);
+			logger: this.logger.child({ "aiki.subscriber": "primary" }),
+		});
 		this.primarySubscriber = primarySubscriber instanceof Promise ? await primarySubscriber : primarySubscriber;
 		this.primarySubscriber.heartbeat = this.withServerHeartbeatForwarding(
 			this.primarySubscriber.heartbeat?.bind(this.primarySubscriber)
 		);
 
 		if (!this.params.subscriber) {
-			const createFallbackSubscriber = httpSubscriber({ api: this.client.api });
-			const fallbackSubscriber = createFallbackSubscriber(subscriberContext);
-			this.fallbackSubscriber = fallbackSubscriber instanceof Promise ? await fallbackSubscriber : fallbackSubscriber;
-			this.fallbackSubscriber.heartbeat = this.withServerHeartbeatForwarding(
-				this.fallbackSubscriber.heartbeat?.bind(this.fallbackSubscriber)
+			const createBackupSubscriber = httpSubscriber({ api: this.client.api });
+			const backupSubscriber = createBackupSubscriber({
+				workerId: this.id,
+				workflows,
+				shards: this.spawnOptions.shards,
+				logger: this.logger.child({ "aiki.subscriber": "backup" }),
+			});
+			this.backupSubscriber = backupSubscriber instanceof Promise ? await backupSubscriber : backupSubscriber;
+			this.backupSubscriber.heartbeat = this.withServerHeartbeatForwarding(
+				this.backupSubscriber.heartbeat?.bind(this.backupSubscriber)
 			);
 		}
 
@@ -208,7 +211,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		this.abortController?.abort();
 		this.availableCapacityLatch.signal();
 
-		await Promise.all([this.primarySubscriber?.close?.(), this.fallbackSubscriber?.close?.()]);
+		await Promise.all([this.primarySubscriber?.close?.(), this.backupSubscriber?.close?.()]);
 
 		await this.subscriberLoopPromise;
 
@@ -317,11 +320,8 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		if (Date.now() >= this.primarySubscriberNextAttemptAt) {
 			try {
 				const batch = await this.primarySubscriber.getNextBatch(size, { abortSignal });
-				if (this.primarySubscriberFailedAttempts > 0) {
-					this.logger.info("Primary subscriber recovered");
-				}
 				this.primarySubscriberFailedAttempts = 0;
-				this.fallbackSubscriberFailedAttempts = 0;
+				this.backupSubscriberFailedAttempts = 0;
 				this.primarySubscriberNextAttemptAt = 0;
 				return { success: true, batch, activeSubscriber: this.primarySubscriber };
 			} catch (error) {
@@ -329,11 +329,10 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 					return { success: false, retryDelayMs: 0 };
 				}
 
-				if (this.primarySubscriberFailedAttempts === 0) {
-					this.logger.error("Primary subscriber failed", {
-						"aiki.error": error instanceof Error ? error.message : String(error),
-					});
-				}
+				this.logger.error("Subscriber failed", {
+					"aiki.subscriber": "primary",
+					"aiki.error": error instanceof Error ? error.message : String(error),
+				});
 
 				this.primarySubscriberFailedAttempts++;
 				const retryDelayMs = this.primarySubscriber.getNextDelay({
@@ -344,7 +343,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 			}
 		}
 
-		if (!this.fallbackSubscriber) {
+		if (!this.backupSubscriber) {
 			return {
 				success: false,
 				retryDelayMs: this.primarySubscriberNextAttemptAt - Date.now(),
@@ -352,30 +351,26 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		}
 
 		try {
-			const batch = await this.fallbackSubscriber.getNextBatch(size, { abortSignal });
-			if (this.fallbackSubscriberFailedAttempts > 0) {
-				this.logger.info("Fallback subscriber recovered");
-			}
-			this.fallbackSubscriberFailedAttempts = 0;
-			return { success: true, batch, activeSubscriber: this.fallbackSubscriber };
+			const batch = await this.backupSubscriber.getNextBatch(size, { abortSignal });
+			this.backupSubscriberFailedAttempts = 0;
+			return { success: true, batch, activeSubscriber: this.backupSubscriber };
 		} catch (error) {
 			if (abortSignal.aborted) {
 				return { success: false, retryDelayMs: 0 };
 			}
 
-			if (this.fallbackSubscriberFailedAttempts === 0) {
-				this.logger.error("Fallback subscriber failed", {
-					"aiki.error": error instanceof Error ? error.message : String(error),
-				});
-			}
+			this.logger.error("Subscriber failed", {
+				"aiki.subscriber": "backup",
+				"aiki.error": error instanceof Error ? error.message : String(error),
+			});
 
-			this.fallbackSubscriberFailedAttempts++;
+			this.backupSubscriberFailedAttempts++;
 
 			return {
 				success: false,
-				retryDelayMs: this.fallbackSubscriber.getNextDelay({
+				retryDelayMs: this.backupSubscriber.getNextDelay({
 					type: "retry",
-					attemptNumber: this.fallbackSubscriberFailedAttempts,
+					attemptNumber: this.backupSubscriberFailedAttempts,
 				}),
 			};
 		}


### PR DESCRIPTION
## Motivation

The Redis subscriber uses `bzpopmin(timeout: 0)` to block until work arrives. The expected ioredis lifecycle is `connect` (TCP up) → `ready` (internal `INFO` check passes) → commands flow. When the connection drops, ioredis reconnects on its own.

There's a gap in this lifecycle that's reliably hit when a Redis Docker container restarts: Docker's port proxy accepts the TCP handshake while the container is still starting, so ioredis emits `connect` and sends its `INFO` ready check — but nothing replies. The client sits in `connect` state indefinitely. ioredis has no built-in timeout for the `connect` → `ready` window, so the blocking `bzpopmin` hangs until the OS-level TCP keepalive eventually kills the socket (minutes to hours).

## Solution

Wrap ioredis with a connection state machine (`disconnected | awaiting_ready | connected | closed`) and a watchdog timer for the `connect` → `ready` gap.

On `connect`, transition to `awaiting_ready` and arm the watchdog (defaults to 5s, or `connectTimeoutMs` when provided). On `ready`, transition to `connected`. On `close`, transition to `disconnected`. In all cases, leaving `awaiting_ready` cancels the watchdog.

If the watchdog fires, call `redis.disconnect(true)` — this tears down the stalled socket and lets ioredis re-establish via its built-in retry path. The cycle repeats until the Redis container is fully up and the ready check passes.

Closing the subscriber transitions to `closed`, which cancels any active watchdog and calls `redis.disconnect()` (without `reconnect`), preventing further reconnection.

## Other changes

- Per-subscriber logger tagging (`aiki.subscriber: "primary" | "backup"`) so logs from each subscriber instance can be distinguished.
- Subscriber failure logs now emit on every attempt instead of only the first in a streak. The "recovered" logs are removed — recovery is implicit in the errors stopping and the `Redis connection established` log from the state machine.
- `no_work` delay changed from 0 to 1s in the Redis subscriber. The worker loop awaits this delay before the first `getNextBatch`, giving ioredis time to reach `ready` and avoiding a startup-race `Stream isn't writeable` error from `enableOfflineQueue: false`.
- Rename fallback subscriber to backup.
