### PR TITLE
Outbox lifecycle follow-up

### DIFF
--- a/examples/workflows/retry-until-success.ts
+++ b/examples/workflows/retry-until-success.ts
@@ -4,16 +4,16 @@ import { task, workflow } from "@aikirun/workflow";
  * Demonstrates task retry. The task fails twice then succeeds on the 3rd attempt.
  */
 
-let attempts = 0;
+let tasAttempts = 0;
 
 const unreliableTask = task({
 	name: "unreliable-task",
 	async handler() {
-		attempts++;
-		if (attempts <= 2) {
-			throw new Error(`Failed (attempt ${attempts})`);
+		tasAttempts++;
+		if (tasAttempts <= 2) {
+			throw new Error(`Failed (attempt ${tasAttempts})`);
 		}
-		attempts = 0;
+		tasAttempts = 0;
 		return { ok: true };
 	},
 	options: {
@@ -21,8 +21,17 @@ const unreliableTask = task({
 	},
 });
 
+let workflowAttempts = 0;
+
 export const retryUntilSuccessV1 = workflow({ name: "retry-until-success" }).v("1.0.0", {
 	async handler(run) {
-		return unreliableTask.start(run);
+		workflowAttempts++;
+		if (workflowAttempts <= 1) {
+			throw new Error(`Workflow (attempt ${workflowAttempts})`);
+		}
+		await unreliableTask.start(run);
+	},
+	options: {
+		retry: { type: "exponential", maxAttempts: Number.MAX_SAFE_INTEGER, baseDelayMs: 500 },
 	},
 });

--- a/sdk/transport/http/subscriber.ts
+++ b/sdk/transport/http/subscriber.ts
@@ -22,7 +22,7 @@ export interface HttpSubscriberOptions {
 
 export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 	const { api, options } = params;
-	const intervalMs = options?.intervalMs ?? 5_000;
+	const intervalMs = options?.intervalMs ?? 1_000;
 	const maxRetryIntervalMs = options?.maxRetryIntervalMs ?? 30_000;
 	const claimMinIdleTimeMs = options?.claimMinIdleTimeMs ?? 90_000;
 

--- a/server/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/server/infra/db/pg/repository/workflow-run-outbox.ts
@@ -13,6 +13,7 @@ import { workflowRunOutbox } from "../schema";
 
 export type WorkflowRunOutboxRow = typeof workflowRunOutbox.$inferSelect;
 export type WorkflowRunOutboxRowInsert = typeof workflowRunOutbox.$inferInsert;
+export type WorkflowRunOutboxRowPublished = WorkflowRunOutboxRow & { status: "published"; publishedAt: Date };
 export type WorkflowRunOutboxRowClaimed = WorkflowRunOutboxRow & { status: "claimed"; claimedAt: Date };
 
 interface ClaimFilter {
@@ -110,11 +111,11 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			claimMinIdleTimeMs: number,
 			limit: number,
 			cursor?: TimerStreamCursor
-		): Promise<WorkflowRunOutboxRow[]> {
+		): Promise<WorkflowRunOutboxRowPublished[]> {
 			const now = Date.now();
 			const staleThreshold = new Date(now - claimMinIdleTimeMs);
 
-			return db
+			const rows = await db
 				.select()
 				.from(workflowRunOutbox)
 				.where(
@@ -126,6 +127,8 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 				)
 				.orderBy(workflowRunOutbox.publishedAt, workflowRunOutbox.id)
 				.limit(limit);
+
+			return rows as WorkflowRunOutboxRowPublished[];
 		},
 
 		async listStaleClaimed(
@@ -195,39 +198,29 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 				.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
 		},
 
-		async claimStalePublished(namespaceId: string, filters: ClaimFilter, claimMinIdleTimeMs: number, limit: number) {
-			const now = Date.now();
-			const staleThreshold = new Date(now - claimMinIdleTimeMs);
-
-			const staleEntries = await db
+		async claimPublished(namespaceId: string, filters: ClaimFilter, limit: number) {
+			const entries = await db
 				.select({ id: workflowRunOutbox.id })
 				.from(workflowRunOutbox)
 				.where(
 					and(
 						eq(workflowRunOutbox.namespaceId, namespaceId),
 						eq(workflowRunOutbox.status, "published"),
-						lt(workflowRunOutbox.publishedAt, staleThreshold),
 						buildClaimFilterPredicate(filters)
 					)
 				)
-				.orderBy(workflowRunOutbox.publishedAt, workflowRunOutbox.rank, workflowRunOutbox.id)
+				.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
 				.limit(limit);
 
-			const staleEntryIds = staleEntries.map(({ id }) => id);
-			if (!isNonEmptyArray(staleEntryIds)) {
+			const entryIds = entries.map(({ id }) => id);
+			if (!isNonEmptyArray(entryIds)) {
 				return [];
 			}
 
 			return db
 				.update(workflowRunOutbox)
-				.set({ status: "claimed", claimedAt: new Date(now) })
-				.where(
-					and(
-						eq(workflowRunOutbox.status, "published"),
-						inArray(workflowRunOutbox.id, staleEntryIds),
-						lt(workflowRunOutbox.publishedAt, staleThreshold)
-					)
-				)
+				.set({ status: "claimed", claimedAt: new Date() })
+				.where(and(eq(workflowRunOutbox.status, "published"), inArray(workflowRunOutbox.id, entryIds)))
 				.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
 		},
 

--- a/server/infra/db/pg/schema/aiki.ts
+++ b/server/infra/db/pg/schema/aiki.ts
@@ -399,14 +399,15 @@ export const workflowRunOutbox = pgTable(
 
 		status: workflowRunOutboxStatusEnum("status").notNull(),
 
+		publishedAt: timestamp("published_at", { withTimezone: true }),
+		claimedAt: timestamp("claimed_at", { withTimezone: true }),
+
 		createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 		updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-		publishedAt: timestamp("published_at", { withTimezone: true }).notNull().defaultNow(),
-		claimedAt: timestamp("claimed_at", { withTimezone: true }),
 	},
 	(table) => [
 		uniqueIndex("uqidx_workflow_run_outbox_workflow_run_id").on(table.workflowRunId),
-		index("idx_workflow_run_outbox_pending").on(
+		index("idx_workflow_run_outbox_status_workflow_rank_id").on(
 			table.namespaceId,
 			table.status,
 			table.workflowName,
@@ -415,17 +416,7 @@ export const workflowRunOutbox = pgTable(
 			table.rank,
 			table.id
 		),
-		index("idx_workflow_run_outbox_published").on(
-			table.namespaceId,
-			table.status,
-			table.workflowName,
-			table.workflowVersionId,
-			table.shard,
-			table.publishedAt,
-			table.rank,
-			table.id
-		),
-		index("idx_workflow_run_outbox_claimed").on(
+		index("idx_workflow_run_outbox_status_workflow_claimed_rank_id").on(
 			table.namespaceId,
 			table.status,
 			table.workflowName,
@@ -438,6 +429,10 @@ export const workflowRunOutbox = pgTable(
 		index("idx_workflow_run_outbox_status_rank_id").on(table.status, table.rank, table.id),
 		index("idx_workflow_run_outbox_status_published_id").on(table.status, table.publishedAt, table.id),
 		index("idx_workflow_run_outbox_status_claimed_id").on(table.status, table.claimedAt, table.id),
+		check(
+			"chk_workflow_run_outbox_published_requires_published_at",
+			sql`${table.status} != 'published' OR ${table.publishedAt} IS NOT NULL`
+		),
 		check(
 			"chk_workflow_run_outbox_claimed_requires_claimed_at",
 			sql`${table.status} != 'claimed' OR ${table.claimedAt} IS NOT NULL`

--- a/server/infra/db/types/workflow-run-outbox.ts
+++ b/server/infra/db/types/workflow-run-outbox.ts
@@ -3,4 +3,5 @@ export type {
 	WorkflowRunOutboxRow,
 	WorkflowRunOutboxRowClaimed,
 	WorkflowRunOutboxRowInsert,
+	WorkflowRunOutboxRowPublished,
 } from "../pg/repository/workflow-run-outbox";

--- a/server/service/workflow-run-outbox.ts
+++ b/server/service/workflow-run-outbox.ts
@@ -25,9 +25,9 @@ export function createWorkflowRunOutboxService(deps: WorkflowRunOutboxServiceDep
 		);
 	}
 
-	async function claimStalePublished(
+	async function claimPublished(
 		context: NamespaceRequestContext,
-		request: Omit<WorkflowRunClaimReadyRequestV1, "limit">,
+		request: Pick<WorkflowRunClaimReadyRequestV1, "workflows" | "shards">,
 		limit: number
 	) {
 		const workflows = request.workflows;
@@ -35,12 +35,7 @@ export function createWorkflowRunOutboxService(deps: WorkflowRunOutboxServiceDep
 			return [];
 		}
 
-		return repos.workflowRunOutbox.claimStalePublished(
-			context.namespaceId,
-			{ workflows, shards: request.shards },
-			request.claimMinIdleTimeMs,
-			limit
-		);
+		return repos.workflowRunOutbox.claimPublished(context.namespaceId, { workflows, shards: request.shards }, limit);
 	}
 
 	async function claimPending(
@@ -63,8 +58,8 @@ export function createWorkflowRunOutboxService(deps: WorkflowRunOutboxServiceDep
 		const stolenEntries = await stealStaleClaimed(context, request);
 		let remainingSlots = request.limit - stolenEntries.length;
 
-		const stalePublishedEntries = remainingSlots > 0 ? await claimStalePublished(context, request, remainingSlots) : [];
-		remainingSlots -= stalePublishedEntries.length;
+		const publishedEntries = remainingSlots > 0 ? await claimPublished(context, request, remainingSlots) : [];
+		remainingSlots -= publishedEntries.length;
 
 		const pendingEntries =
 			remainingSlots > 0
@@ -79,7 +74,7 @@ export function createWorkflowRunOutboxService(deps: WorkflowRunOutboxServiceDep
 		for (const entry of stolenEntries) {
 			runs.push({ id: entry.workflowRunId });
 		}
-		for (const entry of stalePublishedEntries) {
+		for (const entry of publishedEntries) {
 			runs.push({ id: entry.workflowRunId });
 		}
 		for (const entry of pendingEntries) {


### PR DESCRIPTION
Follow-up to #20. After running with the new outbox lifecycle, two reflections:

- **`published_at` was being filled for pending rows.** It defaulted to `now()` at insert, claiming "we just published" even though no push had happened. Fix: column is nullable with no default; a new CHECK constraint enforces `published ⇒ published_at IS NOT NULL`. Pending rows now honestly have `published_at = null` until `markPublished` fires.

- **The outbox `published` state is just a durable queue of ready runs.** A worker claims a ready run from that queue; whether it found out about it via the push subscriber or by polling the HTTP claim endpoint is incidental. There's no semantic difference between the two transports from the queue's perspective, and the queue shouldn't treat them asymmetrically. But the HTTP path carried a staleness check that made it wait before claiming, while the push subscriber could claim immediately. That asymmetry had no real rationale, and it caused starvation as a side effect: whichever column HTTP filtered on for staleness was a column the server's own republish kept refreshing, in every iteration of this design (pre-#20 on `updated_at`, in #20 on `published_at`). Fix: HTTP claim filters on `status = 'published'` only, no staleness. Any unclaimed published row is claimable, regardless of how the worker is reading the queue.

Also: `claimPublished` orders by `(rank, id)` only — rank already encodes time-derived priority so a separate `published_at` ordering would be redundant. With the staleness check gone, the pending and published claim indexes had identical shape and were consolidated into one (`idx_workflow_run_outbox_status_workflow_rank_id`). `listStalePublished` returns a narrowed `WorkflowRunOutboxRowPublished` type backed by the new CHECK, so callers get `publishedAt: Date` without a guard. HTTP subscriber polling interval also dropped to 1s.
