### PR TITLE
Unify Redis transport across SDK and server

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "aiki",
       "devDependencies": {
-        "@biomejs/biome": "^2.3.10",
+        "@biomejs/biome": "2.4.9",
         "@changesets/cli": "^2.27.1",
         "@types/node": "^22.10.2",
         "bun-types": "^1.1.38",
@@ -81,6 +81,7 @@
       "name": "@aikirun/server",
       "version": "0.27.0",
       "dependencies": {
+        "@aikirun/redis": "workspace:*",
         "@aikirun/types": "workspace:*",
         "@orpc/contract": "^1.9.3",
         "@orpc/server": "^1.9.3",
@@ -215,23 +216,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.9", "@biomejs/cli-darwin-x64": "2.4.9", "@biomejs/cli-linux-arm64": "2.4.9", "@biomejs/cli-linux-arm64-musl": "2.4.9", "@biomejs/cli-linux-x64": "2.4.9", "@biomejs/cli-linux-x64-musl": "2.4.9", "@biomejs/cli-win32-arm64": "2.4.9", "@biomejs/cli-win32-x64": "2.4.9" }, "bin": { "biome": "bin/biome" } }, "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.15", "", { "os": "linux", "cpu": "x64" }, "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.9", "", { "os": "linux", "cpu": "x64" }, "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.9", "", { "os": "win32", "cpu": "x64" }, "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		]
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.10",
+		"@biomejs/biome": "2.4.9",
 		"@changesets/cli": "^2.27.1",
 		"@types/node": "^22.10.2",
 		"bun-types": "^1.1.38",

--- a/sdk/transport/http/subscriber.ts
+++ b/sdk/transport/http/subscriber.ts
@@ -64,7 +64,7 @@ export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 				);
 
 				return response.runs.map((run) => ({
-					data: { workflowRunId: run.id as WorkflowRunId },
+					data: { id: run.id as WorkflowRunId },
 				}));
 			},
 		};

--- a/sdk/transport/http/subscriber.ts
+++ b/sdk/transport/http/subscriber.ts
@@ -52,7 +52,7 @@ export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 
 		return {
 			getNextDelay,
-			async getNextBatch(size: number, options?: { abortSignal?: AbortSignal }): Promise<WorkflowRunMessage[]> {
+			async getReadyRuns(size: number, options?: { abortSignal?: AbortSignal }): Promise<WorkflowRunMessage[]> {
 				const response = await api.workflowRun.claimReadyV1(
 					{
 						workflows: workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId })),

--- a/sdk/transport/redis/cache/cache.ts
+++ b/sdk/transport/redis/cache/cache.ts
@@ -1,0 +1,39 @@
+import type { Cache, CacheSetOptions } from "@aikirun/types/cache";
+import type { Redis } from "ioredis";
+
+export interface RedisCacheOptions {
+	keyPrefix?: string;
+}
+
+export function redisCache<V>(redis: Redis, options?: RedisCacheOptions): Cache<V> {
+	const keyPrefix = options?.keyPrefix ?? "";
+	const getCacheKey = (key: string) => `${keyPrefix}${key}`;
+
+	return {
+		async get(key: string): Promise<V | null> {
+			const cached = await redis.get(getCacheKey(key));
+			if (!cached) {
+				return null;
+			}
+			return JSON.parse(cached) as V;
+		},
+
+		async set(key: string, value: V, setOptions?: CacheSetOptions): Promise<void> {
+			const cacheKey = getCacheKey(key);
+			const serialized = JSON.stringify(value);
+			if (setOptions?.ttlSeconds !== undefined) {
+				await redis.setex(cacheKey, setOptions.ttlSeconds, serialized);
+			} else {
+				await redis.set(cacheKey, serialized);
+			}
+		},
+
+		async invalidate(keys): Promise<void> {
+			if (Array.isArray(keys)) {
+				await redis.del(...keys.map(getCacheKey));
+			} else {
+				await redis.del(getCacheKey(keys));
+			}
+		},
+	};
+}

--- a/sdk/transport/redis/cache/index.ts
+++ b/sdk/transport/redis/cache/index.ts
@@ -1,0 +1,2 @@
+export type { RedisCacheOptions } from "./cache";
+export { redisCache } from "./cache";

--- a/sdk/transport/redis/connection.ts
+++ b/sdk/transport/redis/connection.ts
@@ -21,6 +21,7 @@ interface RedisConnectionSupervisorOptions {
  */
 export function attachConnectionSupervisor(redis: Redis, options?: RedisConnectionSupervisorOptions) {
 	const logger = options?.logger;
+	const connectTimeoutMs = redis.options.connectTimeout ?? 5_000;
 
 	type State =
 		| { status: "disconnected" }
@@ -45,7 +46,7 @@ export function attachConnectionSupervisor(redis: Redis, options?: RedisConnecti
 		if (nextStatus === "awaiting_ready") {
 			currentState = {
 				status: "awaiting_ready",
-				supervisor: setTimeout(onReadyHandshakeStalled, redis.options.connectTimeout),
+				supervisor: setTimeout(onReadyHandshakeStalled, connectTimeoutMs),
 			};
 		} else {
 			currentState = { status: nextStatus };

--- a/sdk/transport/redis/connection.ts
+++ b/sdk/transport/redis/connection.ts
@@ -1,0 +1,76 @@
+import type { Logger } from "@aikirun/types/logger";
+import type { Redis } from "ioredis";
+
+export interface RedisConnectionParams {
+	host: string;
+	port: number;
+	password?: string;
+	db?: number;
+	connectTimeoutMs?: number;
+}
+
+interface RedisConnectionSupervisorOptions {
+	connectTimeoutMs?: number;
+	logger?: Logger;
+}
+
+/**
+ * Attaches connection-lifecycle supervision to an existing Redis client. The
+ * client is expected to already be configured in fail-fast mode.
+ * Adds a supervisor over the "connect → ready" handshake and forces a reconnect
+ * if that handshake stalls.
+ */
+export function attachConnectionSupervisor(redis: Redis, options?: RedisConnectionSupervisorOptions) {
+	const connectTimeoutMs = options?.connectTimeoutMs ?? 5_000;
+	const logger = options?.logger;
+
+	type State =
+		| { status: "disconnected" }
+		| { status: "awaiting_ready"; supervisor: ReturnType<typeof setTimeout> }
+		| { status: "connected" }
+		| { status: "closed" };
+
+	let currentState: State = { status: "disconnected" };
+
+	const onReadyHandshakeStalled = () => {
+		logger?.warn("Redis connect handshake stalled, forcing reconnect");
+		redis.disconnect(true);
+	};
+
+	const transitionTo = (nextStatus: State["status"]) => {
+		if (currentState.status === "closed") {
+			return;
+		}
+		if (currentState.status === "awaiting_ready") {
+			clearTimeout(currentState.supervisor);
+		}
+		if (nextStatus === "awaiting_ready") {
+			currentState = {
+				status: "awaiting_ready",
+				supervisor: setTimeout(onReadyHandshakeStalled, connectTimeoutMs),
+			};
+		} else {
+			currentState = { status: nextStatus };
+		}
+	};
+
+	const onError = () => {};
+	const onConnect = () => transitionTo("awaiting_ready");
+	const onReady = () => transitionTo("connected");
+	const onClose = () => transitionTo("disconnected");
+
+	redis.on("error", onError);
+	redis.on("connect", onConnect);
+	redis.on("ready", onReady);
+	redis.on("close", onClose);
+
+	return {
+		detach() {
+			transitionTo("closed");
+			redis.off("error", onError);
+			redis.off("connect", onConnect);
+			redis.off("ready", onReady);
+			redis.off("close", onClose);
+		},
+	};
+}

--- a/sdk/transport/redis/connection.ts
+++ b/sdk/transport/redis/connection.ts
@@ -10,7 +10,6 @@ export interface RedisConnectionParams {
 }
 
 interface RedisConnectionSupervisorOptions {
-	connectTimeoutMs?: number;
 	logger?: Logger;
 }
 
@@ -21,7 +20,6 @@ interface RedisConnectionSupervisorOptions {
  * if that handshake stalls.
  */
 export function attachConnectionSupervisor(redis: Redis, options?: RedisConnectionSupervisorOptions) {
-	const connectTimeoutMs = options?.connectTimeoutMs ?? 5_000;
 	const logger = options?.logger;
 
 	type State =
@@ -47,7 +45,7 @@ export function attachConnectionSupervisor(redis: Redis, options?: RedisConnecti
 		if (nextStatus === "awaiting_ready") {
 			currentState = {
 				status: "awaiting_ready",
-				supervisor: setTimeout(onReadyHandshakeStalled, connectTimeoutMs),
+				supervisor: setTimeout(onReadyHandshakeStalled, redis.options.connectTimeout),
 			};
 		} else {
 			currentState = { status: nextStatus };

--- a/sdk/transport/redis/index.ts
+++ b/sdk/transport/redis/index.ts
@@ -1,2 +1,3 @@
-export type { RedisSubscriberOptions, RedisSubscriberParams } from "./subscriber";
-export { redisSubscriber } from "./subscriber";
+export * from "./cache";
+export * from "./timer-sorted-set";
+export * from "./workflow-queue";

--- a/sdk/transport/redis/timer-sorted-set/index.ts
+++ b/sdk/transport/redis/timer-sorted-set/index.ts
@@ -1,0 +1,1 @@
+export { redisTimerSortedSet } from "./timer-sorted-set";

--- a/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
+++ b/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
@@ -116,10 +116,7 @@ export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 				maxRetriesPerRequest: 0,
 				enableOfflineQueue: false,
 			});
-			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, {
-				connectTimeoutMs: redis.options.connectTimeout,
-				logger: context.logger,
-			});
+			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger: context.logger });
 			let closed = false;
 
 			return {

--- a/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
+++ b/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
@@ -1,7 +1,15 @@
-import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NonEmptyArray } from "@aikirun/types/array";
+import type {
+	DueTimer,
+	TimerEntry,
+	TimerSignalWaiter,
+	TimerSignalWaiterContext,
+	TimerSortedSet,
+	TimerType,
+} from "@aikirun/types/timer";
 import type { Redis } from "ioredis";
 
-import type { DueTimer, TimerEntry, TimerSignalWaiter, TimerSortedSet, TimerType } from "../types";
+import { attachConnectionSupervisor } from "../connection";
 
 function encodeMember(type: TimerType, id: string): string {
 	return `${type}:${id}`;
@@ -62,7 +70,7 @@ end
 return minSignal
 `;
 
-export function createTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
+export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 	const signalKey = `${key}:signal`;
 
 	return {
@@ -103,8 +111,9 @@ export function createTimerSortedSet(redis: Redis, key: string): TimerSortedSet 
 			return Number(result[1]);
 		},
 
-		createSignalWaiter(): TimerSignalWaiter {
+		createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter {
 			const redisDuplicate = redis.duplicate();
+			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger: context.logger });
 			let closed = false;
 
 			return {
@@ -134,6 +143,7 @@ export function createTimerSortedSet(redis: Redis, key: string): TimerSortedSet 
 						return;
 					}
 					closed = true;
+					connectionSupervisor.detach();
 					redisDuplicate.disconnect();
 				},
 			};

--- a/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
+++ b/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
@@ -129,12 +129,12 @@ export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 				async wait(timeoutSeconds: number): Promise<number> {
 					const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
 					if (result === null) {
-						await redis.del(signalKey);
+						await redisDuplicate.del(signalKey);
 						return 0;
 					}
 
 					const signal = Number(result[1]);
-					const minSignal = (await redis.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
+					const minSignal = (await redisDuplicate.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
 					if (minSignal === null) {
 						return signal;
 					}

--- a/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
+++ b/sdk/transport/redis/timer-sorted-set/timer-sorted-set.ts
@@ -112,8 +112,14 @@ export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 		},
 
 		createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter {
-			const redisDuplicate = redis.duplicate();
-			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger: context.logger });
+			const redisDuplicate = redis.duplicate({
+				maxRetriesPerRequest: 0,
+				enableOfflineQueue: false,
+			});
+			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, {
+				connectTimeoutMs: redis.options.connectTimeout,
+				logger: context.logger,
+			});
 			let closed = false;
 
 			return {

--- a/sdk/transport/redis/workflow-queue/index.ts
+++ b/sdk/transport/redis/workflow-queue/index.ts
@@ -1,0 +1,3 @@
+export { redisPublisher } from "./publisher";
+export type { RedisSubscriberOptions } from "./subscriber";
+export { redisSubscriber } from "./subscriber";

--- a/sdk/transport/redis/workflow-queue/keys.ts
+++ b/sdk/transport/redis/workflow-queue/keys.ts
@@ -1,0 +1,3 @@
+export function getWorkflowQueueName(name: string, versionId: string, shard?: string): string {
+	return shard ? `aiki:workflow:${name}:${versionId}:${shard}` : `aiki:workflow:${name}:${versionId}`;
+}

--- a/sdk/transport/redis/workflow-queue/publisher.ts
+++ b/sdk/transport/redis/workflow-queue/publisher.ts
@@ -1,3 +1,4 @@
+import type { NonEmptyArray } from "@aikirun/types/array";
 import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/publisher";
 import type { Redis } from "ioredis";
 
@@ -5,7 +6,7 @@ import { getWorkflowQueueName } from "./keys";
 
 export function redisPublisher(redis: Redis): Publisher {
 	return {
-		async publishReadyRuns(runs: ReadyWorkflowRun[]): Promise<void> {
+		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void> {
 			const redisPipeline = redis.pipeline();
 
 			const argsByQueueName = new Map<string, (string | number)[]>();

--- a/sdk/transport/redis/workflow-queue/publisher.ts
+++ b/sdk/transport/redis/workflow-queue/publisher.ts
@@ -1,12 +1,9 @@
+import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
 import type { Redis } from "ioredis";
 
-import type { WorkflowRunPublisher, WorkflowRunReadyMessage } from "../types";
+import { getWorkflowQueueName } from "./keys";
 
-function getWorkflowQueueName(name: string, versionId: string, shard?: string): string {
-	return shard ? `aiki:workflow:${name}:${versionId}:${shard}` : `aiki:workflow:${name}:${versionId}`;
-}
-
-export function createWorkflowRunPublisher(redis: Redis): WorkflowRunPublisher {
+export function redisPublisher(redis: Redis): Publisher {
 	return {
 		async publishReadyRuns(runs: WorkflowRunReadyMessage[]): Promise<void> {
 			const redisPipeline = redis.pipeline();

--- a/sdk/transport/redis/workflow-queue/publisher.ts
+++ b/sdk/transport/redis/workflow-queue/publisher.ts
@@ -1,11 +1,11 @@
-import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
+import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/publisher";
 import type { Redis } from "ioredis";
 
 import { getWorkflowQueueName } from "./keys";
 
 export function redisPublisher(redis: Redis): Publisher {
 	return {
-		async publishReadyRuns(runs: WorkflowRunReadyMessage[]): Promise<void> {
+		async publishReadyRuns(runs: ReadyWorkflowRun[]): Promise<void> {
 			const redisPipeline = redis.pipeline();
 
 			const argsByQueueName = new Map<string, (string | number)[]>();

--- a/sdk/transport/redis/workflow-queue/subscriber.ts
+++ b/sdk/transport/redis/workflow-queue/subscriber.ts
@@ -95,7 +95,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 	};
 
 	return (context: SubscriberContext): Subscriber => {
-		const connectTimeoutMs = params?.connectTimeoutMs ?? 5_000;
+		const connectTimeoutMs = params.connectTimeoutMs ?? 5_000;
 		const { workflows, shards, logger } = context;
 
 		const redis = new Redis({

--- a/sdk/transport/redis/workflow-queue/subscriber.ts
+++ b/sdk/transport/redis/workflow-queue/subscriber.ts
@@ -108,7 +108,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 			connectTimeout: connectTimeoutMs,
 		});
 		redis.on("ready", () => logger.info("Redis connection established"));
-		const connectionSupervisor = attachConnectionSupervisor(redis, { connectTimeoutMs, logger });
+		const connectionSupervisor = attachConnectionSupervisor(redis, { logger });
 
 		const queueNames = getWorkflowQueueNames(workflows, shards);
 

--- a/sdk/transport/redis/workflow-queue/subscriber.ts
+++ b/sdk/transport/redis/workflow-queue/subscriber.ts
@@ -11,16 +11,10 @@ import type { WorkflowMeta } from "@aikirun/types/workflow";
 import type { WorkflowRunId } from "@aikirun/types/workflow-run";
 import { Redis } from "ioredis";
 
-export interface RedisSubscriberParams {
-	host: string;
-	port: number;
-	password?: string;
-	db?: number;
-	options?: RedisSubscriberOptions;
-}
+import { getWorkflowQueueName } from "./keys";
+import { attachConnectionSupervisor, type RedisConnectionParams } from "../connection";
 
 export interface RedisSubscriberOptions {
-	connectTimeoutMs?: number;
 	maxRetryIntervalMs?: number;
 }
 
@@ -57,11 +51,9 @@ end
 return results
 `;
 
-export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber {
-	const { options } = params;
+export function redisSubscriber(params: RedisConnectionParams, options?: RedisSubscriberOptions): CreateSubscriber {
 	const intervalMs = 1_000;
 	const maxRetryIntervalMs = options?.maxRetryIntervalMs ?? 30_000;
-	const connectTimeoutMs = options?.connectTimeoutMs ?? 5_000;
 
 	const getNextDelay = (delayParams: SubscriberDelayParams) => {
 		switch (delayParams.type) {
@@ -85,6 +77,7 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 	};
 
 	return (context: SubscriberContext): Subscriber => {
+		const connectTimeoutMs = params?.connectTimeoutMs ?? 5_000;
 		const { workflows, shards, logger } = context;
 
 		const redis = new Redis({
@@ -96,50 +89,14 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 			enableOfflineQueue: false,
 			connectTimeout: connectTimeoutMs,
 		});
-
-		type State =
-			| { status: "disconnected" }
-			| { status: "awaiting_ready"; readyWatchdog: ReturnType<typeof setTimeout> }
-			| { status: "connected" }
-			| { status: "closed" };
-
-		let currentState: State = { status: "disconnected" };
-
-		const transitionTo = (nextStatus: State["status"]) => {
-			if (currentState.status === "closed") {
-				return;
-			}
-			if (currentState.status === "awaiting_ready") {
-				clearTimeout(currentState.readyWatchdog);
-			}
-			if (nextStatus === "awaiting_ready") {
-				currentState = { status: "awaiting_ready", readyWatchdog: setTimeout(onReadyCheckTimeout, connectTimeoutMs) };
-			} else {
-				currentState = { status: nextStatus };
-			}
-			if (nextStatus === "closed") {
-				redis.disconnect();
-			}
-		};
-
-		const onReadyCheckTimeout = () => {
-			logger.warn("Redis ready check timed out, forcing reconnect");
-			redis.disconnect(true);
-		};
-
-		redis.on("error", () => {});
-		redis.on("connect", () => transitionTo("awaiting_ready"));
-		redis.on("ready", () => {
-			logger.info("Redis connection established");
-			transitionTo("connected");
-		});
-		redis.on("close", () => transitionTo("disconnected"));
+		redis.on("ready", () => logger.info("Redis connection established"));
+		const connectionSupervisor = attachConnectionSupervisor(redis, { connectTimeoutMs, logger });
 
 		const queueNames = getWorkflowQueueNames(workflows, shards);
 
 		return {
 			getNextDelay,
-			async getNextBatch(size: number): Promise<WorkflowRunMessage[]> {
+			async getReadyRuns(size: number): Promise<WorkflowRunMessage[]> {
 				const shuffledQueueNames = shuffleArray(queueNames);
 				const firstItem = (await redis.bzpopmin(...shuffledQueueNames, 0)) as
 					| [key: string, member: WorkflowRunId, score: string]
@@ -167,7 +124,8 @@ export function redisSubscriber(params: RedisSubscriberParams): CreateSubscriber
 				return batch;
 			},
 			async close(): Promise<void> {
-				transitionTo("closed");
+				connectionSupervisor.detach();
+				redis.disconnect();
 			},
 		};
 	};
@@ -181,8 +139,4 @@ function getWorkflowQueueNames(workflows: WorkflowMeta[], shards?: string[]): st
 	return workflows.flatMap((workflow) =>
 		shards.map((shard) => getWorkflowQueueName(workflow.name, workflow.versionId, shard))
 	);
-}
-
-function getWorkflowQueueName(name: string, versionId: string, shard?: string): string {
-	return shard ? `aiki:workflow:${name}:${versionId}:${shard}` : `aiki:workflow:${name}:${versionId}`;
 }

--- a/sdk/transport/redis/workflow-queue/subscriber.ts
+++ b/sdk/transport/redis/workflow-queue/subscriber.ts
@@ -51,6 +51,24 @@ end
 return results
 `;
 
+/**
+ * Builds a Redis-backed subscriber that workers use to pull ready workflow
+ * runs from sorted-set queues.
+ *
+ * The factory takes connection params (rather than a pre-constructed ioredis
+ * client) for two reasons:
+ *
+ * 1. The subscriber requires specific ioredis settings — `maxRetriesPerRequest: 0`
+ *    and `enableOfflineQueue: false` — so that connection failures surface to
+ *    the worker's retry/backoff loop instead of being silently absorbed. These
+ *    settings can only be applied at construction time, so the factory owns
+ *    client creation to guarantee them.
+ *
+ * 2. Each spawned worker gets its own connection. The subscriber uses
+ *    `BZPOPMIN`, a blocking command that ties up the underlying connection
+ *    while it waits, so connections cannot be shared across concurrent
+ *    workers.
+ */
 export function redisSubscriber(params: RedisConnectionParams, options?: RedisSubscriberOptions): CreateSubscriber {
 	const intervalMs = 1_000;
 	const maxRetryIntervalMs = options?.maxRetryIntervalMs ?? 30_000;

--- a/sdk/transport/redis/workflow-queue/subscriber.ts
+++ b/sdk/transport/redis/workflow-queue/subscriber.ts
@@ -123,7 +123,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 					return [];
 				}
 
-				const batch: WorkflowRunMessage[] = [{ data: { workflowRunId: firstItem[1] } }];
+				const batch: WorkflowRunMessage[] = [{ data: { id: firstItem[1] } }];
 
 				const remainingCapacity = size - 1;
 				if (remainingCapacity > 0) {
@@ -135,7 +135,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 					)) as WorkflowRunId[];
 
 					for (const workflowRunId of workflowRunIds) {
-						batch.push({ data: { workflowRunId: workflowRunId } });
+						batch.push({ data: { id: workflowRunId } });
 					}
 				}
 

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -160,8 +160,8 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 			throw new Error("No workflow registered");
 		}
 
-		const createSubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
-		const primarySubscriber = createSubscriber({
+		const createPrimarySubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
+		const primarySubscriber = createPrimarySubscriber({
 			workerId: this.id,
 			workflows,
 			shards: this.spawnOptions.shards,
@@ -319,7 +319,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 
 		if (Date.now() >= this.primarySubscriberNextAttemptAt) {
 			try {
-				const batch = await this.primarySubscriber.getNextBatch(size, { abortSignal });
+				const batch = await this.primarySubscriber.getReadyRuns(size, { abortSignal });
 				this.primarySubscriberFailedAttempts = 0;
 				this.backupSubscriberFailedAttempts = 0;
 				this.primarySubscriberNextAttemptAt = 0;
@@ -351,7 +351,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		}
 
 		try {
-			const batch = await this.backupSubscriber.getNextBatch(size, { abortSignal });
+			const batch = await this.backupSubscriber.getReadyRuns(size, { abortSignal });
 			this.backupSubscriberFailedAttempts = 0;
 			return { success: true, batch, activeSubscriber: this.backupSubscriber };
 		} catch (error) {

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -289,7 +289,7 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 
 			const workflowRunIdsToEnqueue: WorkflowRunId[] = [];
 			for (const { data } of nextBatchResponse.batch) {
-				const { workflowRunId } = data;
+				const { id: workflowRunId } = data;
 				if (!this.pendingWorkflowRunIds.has(workflowRunId) && !this.activeWorkflowRunsById.has(workflowRunId)) {
 					this.pendingWorkflowRunIds.add(workflowRunId);
 					workflowRunIdsToEnqueue.push(workflowRunId);

--- a/server/daemons/due-timers-consumer.ts
+++ b/server/daemons/due-timers-consumer.ts
@@ -2,17 +2,12 @@ import { groupBy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array
 import { streamChunks } from "@aikirun/lib/async";
 import { withRetry } from "@aikirun/lib/retry";
 import type { NamespaceId } from "@aikirun/types/namespace";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { DueTimer, TimerSignalWaiter, TimerSortedSet, TimerType } from "@aikirun/types/timer";
 import type { WorkflowRunStatus } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type { Repositories } from "server/infra/db/types";
 import type { Logger } from "server/infra/logger";
-import type {
-	DueTimer,
-	TimerSignalWaiter,
-	TimerSortedSet,
-	TimerType,
-	WorkflowRunPublisher,
-} from "server/infra/messaging/types";
 import { computeRank, type Ranked, rankDueAtMs } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
 import { createDaemonContext } from "server/middleware/context";
@@ -31,7 +26,7 @@ export interface DueTimersConsumerDeps {
 	repos: Repositories;
 	timerSortedSet: TimerSortedSet;
 	childRunCanceller: ChildRunCanceller;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 }
 
 export interface DueTimersConsumerOptions {
@@ -51,7 +46,7 @@ export function spawnDueTimersConsumer(
 	const abortController = new AbortController();
 	const { signal: abortSignal } = abortController;
 
-	const timerSignalWaiter = deps.timerSortedSet.createSignalWaiter();
+	const timerSignalWaiter = deps.timerSortedSet.createSignalWaiter({ logger });
 
 	const promise = withRetry(
 		() => dueTimersConsumerLoop(logger, deps, timerSignalWaiter, abortSignal, options),

--- a/server/daemons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/daemons/imminent-child-run-wait-timed-out-runs.ts
@@ -1,5 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -9,7 +11,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import type { Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -25,7 +26,7 @@ type Repos = Pick<
 
 export interface ProcessImminentChildRunWaitTimedOutRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -63,7 +64,7 @@ export async function processImminentChildRunWaitTimedOutRuns(
 export async function queueChildRunWaitTimedOutRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -100,7 +101,7 @@ export async function queueChildRunWaitTimedOutRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>

--- a/server/daemons/imminent-event-wait-timed-out-runs.ts
+++ b/server/daemons/imminent-event-wait-timed-out-runs.ts
@@ -1,5 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -9,7 +11,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import type { Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -25,7 +26,7 @@ type Repos = Pick<
 
 export interface ProcessImminentEventWaitTimedOutRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -63,7 +64,7 @@ export async function processImminentEventWaitTimedOutRuns(
 export async function queueEventWaitTimedOutRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -100,7 +101,7 @@ export async function queueEventWaitTimedOutRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>

--- a/server/daemons/imminent-recurring-workflows.ts
+++ b/server/daemons/imminent-recurring-workflows.ts
@@ -2,7 +2,9 @@ import type { NonEmptyArray } from "@aikirun/lib/array";
 import { isNonEmptyArray, partitionArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
 import type { NamespaceId } from "@aikirun/types/namespace";
+import type { Publisher } from "@aikirun/types/publisher";
 import type { Schedule, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import {
 	NON_TERMINAL_WORKFLOW_RUN_STATUSES,
 	type WorkflowRunId,
@@ -16,7 +18,6 @@ import type {
 	WorkflowRunOutboxRowInsert,
 	WorkflowRunRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { computeRank } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
 import type { CancelledParentRun, ChildRunCanceller } from "server/service/cancel-child-runs";
@@ -29,7 +30,7 @@ import { publishRuns } from "./publish-ready-runs";
 export interface ProcessImminentRecurringWorkflowsDeps {
 	repos: Pick<Repositories, "workflowRun" | "stateTransition" | "schedule" | "workflowRunOutbox" | "transaction">;
 	childRunCanceller: ChildRunCanceller;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -144,7 +145,7 @@ async function processOverlapAllowSchedules(
 	repos: ProcessImminentRecurringWorkflowsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>,
 	now: number,
-	workflowRunPublisher?: WorkflowRunPublisher
+	workflowRunPublisher?: Publisher
 ) {
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
@@ -232,7 +233,7 @@ async function processOverlapSkipSchedules(
 	repos: ProcessImminentRecurringWorkflowsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>,
 	now: number,
-	workflowRunPublisher?: WorkflowRunPublisher
+	workflowRunPublisher?: Publisher
 ) {
 	const { scheduleIdsWithActiveRuns } = await fetchActiveRunsBySchedule(repos, schedules);
 

--- a/server/daemons/imminent-retryable-runs.ts
+++ b/server/daemons/imminent-retryable-runs.ts
@@ -1,5 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -8,7 +10,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import type { Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -25,7 +26,7 @@ type Repos = Pick<
 
 export interface ProcessImminentRetryableRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -63,7 +64,7 @@ export async function processImminentRetryableRuns(
 export async function queueRetryableRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -88,7 +89,7 @@ export async function queueRetryableRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/daemons/imminent-retryable-task-runs.ts
+++ b/server/daemons/imminent-retryable-task-runs.ts
@@ -1,6 +1,8 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -9,7 +11,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import { computeRank, type Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -25,7 +26,7 @@ type Repos = Pick<
 
 export interface ProcessImminentRetryableTaskRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -95,7 +96,7 @@ export async function processImminentRetryableTaskRuns(
 export async function queueRetryableTaskRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -120,7 +121,7 @@ export async function queueRetryableTaskRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/daemons/imminent-scheduled-runs.ts
+++ b/server/daemons/imminent-scheduled-runs.ts
@@ -1,5 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/array";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -8,7 +10,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import type { Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -21,7 +22,7 @@ type Repos = Pick<Repositories, "workflowRun" | "workflow" | "stateTransition" |
 
 export interface ProcessImminentScheduledRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -59,7 +60,7 @@ export async function processImminentScheduledRuns(
 export async function queueScheduledRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -96,7 +97,7 @@ export async function queueScheduledRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>

--- a/server/daemons/imminent-sleep-elapsed-runs.ts
+++ b/server/daemons/imminent-sleep-elapsed-runs.ts
@@ -1,4 +1,6 @@
 import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerEntry, TimerSortedSet } from "@aikirun/types/timer";
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow-run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type {
@@ -7,7 +9,6 @@ import type {
 	WorkflowRow,
 	WorkflowRunOutboxRowInsert,
 } from "server/infra/db/types";
-import type { TimerEntry, TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import { runConcurrently } from "server/lib/concurrency";
 import type { Ranked } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
@@ -23,7 +24,7 @@ type Repos = Pick<
 
 export interface ProcessImminentSleepElapsedRunsDeps {
 	repos: Repos;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 }
 
@@ -61,7 +62,7 @@ export async function processImminentSleepElapsedRuns(
 export async function queueSleepElapsedRuns(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	options?: { chunkSize?: number }
 ) {
@@ -86,7 +87,7 @@ export async function queueSleepElapsedRuns(
 async function processChunk(
 	context: DaemonContext,
 	repos: Repos,
-	workflowRunPublisher: WorkflowRunPublisher | undefined,
+	workflowRunPublisher: Publisher | undefined,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {

--- a/server/daemons/index.ts
+++ b/server/daemons/index.ts
@@ -1,8 +1,9 @@
 import { delay } from "@aikirun/lib/async";
 import { withRetry } from "@aikirun/lib/retry";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerSortedSet } from "@aikirun/types/timer";
 import type { Repositories } from "server/infra/db/types";
 import type { Logger } from "server/infra/logger";
-import type { TimerSortedSet, WorkflowRunPublisher } from "server/infra/messaging/types";
 import type { DaemonContext } from "server/middleware/context";
 import { createDaemonContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
@@ -20,7 +21,7 @@ import { republishStaleRuns } from "./republish-stale-runs";
 
 export interface InitDaemonsDeps {
 	repos: Repositories;
-	workflowRunPublisher?: WorkflowRunPublisher;
+	workflowRunPublisher?: Publisher;
 	timerSortedSet?: TimerSortedSet;
 	childRunCanceller: ChildRunCanceller;
 }

--- a/server/daemons/publish-ready-runs.ts
+++ b/server/daemons/publish-ready-runs.ts
@@ -1,14 +1,14 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
+import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
 import type { Repositories, WorkflowRunOutboxRowInsert } from "server/infra/db/types";
-import type { WorkflowRunPublisher, WorkflowRunReadyMessage } from "server/infra/messaging/types";
 import type { DaemonContext } from "server/middleware/context";
 
 import { createRankStreamCursorAdvancer } from "./lib/rank-stream";
 
 export interface PublishReadyRunsDeps {
 	repos: Pick<Repositories, "workflowRunOutbox">;
-	workflowRunPublisher: WorkflowRunPublisher;
+	workflowRunPublisher: Publisher;
 }
 
 const advanceRankStreamCursor = createRankStreamCursorAdvancer<{ id: string; rank: number }>({
@@ -37,7 +37,7 @@ export async function publishReadyRuns(
 export async function publishRuns(
 	context: DaemonContext,
 	repos: Pick<Repositories, "workflowRunOutbox">,
-	workflowRunPublisher: WorkflowRunPublisher,
+	workflowRunPublisher: Publisher,
 	entries: NonEmptyArray<WorkflowRunOutboxRowInsert>
 ): Promise<void> {
 	const entryIds: string[] = [];

--- a/server/daemons/publish-ready-runs.ts
+++ b/server/daemons/publish-ready-runs.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
-import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
+import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/publisher";
 import type { Repositories, WorkflowRunOutboxRowInsert } from "server/infra/db/types";
 import type { DaemonContext } from "server/middleware/context";
 
@@ -41,10 +41,10 @@ export async function publishRuns(
 	entries: NonEmptyArray<WorkflowRunOutboxRowInsert>
 ): Promise<void> {
 	const entryIds: string[] = [];
-	const messages: WorkflowRunReadyMessage[] = [];
+	const runs: ReadyWorkflowRun[] = [];
 	for (const entry of entries) {
 		entryIds.push(entry.id);
-		messages.push({
+		runs.push({
 			id: entry.workflowRunId,
 			name: entry.workflowName,
 			versionId: entry.workflowVersionId,
@@ -53,8 +53,8 @@ export async function publishRuns(
 		});
 	}
 
-	await workflowRunPublisher.publishReadyRuns(messages as NonEmptyArray<WorkflowRunReadyMessage>);
-	context.logger.debug({ count: messages.length }, "Published ready workflow runs");
+	await workflowRunPublisher.publishReadyRuns(runs as NonEmptyArray<ReadyWorkflowRun>);
+	context.logger.debug({ count: runs.length }, "Published ready workflow runs");
 
 	await repos.workflowRunOutbox.markPublished(entryIds as NonEmptyArray<string>);
 }

--- a/server/daemons/republish-stale-runs.ts
+++ b/server/daemons/republish-stale-runs.ts
@@ -1,14 +1,14 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
+import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
 import type { Repositories, WorkflowRunOutboxRow } from "server/infra/db/types";
-import type { WorkflowRunPublisher, WorkflowRunReadyMessage } from "server/infra/messaging/types";
 import type { DaemonContext } from "server/middleware/context";
 
 import { createTimerStreamCursorAdvancer } from "./lib/timer-stream";
 
 export interface RepublishStaleRuns {
 	repos: Pick<Repositories, "workflowRunOutbox">;
-	workflowRunPublisher: WorkflowRunPublisher;
+	workflowRunPublisher: Publisher;
 }
 
 const advanceClaimedCursor = createTimerStreamCursorAdvancer<{ id: string; claimedAt: Date }>({
@@ -57,7 +57,7 @@ export async function republishStaleRuns(
 
 async function republishRuns(
 	context: DaemonContext,
-	workflowRunPublisher: WorkflowRunPublisher,
+	workflowRunPublisher: Publisher,
 	entries: NonEmptyArray<WorkflowRunOutboxRow>
 ): Promise<void> {
 	const messages = entries.map((entry) => ({

--- a/server/daemons/republish-stale-runs.ts
+++ b/server/daemons/republish-stale-runs.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
-import type { Publisher, WorkflowRunReadyMessage } from "@aikirun/types/publisher";
+import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/publisher";
 import type { Repositories, WorkflowRunOutboxRow } from "server/infra/db/types";
 import type { DaemonContext } from "server/middleware/context";
 
@@ -60,14 +60,14 @@ async function republishRuns(
 	workflowRunPublisher: Publisher,
 	entries: NonEmptyArray<WorkflowRunOutboxRow>
 ): Promise<void> {
-	const messages = entries.map((entry) => ({
+	const runs = entries.map((entry) => ({
 		id: entry.workflowRunId,
 		name: entry.workflowName,
 		versionId: entry.workflowVersionId,
 		rank: entry.rank,
 		shard: entry.shard ?? undefined,
-	})) as NonEmptyArray<WorkflowRunReadyMessage>;
+	})) as NonEmptyArray<ReadyWorkflowRun>;
 
-	await workflowRunPublisher.publishReadyRuns(messages);
-	context.logger.debug({ count: messages.length }, "Published ready workflow runs");
+	await workflowRunPublisher.publishReadyRuns(runs);
+	context.logger.debug({ count: runs.length }, "Published ready workflow runs");
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -189,7 +189,7 @@ if (import.meta.main) {
 	const shutdown = () => {
 		if (!shutdownPromise) {
 			shutdownPromise = (async () => {
-				await Promise.all([daemons.shutdown(), timerSortedSet?.close?.(), redis?.quit()]);
+				await Promise.all([daemons.shutdown(), redis?.quit()]);
 				process.exit(0);
 			})();
 		}

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ import {
 	type OrganizationRequestContext,
 } from "./middleware/context";
 import { createNamespaceAuthedRouter, createOrganizationAuthedRouter } from "./router/index";
-import { type CachedApiKeyInfo, createApiKeyService } from "./service/api-key";
+import { type ApiKeyAuthorizationInfo, createApiKeyService } from "./service/api-key";
 import { createAuthService } from "./service/auth";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
 import { createNamespaceService } from "./service/namespace";
@@ -38,7 +38,7 @@ if (import.meta.main) {
 
 	let redis: Redis | undefined;
 
-	let apiKeyCache: Cache<CachedApiKeyInfo> | undefined;
+	let apiKeyCache: Cache<ApiKeyAuthorizationInfo> | undefined;
 	let timerSortedSet: TimerSortedSet | undefined;
 	let workflowRunPublisher: Publisher | undefined;
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -189,7 +189,10 @@ if (import.meta.main) {
 	const shutdown = () => {
 		if (!shutdownPromise) {
 			shutdownPromise = (async () => {
-				await Promise.all([daemons.shutdown(), redis?.quit()]);
+				await daemons.shutdown();
+				if (redis) {
+					await redis.quit();
+				}
 				process.exit(0);
 			})();
 		}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,8 @@
 import process from "node:process";
+import { redisCache, redisPublisher, redisTimerSortedSet } from "@aikirun/redis";
+import type { Cache } from "@aikirun/types/cache";
+import type { Publisher } from "@aikirun/types/publisher";
+import type { TimerSortedSet } from "@aikirun/types/timer";
 import { RPCHandler } from "@orpc/server/fetch";
 import { Redis } from "ioredis";
 
@@ -7,9 +11,6 @@ import { initDaemons } from "./daemons";
 import { UnauthorizedError } from "./errors";
 import { createDatabase } from "./infra/db";
 import { createLogger } from "./infra/logger";
-import { createWorkflowRunPublisher } from "./infra/messaging/redis/publisher";
-import { createTimerSortedSet } from "./infra/messaging/redis/timer-sorted-set";
-import type { TimerSortedSet, WorkflowRunPublisher } from "./infra/messaging/types";
 import { createAuthorizer } from "./middleware/authorization";
 import {
 	createNamespaceRequestContext,
@@ -18,7 +19,7 @@ import {
 	type OrganizationRequestContext,
 } from "./middleware/context";
 import { createNamespaceAuthedRouter, createOrganizationAuthedRouter } from "./router/index";
-import { createApiKeyService } from "./service/api-key";
+import { type CachedApiKeyInfo, createApiKeyService } from "./service/api-key";
 import { createAuthService } from "./service/auth";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
 import { createNamespaceService } from "./service/namespace";
@@ -36,8 +37,10 @@ if (import.meta.main) {
 	const { repos, conn, betterAuthSchema } = createDatabase(config.database);
 
 	let redis: Redis | undefined;
+
+	let apiKeyCache: Cache<CachedApiKeyInfo> | undefined;
 	let timerSortedSet: TimerSortedSet | undefined;
-	let workflowRunPublisher: WorkflowRunPublisher | undefined;
+	let workflowRunPublisher: Publisher | undefined;
 
 	if (config.redis) {
 		redis = new Redis({
@@ -48,11 +51,12 @@ if (import.meta.main) {
 		redis.on("error", (err: Error) => {
 			logger.error({ err }, "Redis connection error");
 		});
-		timerSortedSet = createTimerSortedSet(redis, "aiki:timers");
-		workflowRunPublisher = createWorkflowRunPublisher(redis);
+		apiKeyCache = redisCache(redis, { keyPrefix: "aiki:api_key:" });
+		timerSortedSet = redisTimerSortedSet(redis, "aiki:timers");
+		workflowRunPublisher = redisPublisher(redis);
 	}
 
-	const apiKeyService = createApiKeyService({ repos, redis });
+	const apiKeyService = createApiKeyService({ repos, cache: apiKeyCache });
 	const authService = createAuthService({
 		conn,
 		provider: config.database.provider,
@@ -185,10 +189,7 @@ if (import.meta.main) {
 	const shutdown = () => {
 		if (!shutdownPromise) {
 			shutdownPromise = (async () => {
-				await daemons.shutdown();
-				if (redis) {
-					await redis.quit();
-				}
+				await Promise.all([daemons.shutdown(), timerSortedSet?.close?.(), redis?.quit()]);
 				process.exit(0);
 			})();
 		}

--- a/server/infra/messaging/types/index.ts
+++ b/server/infra/messaging/types/index.ts
@@ -1,2 +1,0 @@
-export * from "./publisher";
-export * from "./timer";

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
 		"db:push": "drizzle-kit push --config infra/db/drizzle.config.ts"
 	},
 	"dependencies": {
+		"@aikirun/redis": "workspace:*",
 		"@aikirun/types": "workspace:*",
 		"@orpc/contract": "^1.9.3",
 		"@orpc/server": "^1.9.3",

--- a/server/service/api-key.ts
+++ b/server/service/api-key.ts
@@ -1,9 +1,9 @@
 import { randomBytes } from "node:crypto";
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import { sha256Sync } from "@aikirun/lib/crypto";
+import type { Cache } from "@aikirun/types/cache";
 import type { NamespaceId, NamespaceRole } from "@aikirun/types/namespace";
 import type { OrganizationId } from "@aikirun/types/organization";
-import type { Redis } from "ioredis";
 import { UnauthorizedError } from "server/errors";
 import type { ApiKeyRepository, ApiKeyRowInsert, Repositories } from "server/infra/db/types";
 import type { NamespaceSessionRequestContext } from "server/middleware/context";
@@ -13,9 +13,8 @@ const PLATFORM = "aiki";
 const PREFIX_LENGTH = 8;
 const SECRET_LENGTH = 32;
 const CACHE_TTL_SECONDS = 4 * 60 * 60;
-const CACHE_KEY_PREFIX = `${PLATFORM}:api_key:`;
 
-interface CachedKeyInfo {
+export interface CachedApiKeyInfo {
 	organizationId: OrganizationId;
 	namespaceId: NamespaceId;
 	expiresAt: number | null;
@@ -46,16 +45,12 @@ function isValidKeyFormat(key: string): boolean {
 	return platform === PLATFORM && prefix.length === PREFIX_LENGTH && secret.length > 0;
 }
 
-function getCacheKey(keyHash: string): string {
-	return `${CACHE_KEY_PREFIX}${keyHash}`;
-}
-
 export interface ApiKeyServiceDeps {
 	repos: Pick<Repositories, "apiKey" | "organization" | "namespace">;
-	redis?: Redis;
+	cache?: Cache<CachedApiKeyInfo>;
 }
 
-export function createApiKeyService({ repos, redis }: ApiKeyServiceDeps) {
+export function createApiKeyService({ repos, cache }: ApiKeyServiceDeps) {
 	return {
 		async resolveNamespaceRole(context: NamespaceSessionRequestContext): Promise<NamespaceRole> {
 			const organizationRole = await repos.organization.getMemberRole(context.organizationId, context.userId);
@@ -96,11 +91,9 @@ export function createApiKeyService({ repos, redis }: ApiKeyServiceDeps) {
 
 			const keyHash = sha256Sync(key);
 
-			if (redis) {
-				const cacheKey = getCacheKey(keyHash);
-				const cached = await redis.get(cacheKey);
-				if (cached) {
-					const cachedKeyInfo: CachedKeyInfo = JSON.parse(cached);
+			if (cache) {
+				const cachedKeyInfo = await cache.get(keyHash);
+				if (cachedKeyInfo) {
 					if (cachedKeyInfo.expiresAt && cachedKeyInfo.expiresAt <= Date.now()) {
 						return null;
 					}
@@ -120,14 +113,16 @@ export function createApiKeyService({ repos, redis }: ApiKeyServiceDeps) {
 				return null;
 			}
 
-			if (redis) {
-				const cacheKey = getCacheKey(keyHash);
-				const cachedKeyInfo: CachedKeyInfo = {
-					organizationId: keyInfo.organizationId as OrganizationId,
-					namespaceId: keyInfo.namespaceId as NamespaceId,
-					expiresAt: keyInfo.expiresAt,
-				};
-				await redis.setex(cacheKey, CACHE_TTL_SECONDS, JSON.stringify(cachedKeyInfo));
+			if (cache) {
+				await cache.set(
+					keyHash,
+					{
+						organizationId: keyInfo.organizationId as OrganizationId,
+						namespaceId: keyInfo.namespaceId as NamespaceId,
+						expiresAt: keyInfo.expiresAt,
+					},
+					{ ttlSeconds: CACHE_TTL_SECONDS }
+				);
 			}
 
 			return {
@@ -149,14 +144,8 @@ export function createApiKeyService({ repos, redis }: ApiKeyServiceDeps) {
 		},
 
 		async invalidateCacheByHashes(keyHashes: string | NonEmptyArray<string>): Promise<void> {
-			if (redis) {
-				if (Array.isArray(keyHashes)) {
-					const cacheKeys = keyHashes.map(getCacheKey);
-					await redis.del(...cacheKeys);
-				} else {
-					const cacheKey = getCacheKey(keyHashes);
-					await redis.del(cacheKey);
-				}
+			if (cache) {
+				await cache.invalidate(keyHashes);
 			}
 		},
 	};

--- a/server/service/api-key.ts
+++ b/server/service/api-key.ts
@@ -14,7 +14,7 @@ const PREFIX_LENGTH = 8;
 const SECRET_LENGTH = 32;
 const CACHE_TTL_SECONDS = 4 * 60 * 60;
 
-export interface CachedApiKeyInfo {
+export interface ApiKeyAuthorizationInfo {
 	organizationId: OrganizationId;
 	namespaceId: NamespaceId;
 	expiresAt: number | null;
@@ -47,7 +47,7 @@ function isValidKeyFormat(key: string): boolean {
 
 export interface ApiKeyServiceDeps {
 	repos: Pick<Repositories, "apiKey" | "organization" | "namespace">;
-	cache?: Cache<CachedApiKeyInfo>;
+	cache?: Cache<ApiKeyAuthorizationInfo>;
 }
 
 export function createApiKeyService({ repos, cache }: ApiKeyServiceDeps) {

--- a/types/cache.ts
+++ b/types/cache.ts
@@ -1,0 +1,11 @@
+import type { NonEmptyArray } from "./array";
+
+export interface CacheSetOptions {
+	ttlSeconds?: number;
+}
+
+export interface Cache<V> {
+	get(key: string): Promise<V | null>;
+	set(key: string, value: V, options?: CacheSetOptions): Promise<void>;
+	invalidate(keys: string | NonEmptyArray<string>): Promise<void>;
+}

--- a/types/package.json
+++ b/types/package.json
@@ -12,6 +12,10 @@
 			"types": "./dist/array.d.ts",
 			"import": "./dist/array.js"
 		},
+		"./cache": {
+			"types": "./dist/cache.d.ts",
+			"import": "./dist/cache.js"
+		},
 		"./client": {
 			"types": "./dist/client.d.ts",
 			"import": "./dist/client.js"
@@ -43,6 +47,10 @@
 		"./property": {
 			"types": "./dist/property.d.ts",
 			"import": "./dist/property.js"
+		},
+		"./publisher": {
+			"types": "./dist/publisher.d.ts",
+			"import": "./dist/publisher.js"
 		},
 		"./replay-manifest": {
 			"types": "./dist/replay-manifest.d.ts",
@@ -87,6 +95,10 @@
 		"./task-error": {
 			"types": "./dist/task-error.d.ts",
 			"import": "./dist/task-error.js"
+		},
+		"./timer": {
+			"types": "./dist/timer.d.ts",
+			"import": "./dist/timer.js"
 		},
 		"./trigger": {
 			"types": "./dist/trigger.d.ts",

--- a/types/publisher.ts
+++ b/types/publisher.ts
@@ -1,4 +1,4 @@
-import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NonEmptyArray } from "./array";
 
 export interface WorkflowRunReadyMessage {
 	id: string;
@@ -8,6 +8,6 @@ export interface WorkflowRunReadyMessage {
 	shard?: string;
 }
 
-export interface WorkflowRunPublisher {
+export interface Publisher {
 	publishReadyRuns(runs: NonEmptyArray<WorkflowRunReadyMessage>): Promise<void>;
 }

--- a/types/publisher.ts
+++ b/types/publisher.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyArray } from "./array";
 
-export interface WorkflowRunReadyMessage {
+export interface ReadyWorkflowRun {
 	id: string;
 	name: string;
 	versionId: string;
@@ -9,5 +9,5 @@ export interface WorkflowRunReadyMessage {
 }
 
 export interface Publisher {
-	publishReadyRuns(runs: NonEmptyArray<WorkflowRunReadyMessage>): Promise<void>;
+	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void>;
 }

--- a/types/subscriber.ts
+++ b/types/subscriber.ts
@@ -4,7 +4,7 @@ import type { WorkflowMeta } from "./workflow";
 import type { WorkflowRunId } from "./workflow-run";
 
 export interface WorkflowRunMessage {
-	data: { workflowRunId: WorkflowRunId };
+	data: { id: WorkflowRunId };
 }
 
 export type SubscriberDelayParams = { type: "no_work" } | { type: "retry"; attemptNumber: number };

--- a/types/subscriber.ts
+++ b/types/subscriber.ts
@@ -11,7 +11,7 @@ export type SubscriberDelayParams = { type: "no_work" } | { type: "retry"; attem
 
 export interface Subscriber {
 	getNextDelay: (context: SubscriberDelayParams) => number;
-	getNextBatch: (size: number, options?: { abortSignal?: AbortSignal }) => Promise<WorkflowRunMessage[]>;
+	getReadyRuns: (size: number, options?: { abortSignal?: AbortSignal }) => Promise<WorkflowRunMessage[]>;
 	heartbeat?: (workflowRunId: WorkflowRunId) => Promise<void>;
 	acknowledge?: (workflowRunId: WorkflowRunId) => Promise<void>;
 	close?: () => Promise<void>;

--- a/types/timer.ts
+++ b/types/timer.ts
@@ -37,5 +37,4 @@ export interface TimerSortedSet {
 	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
 	peekNextRank(): Promise<number | null>;
 	createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter;
-	close?(): Promise<void>;
 }

--- a/types/timer.ts
+++ b/types/timer.ts
@@ -1,4 +1,5 @@
-import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { NonEmptyArray } from "./array";
+import type { Logger } from "./logger";
 
 export type TimerType =
 	| "scheduled"
@@ -27,9 +28,14 @@ export interface TimerSignalWaiter {
 	close(): Promise<void>;
 }
 
+export interface TimerSignalWaiterContext {
+	logger: Logger;
+}
+
 export interface TimerSortedSet {
 	add(timers: NonEmptyArray<TimerEntry>): Promise<void>;
 	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
 	peekNextRank(): Promise<number | null>;
-	createSignalWaiter(): TimerSignalWaiter;
+	createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter;
+	close?(): Promise<void>;
 }

--- a/types/tsup.config.ts
+++ b/types/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	entry: {
 		"api-key-api": "api-key-api.ts",
 		array: "array.ts",
+		cache: "cache.ts",
 		client: "client.ts",
 		duration: "duration.ts",
 		event: "event.ts",
@@ -12,6 +13,7 @@ export default defineConfig({
 		"namespace-api": "namespace-api.ts",
 		organization: "organization.ts",
 		property: "property.ts",
+		publisher: "publisher.ts",
 		"replay-manifest": "replay-manifest.ts",
 		retry: "retry.ts",
 		schedule: "schedule.ts",
@@ -23,6 +25,7 @@ export default defineConfig({
 		symbols: "symbols.ts",
 		task: "task.ts",
 		"task-error": "task-error.ts",
+		timer: "timer.ts",
 		trigger: "trigger.ts",
 		validator: "validator.ts",
 		worker: "worker.ts",


### PR DESCRIPTION
## Motivation

Aiki's transport layer is being designed to be pluggable: the server takes whichever publisher, timer store, and cache its deployment wants, and Redis is one implementation provided out of the box. Users are free to bring their own backend by satisfying the contracts.

The codebase doesn't reflect that yet. The SDK ships `@aikirun/redis` for the subscriber side, while the server keeps its own private Redis code for three jobs that participate in the same Redis deployment:

- **Publishing** ready workflow runs onto the same per-workflow queues workers subscribe to.
- **Driving the timer tier**: a store the server consults to discover which workflow runs are due to wake (sleeps, retries, event waits, scheduled runs, recurring schedules). A consumer daemon waits on it via a blocking command and pops the entries that are now due.
- **Caching API key authorization info** so request auth doesn't round-trip to the DB on every call.

That split has two visible costs:

1. **There's nothing for an alternative transport to satisfy.** Without abstract `Publisher` / `TimerSortedSet` / `Cache` contracts, "pluggable" is aspirational. And the Redis publisher and subscriber participate in the same wire protocol (queue naming, message shape, key conventions) but live in different packages, free to drift.
2. **The SDK's connection supervisor couldn't be reused.** PR #17 added a supervisor to the subscriber's Redis client to escape a stalled `connect → ready` handshake (Docker port proxy accepts the TCP handshake while Redis is still booting; ioredis emits `connect`, sends `INFO`, and gets no reply; the blocking `BZPOPMIN` hangs until OS-level TCP keepalive eventually kills the socket — minutes to hours). The server's timer signal waiter uses `BRPOP` and had identical exposure with no guard.

## Solution

Lift the transport contracts into `@aikirun/types` and the Redis implementations into `@aikirun/redis`. The server depends on the package and receives concrete plugins at bootstrap — the same compositional pattern the SDK already uses for its subscriber, now applied across the whole transport surface.

Four contracts live in `@aikirun/types`:

- `Subscriber` (already there).
- `Publisher` — publish a batch of ready workflow runs.
- `TimerSortedSet` — add timers, pop due ones, peek the next due timestamp, and create a blocking signal waiter for the consumer daemon to sleep on.
- `Cache<V>` — `get`/`set`/`invalidate` with optional TTL. The API key service takes one of these instead of a raw Redis client, so it no longer cares about transport.

An alternative backend — a different broker, a different timer store, a different cache — only has to satisfy these four interfaces; the server doesn't need to change.

The connection supervisor from PR #17 is extracted into a single primitive any ioredis client can opt into. It bounds the time spent in the `connect → ready` phase and forces a reconnect if the handshake stalls. It's attached in two places: the subscriber's own client, and the timer signal waiter's duplicate — exactly where a blocking command can hang indefinitely on a stalled handshake. The signal waiter's duplicate is also configured fail-fast so the daemon's existing retry/backoff loop handles transient failures rather than ioredis silently swallowing them.

The server's primary Redis client — used by the publisher, the non-blocking timer ops, and the cache — is intentionally **not** wrapped. The stalled-handshake failure mode only matters when a command can't recover on its own: a blocking command's in-flight Promise never settles. ioredis's built-in reconnection and per-request retry handle the clean-restart case for non-blocking commands.

## Breaking changes

- `Subscriber.getNextBatch` → `getReadyRuns`.
- `WorkflowRunBatch` removed; subscribers return `WorkflowRunMessage[]` directly.
- `WorkflowRunMessage.data.workflowRunId` → `WorkflowRunMessage.data.id`.
- `WorkflowRunReadyMessage` → `ReadyWorkflowRun`.
