### PR TITLE
Per-file transaction migrator

### DIFF
--- a/server/infra/db/migrate.ts
+++ b/server/infra/db/migrate.ts
@@ -1,0 +1,22 @@
+import { migratePg } from "./pg/migrate";
+import { loadConfig } from "../../config";
+import { createLogger } from "../logger";
+
+const config = await loadConfig();
+const logger = createLogger(config.logLevel, config.prettyLogs);
+
+const { database } = config;
+
+switch (database.provider) {
+	case "pg":
+		await migratePg(database, logger);
+		break;
+	case "sqlite":
+		throw new Error("SQLite migrations not yet implemented");
+	case "mysql":
+		throw new Error("MySQL migrations not yet implemented");
+	default:
+		database satisfies never;
+}
+
+logger.info("migrations applied");

--- a/server/infra/db/pg/migrate.ts
+++ b/server/infra/db/pg/migrate.ts
@@ -1,0 +1,49 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sql } from "drizzle-orm";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import type { PgDatabaseConfig } from "server/config/schema";
+
+import { createPgDatabaseConn, type PgDatabaseOptions } from "./provider";
+import type { Logger } from "../../logger";
+
+const migrationsFolder = join(dirname(fileURLToPath(import.meta.url)), "migration");
+
+export async function migratePg(options: PgDatabaseOptions | PgDatabaseConfig, logger: Logger): Promise<void> {
+	const db = createPgDatabaseConn({ ...options, maxConnections: 1 });
+
+	try {
+		await db.execute(sql`CREATE SCHEMA IF NOT EXISTS drizzle`);
+		await db.execute(sql`
+			CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+				id SERIAL PRIMARY KEY,
+				hash text NOT NULL,
+				created_at bigint
+			)
+		`);
+
+		const applied = await db.execute<{ hash: string }>(sql`SELECT hash FROM drizzle.__drizzle_migrations`);
+		const appliedHashes = new Set(applied.map((row) => row.hash));
+
+		const migrations = readMigrationFiles({ migrationsFolder });
+
+		for (const migration of migrations) {
+			if (appliedHashes.has(migration.hash)) {
+				continue;
+			}
+
+			logger.info({ hash: migration.hash.slice(0, 12) }, "applying migration");
+
+			await db.transaction(async (tx) => {
+				for (const statement of migration.sql) {
+					await tx.execute(sql.raw(statement));
+				}
+				await tx.execute(
+					sql`INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (${migration.hash}, ${migration.folderMillis})`
+				);
+			});
+		}
+	} finally {
+		await db.$client.end();
+	}
+}

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
 		"db:generate": "drizzle-kit generate --config infra/db/drizzle.config.ts",
 		"db:generate:custom": "drizzle-kit generate --config infra/db/drizzle.config.ts --custom",
 		"db:migrate": "drizzle-kit migrate --config infra/db/drizzle.config.ts",
+		"db:migrate:debug": "bun run infra/db/migrate.ts",
 		"db:push": "drizzle-kit push --config infra/db/drizzle.config.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Motivation

`drizzle-kit migrate` wraps **all pending migrations in a single outer transaction** — every unapplied file runs as part of the same transaction before any of them is committed. The migration journal lives in `drizzle.__drizzle_migrations`, populated as part of that same transaction.

This breaks on operations Postgres does not allow within a single transaction. Concretely: migration 0007 adds `'claimed'` to an enum (`ALTER TYPE … ADD VALUE`), and migration 0008 references `'claimed'` in a `CHECK` constraint. Postgres rejects this with *"unsafe use of new value … New enum values must be committed before they can be used"*. On a fresh database both files share one outer transaction, so 0007's `ADD VALUE` has not committed when 0008 tries to use it, and the entire migrate run fails.

This is a known upstream bug (drizzle-team/drizzle-orm#3249, #3466). The proposed upstream fix (PR #5199) is still open and unreleased.

## Solution

Add a second migrate path, `db:migrate:debug`, that runs each migration file in its own transaction so the journal commits between files. Hashes are read with drizzle's `readMigrationFiles`, so the journal stays compatible with the stock `drizzle-kit migrate` and the two paths can be used interchangeably.

The entry point follows the existing `createDatabase` dispatch pattern: a top-level switch by provider in `infra/db/migrate.ts`, delegating to a provider-specific migrator next to its `provider.ts`. Only `pg` is implemented; the others throw, matching the rest of the codebase.