### PR TITLE
Factory shape for Publisher, Cache, and TimerSortedSet

### DIFF
--- a/sdk/adapter/redis/cache/cache.ts
+++ b/sdk/adapter/redis/cache/cache.ts
@@ -1,15 +1,15 @@
-import type { Cache, CacheSetOptions } from "@aikirun/types/infra/cache";
+import type { CacheContext, CacheSetOptions, CreateCache } from "@aikirun/types/infra/cache";
 import type { Redis } from "ioredis";
 
 export interface RedisCacheOptions {
 	keyPrefix?: string;
 }
 
-export function redisCache<V>(redis: Redis, options?: RedisCacheOptions): Cache<V> {
+export function redisCache<V>(redis: Redis, options?: RedisCacheOptions): CreateCache<V> {
 	const keyPrefix = options?.keyPrefix ?? "";
 	const getCacheKey = (key: string) => `${keyPrefix}${key}`;
 
-	return {
+	return (_context: CacheContext) => ({
 		async get(key: string): Promise<V | null> {
 			const cached = await redis.get(getCacheKey(key));
 			if (!cached) {
@@ -35,5 +35,5 @@ export function redisCache<V>(redis: Redis, options?: RedisCacheOptions): Cache<
 				await redis.del(getCacheKey(keys));
 			}
 		},
-	};
+	});
 }

--- a/sdk/adapter/redis/queue/publisher.ts
+++ b/sdk/adapter/redis/queue/publisher.ts
@@ -1,11 +1,11 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type { CreatePublisher, PublisherContext, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
 import type { Redis } from "ioredis";
 
 import { getWorkflowQueueName } from "./key";
 
-export function redisPublisher(redis: Redis): Publisher {
-	return {
+export function redisPublisher(redis: Redis): CreatePublisher {
+	return (_context: PublisherContext) => ({
 		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void> {
 			const redisPipeline = redis.pipeline();
 
@@ -26,5 +26,5 @@ export function redisPublisher(redis: Redis): Publisher {
 
 			await redisPipeline.exec();
 		},
-	};
+	});
 }

--- a/sdk/adapter/redis/timer/sorted-set.ts
+++ b/sdk/adapter/redis/timer/sorted-set.ts
@@ -1,10 +1,9 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
 import type {
+	CreateTimerSortedSet,
 	DueTimer,
 	TimerEntry,
 	TimerSignalWaiter,
-	TimerSignalWaiterContext,
-	TimerSortedSet,
 	TimerType,
 } from "@aikirun/types/infra/timer";
 import type { Redis } from "ioredis";
@@ -70,10 +69,10 @@ end
 return minSignal
 `;
 
-export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
+export function redisTimerSortedSet(redis: Redis, key: string): CreateTimerSortedSet {
 	const signalKey = `${key}:signal`;
 
-	return {
+	return ({ logger }) => ({
 		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
 			let minDueAt = timers[0].dueAt;
 			const args: (string | number)[] = [];
@@ -111,12 +110,12 @@ export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 			return Number(result[1]);
 		},
 
-		createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter {
+		createSignalWaiter(): TimerSignalWaiter {
 			const redisDuplicate = redis.duplicate({
 				maxRetriesPerRequest: 0,
 				enableOfflineQueue: false,
 			});
-			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger: context.logger });
+			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger });
 			let closed = false;
 
 			return {
@@ -151,5 +150,5 @@ export function redisTimerSortedSet(redis: Redis, key: string): TimerSortedSet {
 				},
 			};
 		},
-	};
+	});
 }

--- a/server/daemons/due-timers-consumer.ts
+++ b/server/daemons/due-timers-consumer.ts
@@ -46,7 +46,7 @@ export function spawnDueTimersConsumer(
 	const abortController = new AbortController();
 	const { signal: abortSignal } = abortController;
 
-	const timerSignalWaiter = deps.timerSortedSet.createSignalWaiter({ logger });
+	const timerSignalWaiter = deps.timerSortedSet.createSignalWaiter();
 
 	const promise = withRetry(
 		() => dueTimersConsumerLoop(logger, deps, timerSignalWaiter, abortSignal, options),

--- a/server/index.ts
+++ b/server/index.ts
@@ -51,9 +51,23 @@ if (import.meta.main) {
 		redis.on("error", (err: Error) => {
 			logger.error({ err }, "Redis connection error");
 		});
-		apiKeyCache = redisCache(redis, { keyPrefix: "aiki:api_key:" });
-		timerSortedSet = redisTimerSortedSet(redis, "aiki:timers");
-		workflowRunPublisher = redisPublisher(redis);
+
+		const createApiKeyCache = redisCache<ApiKeyAuthorizationInfo>(redis, { keyPrefix: "aiki:api_key:" });
+		const apiKeyCacheValue = createApiKeyCache({ logger: logger.child({ "aiki.component": "api-key-cache" }) });
+		apiKeyCache = apiKeyCacheValue instanceof Promise ? await apiKeyCacheValue : apiKeyCacheValue;
+
+		const createTimerSortedSet = redisTimerSortedSet(redis, "aiki:timers");
+		const timerSortedSetValue = createTimerSortedSet({
+			logger: logger.child({ "aiki.component": "timer-sorted-set" }),
+		});
+		timerSortedSet = timerSortedSetValue instanceof Promise ? await timerSortedSetValue : timerSortedSetValue;
+
+		const createWorkflowRunPublisher = redisPublisher(redis);
+		const workflowRunPublisherValue = createWorkflowRunPublisher({
+			logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
+		});
+		workflowRunPublisher =
+			workflowRunPublisherValue instanceof Promise ? await workflowRunPublisherValue : workflowRunPublisherValue;
 	}
 
 	const apiKeyService = createApiKeyService({ repos, cache: apiKeyCache });

--- a/types/infra/cache.ts
+++ b/types/infra/cache.ts
@@ -1,4 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { Logger } from "@aikirun/lib/logger";
 
 export interface CacheSetOptions {
 	ttlSeconds?: number;
@@ -9,3 +10,9 @@ export interface Cache<V> {
 	set(key: string, value: V, options?: CacheSetOptions): Promise<void>;
 	invalidate(keys: string | NonEmptyArray<string>): Promise<void>;
 }
+
+export interface CacheContext {
+	logger: Logger;
+}
+
+export type CreateCache<V> = (context: CacheContext) => Cache<V> | Promise<Cache<V>>;

--- a/types/infra/queue/publisher.ts
+++ b/types/infra/queue/publisher.ts
@@ -1,4 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
+import type { Logger } from "@aikirun/lib/logger";
 
 export interface ReadyWorkflowRun {
 	id: string;
@@ -11,3 +12,9 @@ export interface ReadyWorkflowRun {
 export interface Publisher {
 	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void>;
 }
+
+export interface PublisherContext {
+	logger: Logger;
+}
+
+export type CreatePublisher = (context: PublisherContext) => Publisher | Promise<Publisher>;

--- a/types/infra/timer.ts
+++ b/types/infra/timer.ts
@@ -28,13 +28,15 @@ export interface TimerSignalWaiter {
 	close(): Promise<void>;
 }
 
-export interface TimerSignalWaiterContext {
-	logger: Logger;
-}
-
 export interface TimerSortedSet {
 	add(timers: NonEmptyArray<TimerEntry>): Promise<void>;
 	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
 	peekNextRank(): Promise<number | null>;
-	createSignalWaiter(context: TimerSignalWaiterContext): TimerSignalWaiter;
+	createSignalWaiter(): TimerSignalWaiter;
 }
+
+export interface TimerSortedSetContext {
+	logger: Logger;
+}
+
+export type CreateTimerSortedSet = (context: TimerSortedSetContext) => TimerSortedSet | Promise<TimerSortedSet>;


### PR DESCRIPTION
## Motivation

The SDK exposes four infrastructure interfaces that callers can plug their own implementations into:

- **`Publisher`** — enqueues ready workflow runs onto the run queue.
- **`Cache<V>`** — a key/value store, used today for API-key authorization caching.
- **`TimerSortedSet`** — storage for low-latency wakeups when timers are due.
- **`Subscriber`** — pulls ready runs off the queue inside the worker.

The `Subscriber` adapter already uses a two-step construction shape: a `CreateSubscriber` factory of `(context: SubscriberContext) => Subscriber | Promise<Subscriber>`, where the outer adapter function captures static configuration (Redis client, HTTP API client, options) and the inner factory receives runtime context (worker identity, workflow registry, a scoped logger).

The other three adapters return their instance directly from a single function call (`redisCache(redis)`, `redisPublisher(redis)`, `redisTimerSortedSet(redis, key)`). There is no construction-time hook for context.

An upcoming `server()` library factory needs a single, uniform construction shape across all four adapters so callers can mix and match implementations with consistent context plumbing. Only logger is injected currently, but this will grow.

## Solution

Mirror the `CreateSubscriber` shape for the remaining three:

- Add `PublisherContext`, `CacheContext`, and `TimerSortedSetContext` — each currently `{ logger: Logger }`, intentionally minimal so they can grow.
- Add `CreatePublisher`, `CreateCache<V>`, and `CreateTimerSortedSet` aliases matching `(context) => Instance | Promise<Instance>`.
- Reshape the Redis adapters so the outer function keeps its existing arguments (Redis client plus key/options where relevant) but returns the `Create*` factory instead of the instance.
- Drop `TimerSignalWaiterContext`. With the timer adapter now constructed with its own logger, every signal waiter it creates can reuse that logger.
- Update the server bootstrap to invoke each adapter factory with a `logger.child({ "aiki.component": … })`.

The underlying `Publisher`, `Cache`, and `TimerSortedSet` interfaces are unchanged.