### PR TITLE
Server as a library

### DIFF
--- a/sdk/adapter/redis/cache/cache.ts
+++ b/sdk/adapter/redis/cache/cache.ts
@@ -1,39 +1,36 @@
-import type { CacheContext, CacheSetOptions, CreateCache } from "@aikirun/types/infra/cache";
+import type { Cache, CacheContext, CacheSetOptions, CreateCache } from "@aikirun/types/infra/cache";
 import type { Redis } from "ioredis";
 
-export interface RedisCacheOptions {
-	keyPrefix?: string;
-}
+export function redisCache(redis: Redis): CreateCache {
+	return <V>({ keyPrefix }: CacheContext): Cache<V> => {
+		const getCacheKey = (key: string) => (keyPrefix !== undefined ? `${keyPrefix}${key}` : key);
 
-export function redisCache<V>(redis: Redis, options?: RedisCacheOptions): CreateCache<V> {
-	const keyPrefix = options?.keyPrefix ?? "";
-	const getCacheKey = (key: string) => `${keyPrefix}${key}`;
+		return {
+			async get(key: string): Promise<V | null> {
+				const cached = await redis.get(getCacheKey(key));
+				if (!cached) {
+					return null;
+				}
+				return JSON.parse(cached) as V;
+			},
 
-	return (_context: CacheContext) => ({
-		async get(key: string): Promise<V | null> {
-			const cached = await redis.get(getCacheKey(key));
-			if (!cached) {
-				return null;
-			}
-			return JSON.parse(cached) as V;
-		},
+			async set(key: string, value: V, setOptions?: CacheSetOptions): Promise<void> {
+				const cacheKey = getCacheKey(key);
+				const serialized = JSON.stringify(value);
+				if (setOptions?.ttlSeconds !== undefined) {
+					await redis.setex(cacheKey, setOptions.ttlSeconds, serialized);
+				} else {
+					await redis.set(cacheKey, serialized);
+				}
+			},
 
-		async set(key: string, value: V, setOptions?: CacheSetOptions): Promise<void> {
-			const cacheKey = getCacheKey(key);
-			const serialized = JSON.stringify(value);
-			if (setOptions?.ttlSeconds !== undefined) {
-				await redis.setex(cacheKey, setOptions.ttlSeconds, serialized);
-			} else {
-				await redis.set(cacheKey, serialized);
-			}
-		},
-
-		async invalidate(keys): Promise<void> {
-			if (Array.isArray(keys)) {
-				await redis.del(...keys.map(getCacheKey));
-			} else {
-				await redis.del(getCacheKey(keys));
-			}
-		},
-	});
+			async invalidate(keys): Promise<void> {
+				if (Array.isArray(keys)) {
+					await redis.del(...keys.map(getCacheKey));
+				} else {
+					await redis.del(getCacheKey(keys));
+				}
+			},
+		};
+	};
 }

--- a/sdk/adapter/redis/cache/index.ts
+++ b/sdk/adapter/redis/cache/index.ts
@@ -1,2 +1,1 @@
-export type { RedisCacheOptions } from "./cache";
 export { redisCache } from "./cache";

--- a/sdk/adapter/redis/queue/publisher.ts
+++ b/sdk/adapter/redis/queue/publisher.ts
@@ -1,11 +1,11 @@
 import type { NonEmptyArray } from "@aikirun/lib/array";
-import type { CreatePublisher, PublisherContext, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type { CreatePublisher, Publisher, PublisherContext, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
 import type { Redis } from "ioredis";
 
 import { getWorkflowQueueName } from "./key";
 
 export function redisPublisher(redis: Redis): CreatePublisher {
-	return (_context: PublisherContext) => ({
+	return (_context: PublisherContext): Publisher => ({
 		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void> {
 			const redisPipeline = redis.pipeline();
 

--- a/sdk/adapter/redis/timer/sorted-set.ts
+++ b/sdk/adapter/redis/timer/sorted-set.ts
@@ -4,6 +4,7 @@ import type {
 	DueTimer,
 	TimerEntry,
 	TimerSignalWaiter,
+	TimerSortedSet,
 	TimerType,
 } from "@aikirun/types/infra/timer";
 import type { Redis } from "ioredis";
@@ -72,7 +73,7 @@ return minSignal
 export function redisTimerSortedSet(redis: Redis, key: string): CreateTimerSortedSet {
 	const signalKey = `${key}:signal`;
 
-	return ({ logger }) => ({
+	return ({ logger }): TimerSortedSet => ({
 		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
 			let minDueAt = timers[0].dueAt;
 			const args: (string | number)[] = [];

--- a/sdk/worker/worker.ts
+++ b/sdk/worker/worker.ts
@@ -161,26 +161,24 @@ class WorkerHandleImpl<AppContext> implements WorkerHandle {
 		}
 
 		const createPrimarySubscriber = this.params.subscriber ?? httpSubscriber({ api: this.client.api });
-		const primarySubscriber = createPrimarySubscriber({
+		this.primarySubscriber = createPrimarySubscriber({
 			workerId: this.id,
 			workflows,
 			shards: this.spawnOptions.shards,
 			logger: this.logger.child({ "aiki.subscriber": "primary" }),
 		});
-		this.primarySubscriber = primarySubscriber instanceof Promise ? await primarySubscriber : primarySubscriber;
 		this.primarySubscriber.heartbeat = this.withServerHeartbeatForwarding(
 			this.primarySubscriber.heartbeat?.bind(this.primarySubscriber)
 		);
 
 		if (!this.params.subscriber) {
 			const createBackupSubscriber = httpSubscriber({ api: this.client.api });
-			const backupSubscriber = createBackupSubscriber({
+			this.backupSubscriber = createBackupSubscriber({
 				workerId: this.id,
 				workflows,
 				shards: this.spawnOptions.shards,
 				logger: this.logger.child({ "aiki.subscriber": "backup" }),
 			});
-			this.backupSubscriber = backupSubscriber instanceof Promise ? await backupSubscriber : backupSubscriber;
 			this.backupSubscriber.heartbeat = this.withServerHeartbeatForwarding(
 				this.backupSubscriber.heartbeat?.bind(this.backupSubscriber)
 			);

--- a/server/daemons/due-timers-consumer.ts
+++ b/server/daemons/due-timers-consumer.ts
@@ -1,5 +1,6 @@
 import { groupBy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
 import { streamChunks } from "@aikirun/lib/async";
+import type { Logger } from "@aikirun/lib/logger";
 import { withRetry } from "@aikirun/lib/retry";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { DueTimer, TimerSignalWaiter, TimerSortedSet, TimerType } from "@aikirun/types/infra/timer";
@@ -7,7 +8,6 @@ import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import type { WorkflowRunMeta } from "server/infra/db/pg/repository/workflow-run";
 import type { Repositories } from "server/infra/db/types";
-import type { Logger } from "server/infra/logger";
 import { computeRank, type Ranked, rankDueAtMs } from "server/lib/rank";
 import type { DaemonContext } from "server/middleware/context";
 import { createDaemonContext } from "server/middleware/context";
@@ -57,7 +57,7 @@ export function spawnDueTimersConsumer(
 				if (abortSignal.aborted) {
 					return;
 				}
-				logger.error({ error }, "Due timers consumer crashed unexpectedly");
+				logger.error("Due timers consumer crashed unexpectedly", { error });
 			},
 		}
 	).run();
@@ -115,7 +115,7 @@ async function dueTimersConsumerLoop(
 			try {
 				await processDueTimers(context, deps, dueTimers);
 			} catch (error) {
-				context.logger.error({ error }, "Failed to process due timers batch");
+				context.logger.error("Failed to process due timers batch", { error });
 			}
 		}
 

--- a/server/daemons/imminent-child-run-wait-timed-out-runs.ts
+++ b/server/daemons/imminent-child-run-wait-timed-out-runs.ts
@@ -93,7 +93,7 @@ export async function queueChildRunWaitTimedOutRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/imminent-event-wait-timed-out-runs.ts
+++ b/server/daemons/imminent-event-wait-timed-out-runs.ts
@@ -93,7 +93,7 @@ export async function queueEventWaitTimedOutRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/imminent-recurring-workflows.ts
+++ b/server/daemons/imminent-recurring-workflows.ts
@@ -135,7 +135,7 @@ export async function queueRecurringWorkflows(
 
 	for (const result of results) {
 		if (result.status === "rejected") {
-			context.logger.warn({ err: result.reason }, "Failed to process recurring schedules batch, will retry next tick");
+			context.logger.warn("Failed to process recurring schedules batch, will retry next tick", { err: result.reason });
 		}
 	}
 }

--- a/server/daemons/imminent-retryable-runs.ts
+++ b/server/daemons/imminent-retryable-runs.ts
@@ -81,7 +81,7 @@ export async function queueRetryableRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/imminent-retryable-task-runs.ts
+++ b/server/daemons/imminent-retryable-task-runs.ts
@@ -113,7 +113,7 @@ export async function queueRetryableTaskRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/imminent-scheduled-runs.ts
+++ b/server/daemons/imminent-scheduled-runs.ts
@@ -89,7 +89,7 @@ export async function queueScheduledRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/imminent-sleep-elapsed-runs.ts
+++ b/server/daemons/imminent-sleep-elapsed-runs.ts
@@ -79,7 +79,7 @@ export async function queueSleepElapsedRuns(
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
 		} catch (error) {
-			spanCtx.logger.warn({ error, chunkSize: chunk.length }, "Failed to process chunk, will retry next tick");
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
 		}
 	});
 }

--- a/server/daemons/index.ts
+++ b/server/daemons/index.ts
@@ -1,9 +1,9 @@
 import { delay } from "@aikirun/lib/async";
+import type { Logger } from "@aikirun/lib/logger";
 import { withRetry } from "@aikirun/lib/retry";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerSortedSet } from "@aikirun/types/infra/timer";
 import type { Repositories } from "server/infra/db/types";
-import type { Logger } from "server/infra/logger";
 import type { DaemonContext } from "server/middleware/context";
 import { createDaemonContext } from "server/middleware/context";
 import type { ChildRunCanceller } from "server/service/cancel-child-runs";
@@ -44,7 +44,7 @@ function initDaemon<Deps, Options>(
 				const start = performance.now();
 				await fn(context, deps, options);
 				const durationMs = Math.round(performance.now() - start);
-				context.logger.debug({ durationMs }, "Completed");
+				context.logger.debug("Completed", { durationMs });
 				const delayMs = intervalMs - durationMs;
 				if (delayMs > 0) {
 					await delay(delayMs, { abortSignal: signal });
@@ -58,7 +58,7 @@ function initDaemon<Deps, Options>(
 				if (signal.aborted) {
 					return;
 				}
-				logger.error({ err }, `Daemon ${name} failed`);
+				logger.error(`Daemon ${name} failed`, { err });
 			},
 		}
 	).run();

--- a/server/daemons/publish-ready-runs.ts
+++ b/server/daemons/publish-ready-runs.ts
@@ -54,7 +54,7 @@ export async function publishRuns(
 	}
 
 	await workflowRunPublisher.publishReadyRuns(runs as NonEmptyArray<ReadyWorkflowRun>);
-	context.logger.debug({ count: runs.length }, "Published ready workflow runs");
+	context.logger.debug("Published ready workflow runs", { count: runs.length });
 
 	await repos.workflowRunOutbox.markPublished(entryIds as NonEmptyArray<string>);
 }

--- a/server/daemons/republish-stale-runs.ts
+++ b/server/daemons/republish-stale-runs.ts
@@ -35,7 +35,7 @@ export async function republishStaleRuns(
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		context.logger.info({ count: staleEntries.length }, "Releasing stale outbox claims");
+		context.logger.info("Releasing stale outbox claims", { count: staleEntries.length });
 		await republishRuns(context, deps.workflowRunPublisher, staleEntries);
 		const staleEntryIds = staleEntries.map((entry) => entry.id) as NonEmptyArray<string>;
 		await deps.repos.workflowRunOutbox.releaseStaleClaim(staleEntryIds);
@@ -48,7 +48,7 @@ export async function republishStaleRuns(
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		context.logger.info({ count: staleEntries.length }, "Republishing stale published outbox entries");
+		context.logger.info("Republishing stale published outbox entries", { count: staleEntries.length });
 		await republishRuns(context, deps.workflowRunPublisher, staleEntries);
 		const staleEntryIds = staleEntries.map((entry) => entry.id) as NonEmptyArray<string>;
 		await deps.repos.workflowRunOutbox.markRepublished(staleEntryIds);
@@ -69,5 +69,5 @@ async function republishRuns(
 	})) as NonEmptyArray<ReadyWorkflowRun>;
 
 	await workflowRunPublisher.publishReadyRuns(runs);
-	context.logger.debug({ count: runs.length }, "Published ready workflow runs");
+	context.logger.debug("Published ready workflow runs", { count: runs.length });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ if (import.meta.main) {
 
 	const aiki = server({
 		db: config.database,
+		cache: redis && redisCache(redis),
 		logger,
 		handler: {
 			auth: {
@@ -31,7 +32,6 @@ if (import.meta.main) {
 				baseURL: config.baseURL,
 				trustedOrigins: config.corsOrigins,
 			},
-			...(redis && { cache: redisCache(redis) }),
 		},
 		runtime: {
 			...(redis && {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,47 +1,16 @@
 import process from "node:process";
 import { redisCache, redisPublisher, redisTimerSortedSet } from "@aikirun/redis";
-import type { Cache } from "@aikirun/types/infra/cache";
-import type { Publisher } from "@aikirun/types/infra/queue";
-import type { TimerSortedSet } from "@aikirun/types/infra/timer";
-import { RPCHandler } from "@orpc/server/fetch";
 import { Redis } from "ioredis";
 
 import { loadConfig } from "./config/index";
-import { initDaemons } from "./daemons";
-import { UnauthorizedError } from "./errors";
-import { createDatabase } from "./infra/db";
 import { createLogger } from "./infra/logger";
-import { createAuthorizer } from "./middleware/authorization";
-import {
-	createNamespaceRequestContext,
-	createOrganizationRequestContext,
-	type NamespaceRequestContext,
-	type OrganizationRequestContext,
-} from "./middleware/context";
-import { createNamespaceAuthedRouter, createOrganizationAuthedRouter } from "./router/index";
-import { type ApiKeyAuthorizationInfo, createApiKeyService } from "./service/api-key";
-import { createAuthService } from "./service/auth";
-import { createChildRunCanceller } from "./service/cancel-child-runs";
-import { createNamespaceService } from "./service/namespace";
-import { createScheduleService } from "./service/schedule";
-import { createTaskStateMachineService } from "./service/task-state-machine";
-import { createWorkflowService } from "./service/workflow";
-import { createWorkflowRunService } from "./service/workflow-run";
-import { createWorkflowRunOutboxService } from "./service/workflow-run-outbox";
-import { createWorkflowRunStateMachineService } from "./service/workflow-run-state-machine";
+import { server } from "./server";
 
 if (import.meta.main) {
 	const config = await loadConfig();
 	const logger = createLogger(config.logLevel, config.prettyLogs);
 
-	const { repos, conn, betterAuthSchema } = createDatabase(config.database);
-
 	let redis: Redis | undefined;
-
-	let apiKeyCache: Cache<ApiKeyAuthorizationInfo> | undefined;
-	let timerSortedSet: TimerSortedSet | undefined;
-	let workflowRunPublisher: Publisher | undefined;
-
 	if (config.redis) {
 		redis = new Redis({
 			host: config.redis.host,
@@ -49,161 +18,50 @@ if (import.meta.main) {
 			password: config.redis.password,
 		});
 		redis.on("error", (err: Error) => {
-			logger.error({ err }, "Redis connection error");
+			logger.error("Redis connection error", { err });
 		});
-
-		const createApiKeyCache = redisCache<ApiKeyAuthorizationInfo>(redis, { keyPrefix: "aiki:api_key:" });
-		const apiKeyCacheValue = createApiKeyCache({ logger: logger.child({ "aiki.component": "api-key-cache" }) });
-		apiKeyCache = apiKeyCacheValue instanceof Promise ? await apiKeyCacheValue : apiKeyCacheValue;
-
-		const createTimerSortedSet = redisTimerSortedSet(redis, "aiki:timers");
-		const timerSortedSetValue = createTimerSortedSet({
-			logger: logger.child({ "aiki.component": "timer-sorted-set" }),
-		});
-		timerSortedSet = timerSortedSetValue instanceof Promise ? await timerSortedSetValue : timerSortedSetValue;
-
-		const createWorkflowRunPublisher = redisPublisher(redis);
-		const workflowRunPublisherValue = createWorkflowRunPublisher({
-			logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
-		});
-		workflowRunPublisher =
-			workflowRunPublisherValue instanceof Promise ? await workflowRunPublisherValue : workflowRunPublisherValue;
 	}
 
-	const apiKeyService = createApiKeyService({ repos, cache: apiKeyCache });
-	const authService = createAuthService({
-		conn,
-		provider: config.database.provider,
-		betterAuthSchema,
-		baseURL: config.baseURL,
-		secret: config.auth.secret,
-		corsOrigins: config.corsOrigins,
+	const aiki = server({
+		db: config.database,
+		logger,
+		handler: {
+			auth: {
+				secret: config.auth.secret,
+				baseURL: config.baseURL,
+				trustedOrigins: config.corsOrigins,
+			},
+			...(redis && { cache: redisCache(redis) }),
+		},
+		runtime: {
+			...(redis && {
+				publisher: redisPublisher(redis),
+				timerSortedSet: redisTimerSortedSet(redis, "aiki:timers"),
+			}),
+		},
 	});
 
-	const { authorizeByApiKey, authorizeByOrganizationSession, authorizeByNamespaceSession } = createAuthorizer(
-		apiKeyService,
-		authService,
-		repos.organization
-	);
-
-	const namespaceService = createNamespaceService(repos, apiKeyService);
-	const childRunCanceller = createChildRunCanceller();
-	const workflowRunStateMachineService = createWorkflowRunStateMachineService({
-		repos,
-		childRunCanceller,
-	});
-	const taskStateMachineService = createTaskStateMachineService({ repos });
-	const workflowRunService = createWorkflowRunService({
-		repos,
-		childRunCanceller,
-		workflowRunStateMachineService,
-	});
-	const workflowService = createWorkflowService({ repos });
-	const scheduleService = createScheduleService({ repos });
-	const workflowRunOutboxService = createWorkflowRunOutboxService({ repos });
-
-	const daemons = initDaemons(logger, {
-		repos,
-		workflowRunPublisher,
-		timerSortedSet,
-		childRunCanceller,
-	});
-
-	const organizationAuthedRouter = createOrganizationAuthedRouter(namespaceService);
-	const namespaceAuthedRouter = createNamespaceAuthedRouter({
-		apiKeyService,
-		workflowRunService,
-		workflowRunStateMachineService,
-		taskStateMachineService,
-		workflowService,
-		scheduleService,
-		workflowRunOutboxService,
-	});
-
-	const organizationAuthedHandler = new RPCHandler(organizationAuthedRouter, {});
-	const namespaceAuthedHandler = new RPCHandler(namespaceAuthedRouter, {});
+	const runtimeHandle = await aiki.runtime.start();
 
 	const { createCorsResponse, withCorsHeaders } = createCorsHelpers(config.corsOrigins);
 
 	Bun.serve({
 		hostname: config.host,
 		port: config.port,
-		routes: {
-			"/health": async (request) => {
-				if (request.method === "OPTIONS") return createCorsResponse(request);
-				if (request.method !== "GET") {
-					return withCorsHeaders(request, new Response("Method Not Allowed", { status: 405 }));
-				}
-				return withCorsHeaders(request, Response.json({ status: "ok" }));
-			},
-			"/auth/*": async (request) => {
-				if (request.method === "OPTIONS") return createCorsResponse(request);
-				return withCorsHeaders(request, await authService.handler(request));
-			},
-			"/api/*": async (request) => {
-				if (request.method === "OPTIONS") return createCorsResponse(request);
-
-				let context: NamespaceRequestContext;
-				try {
-					context = await createNamespaceRequestContext({ request, logger, authorizer: authorizeByApiKey });
-				} catch (error) {
-					if (error instanceof UnauthorizedError) {
-						return withCorsHeaders(request, new Response(error.message, { status: 401 }));
-					}
-					logger.error({ error }, "Unhandled error");
-					return withCorsHeaders(request, new Response("Internal Server Error", { status: 500 }));
-				}
-
-				const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/api" });
-				return withCorsHeaders(request, result.response ?? new Response("Not Found", { status: 404 }));
-			},
-			"/web/namespace/*": async (request) => {
-				if (request.method === "OPTIONS") return createCorsResponse(request);
-
-				let context: OrganizationRequestContext;
-				try {
-					context = await createOrganizationRequestContext({
-						request,
-						logger,
-						authorizer: authorizeByOrganizationSession,
-					});
-				} catch (error) {
-					if (error instanceof UnauthorizedError) {
-						return withCorsHeaders(request, new Response(error.message, { status: 401 }));
-					}
-					logger.error({ error }, "Unhandled error");
-					return withCorsHeaders(request, new Response("Internal Server Error", { status: 500 }));
-				}
-
-				const result = await organizationAuthedHandler.handle(request, { context, prefix: "/web" });
-				return withCorsHeaders(request, result.response ?? new Response("Not Found", { status: 404 }));
-			},
-			"/web/*": async (request) => {
-				if (request.method === "OPTIONS") return createCorsResponse(request);
-
-				let context: NamespaceRequestContext;
-				try {
-					context = await createNamespaceRequestContext({ request, logger, authorizer: authorizeByNamespaceSession });
-				} catch (error) {
-					if (error instanceof UnauthorizedError) {
-						return withCorsHeaders(request, new Response(error.message, { status: 401 }));
-					}
-					logger.error({ error }, "Unhandled error");
-					return withCorsHeaders(request, new Response("Internal Server Error", { status: 500 }));
-				}
-
-				const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/web" });
-				return withCorsHeaders(request, result.response ?? new Response("Not Found", { status: 404 }));
-			},
+		fetch: async (request) => {
+			if (request.method === "OPTIONS") {
+				return createCorsResponse(request);
+			}
+			const response = await aiki.handler(request);
+			return withCorsHeaders(request, response);
 		},
-		fetch: async (request) => withCorsHeaders(request, new Response("Not Found", { status: 404 })),
 	});
 
 	let shutdownPromise: Promise<void> | undefined;
 	const shutdown = () => {
 		if (!shutdownPromise) {
 			shutdownPromise = (async () => {
-				await daemons.shutdown();
+				await runtimeHandle.stop();
 				if (redis) {
 					await redis.quit();
 				}

--- a/server/infra/db/pg/migrate.ts
+++ b/server/infra/db/pg/migrate.ts
@@ -1,11 +1,11 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Logger } from "@aikirun/lib/logger";
 import { sql } from "drizzle-orm";
 import { readMigrationFiles } from "drizzle-orm/migrator";
 import type { PgDatabaseConfig } from "server/config/schema";
 
 import { createPgDatabaseConn, type PgDatabaseOptions } from "./provider";
-import type { Logger } from "../../logger";
 
 const migrationsFolder = join(dirname(fileURLToPath(import.meta.url)), "migration");
 
@@ -32,7 +32,7 @@ export async function migratePg(options: PgDatabaseOptions | PgDatabaseConfig, l
 				continue;
 			}
 
-			logger.info({ hash: migration.hash.slice(0, 12) }, "applying migration");
+			logger.info("applying migration", { hash: migration.hash.slice(0, 12) });
 
 			await db.transaction(async (tx) => {
 				for (const statement of migration.sql) {

--- a/server/infra/logger/index.ts
+++ b/server/infra/logger/index.ts
@@ -1,10 +1,11 @@
+import type { Logger } from "@aikirun/lib/logger";
 import pino from "pino";
 import pretty from "pino-pretty";
 
 export const logLevels = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
 export type LogLevel = (typeof logLevels)[number];
 
-export function createLogger(logLevel: LogLevel, prettyLogs: boolean) {
+export function createLogger(logLevel: LogLevel, prettyLogs: boolean): Logger {
 	const baseOptions: pino.LoggerOptions = {
 		level: logLevel,
 		formatters: {
@@ -12,19 +13,28 @@ export function createLogger(logLevel: LogLevel, prettyLogs: boolean) {
 		},
 	};
 
-	if (prettyLogs) {
-		return pino(
-			baseOptions,
-			pretty({
-				colorize: true,
-				ignore: "pid,hostname",
-				translateTime: "yyyy-mm-dd HH:MM:ss",
-				singleLine: false,
-			})
-		);
-	}
+	const pinoLogger = prettyLogs
+		? pino(
+				baseOptions,
+				pretty({
+					colorize: true,
+					ignore: "pid,hostname",
+					translateTime: "yyyy-mm-dd HH:MM:ss",
+					singleLine: false,
+				})
+			)
+		: pino(baseOptions);
 
-	return pino(baseOptions);
+	return adaptPino(pinoLogger);
 }
 
-export type Logger = ReturnType<typeof createLogger>;
+function adaptPino(pinoLogger: pino.Logger): Logger {
+	return {
+		trace: (message, metadata) => pinoLogger.trace(metadata ?? {}, message),
+		debug: (message, metadata) => pinoLogger.debug(metadata ?? {}, message),
+		info: (message, metadata) => pinoLogger.info(metadata ?? {}, message),
+		warn: (message, metadata) => pinoLogger.warn(metadata ?? {}, message),
+		error: (message, metadata) => pinoLogger.error(metadata ?? {}, message),
+		child: (bindings) => adaptPino(pinoLogger.child(bindings)),
+	};
+}

--- a/server/middleware/context.ts
+++ b/server/middleware/context.ts
@@ -1,7 +1,7 @@
+import type { Logger } from "@aikirun/lib/logger";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { OrganizationId } from "@aikirun/types/organization";
 import type { OrganizationRole } from "server/infra/db/constants/organization";
-import type { Logger } from "server/infra/logger";
 import { ulid } from "ulidx";
 
 import type {

--- a/server/router/implementer.ts
+++ b/server/router/implementer.ts
@@ -72,17 +72,14 @@ function handleError<T extends ContextBase>(context: T, error: unknown) {
 	}
 
 	const cause = error instanceof Error && "cause" in error ? error.cause : undefined;
-	context.logger.error(
-		{
-			errorName: error instanceof Error ? error.name : "Unknown",
-			errorMessage: error instanceof Error ? error.message : String(error),
-			error,
-			...(cause && typeof cause === "object" && "issues" in cause
-				? { validationIssues: (cause as { issues: unknown }).issues }
-				: {}),
-		},
-		"Request error occurred"
-	);
+	context.logger.error("Request error occurred", {
+		errorName: error instanceof Error ? error.name : "Unknown",
+		errorMessage: error instanceof Error ? error.message : String(error),
+		error,
+		...(cause && typeof cause === "object" && "issues" in cause
+			? { validationIssues: (cause as { issues: unknown }).issues }
+			: {}),
+	});
 
 	throw error;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,0 +1,266 @@
+import { delay } from "@aikirun/lib/async";
+import { ConsoleLogger, type Logger } from "@aikirun/lib/logger";
+import type { CreateCache } from "@aikirun/types/infra/cache";
+import type { CreatePublisher } from "@aikirun/types/infra/queue";
+import type { CreateTimerSortedSet } from "@aikirun/types/infra/timer";
+import { RPCHandler } from "@orpc/server/fetch";
+import { ulid } from "ulidx";
+
+import type { DatabaseConfig } from "./config/schema";
+import { initDaemons } from "./daemons";
+import { UnauthorizedError } from "./errors";
+import { createDatabase } from "./infra/db";
+import { createAuthorizer } from "./middleware/authorization";
+import {
+	createNamespaceRequestContext,
+	createOrganizationRequestContext,
+	type NamespaceRequestContext,
+	type OrganizationRequestContext,
+} from "./middleware/context";
+import { createNamespaceAuthedRouter, createOrganizationAuthedRouter } from "./router/index";
+import { type ApiKeyAuthorizationInfo, createApiKeyService } from "./service/api-key";
+import { createAuthService } from "./service/auth";
+import { createChildRunCanceller } from "./service/cancel-child-runs";
+import { createNamespaceService } from "./service/namespace";
+import { createScheduleService } from "./service/schedule";
+import { createTaskStateMachineService } from "./service/task-state-machine";
+import { createWorkflowService } from "./service/workflow";
+import { createWorkflowRunService } from "./service/workflow-run";
+import { createWorkflowRunOutboxService } from "./service/workflow-run-outbox";
+import { createWorkflowRunStateMachineService } from "./service/workflow-run-state-machine";
+
+export interface ServerHandlerAuth {
+	secret: string;
+	baseURL: string;
+	trustedOrigins: string[];
+}
+
+export interface ServerHandlerParams {
+	auth: ServerHandlerAuth;
+	cache?: CreateCache;
+}
+
+export interface ServerRuntimeOptions {
+	gracefulShutdownTimeoutMs?: number;
+}
+
+export interface ServerRuntimeParams {
+	publisher?: CreatePublisher;
+	timerSortedSet?: CreateTimerSortedSet;
+	options?: ServerRuntimeOptions;
+}
+
+export interface ServerParams {
+	db: DatabaseConfig;
+	logger?: Logger;
+	handler: ServerHandlerParams;
+	runtime?: ServerRuntimeParams;
+}
+
+export type RuntimeId = string & { _brand: "runtime_id" };
+
+export interface RuntimeHandle {
+	id: RuntimeId;
+	stop: () => Promise<void>;
+}
+
+export interface Server {
+	handler: (request: Request) => Promise<Response>;
+	runtime: { start: () => Promise<RuntimeHandle> };
+}
+
+export function server(params: ServerParams): Server {
+	const logger: Logger = params.logger ?? new ConsoleLogger();
+	const { repos, conn, betterAuthSchema } = createDatabase(params.db);
+
+	const childRunCanceller = createChildRunCanceller();
+
+	const createHandler = () => {
+		const apiKeyService = createApiKeyService({
+			repos,
+			cache: params.handler.cache?.<ApiKeyAuthorizationInfo>({
+				logger: logger.child({ "aiki.component": "cache.apiKeyAuth" }),
+				keyPrefix: "api_key:",
+			}),
+		});
+		const authService = createAuthService({
+			conn,
+			provider: params.db.provider,
+			betterAuthSchema,
+			baseURL: params.handler.auth.baseURL,
+			secret: params.handler.auth.secret,
+			trustedOrigins: params.handler.auth.trustedOrigins,
+		});
+
+		const { authorizeByApiKey, authorizeByOrganizationSession, authorizeByNamespaceSession } = createAuthorizer(
+			apiKeyService,
+			authService,
+			repos.organization
+		);
+
+		const namespaceService = createNamespaceService(repos, apiKeyService);
+
+		const workflowRunStateMachineService = createWorkflowRunStateMachineService({
+			repos,
+			childRunCanceller,
+		});
+		const taskStateMachineService = createTaskStateMachineService({ repos });
+		const workflowRunService = createWorkflowRunService({
+			repos,
+			childRunCanceller,
+			workflowRunStateMachineService,
+		});
+		const workflowService = createWorkflowService({ repos });
+		const scheduleService = createScheduleService({ repos });
+		const workflowRunOutboxService = createWorkflowRunOutboxService({ repos });
+
+		const organizationAuthedRouter = createOrganizationAuthedRouter(namespaceService);
+		const namespaceAuthedRouter = createNamespaceAuthedRouter({
+			apiKeyService,
+			workflowRunService,
+			workflowRunStateMachineService,
+			taskStateMachineService,
+			workflowService,
+			scheduleService,
+			workflowRunOutboxService,
+		});
+
+		const organizationAuthedHandler = new RPCHandler(organizationAuthedRouter, {});
+		const namespaceAuthedHandler = new RPCHandler(namespaceAuthedRouter, {});
+
+		return async (request: Request): Promise<Response> => {
+			const pathname = new URL(request.url).pathname;
+
+			if (pathname.startsWith("/api/")) {
+				let context: NamespaceRequestContext;
+				try {
+					context = await createNamespaceRequestContext({ request, logger, authorizer: authorizeByApiKey });
+				} catch (error) {
+					if (error instanceof UnauthorizedError) {
+						return new Response(error.message, { status: 401 });
+					}
+					logger.error("Unhandled error", { error });
+					return new Response("Internal Server Error", { status: 500 });
+				}
+
+				const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/api" });
+				return result.response ?? new Response("Not Found", { status: 404 });
+			}
+
+			if (pathname.startsWith("/web/namespace/")) {
+				let context: OrganizationRequestContext;
+				try {
+					context = await createOrganizationRequestContext({
+						request,
+						logger,
+						authorizer: authorizeByOrganizationSession,
+					});
+				} catch (error) {
+					if (error instanceof UnauthorizedError) {
+						return new Response(error.message, { status: 401 });
+					}
+					logger.error("Unhandled error", { error });
+					return new Response("Internal Server Error", { status: 500 });
+				}
+
+				const result = await organizationAuthedHandler.handle(request, { context, prefix: "/web" });
+				return result.response ?? new Response("Not Found", { status: 404 });
+			}
+
+			if (pathname.startsWith("/web/")) {
+				let context: NamespaceRequestContext;
+				try {
+					context = await createNamespaceRequestContext({ request, logger, authorizer: authorizeByNamespaceSession });
+				} catch (error) {
+					if (error instanceof UnauthorizedError) {
+						return new Response(error.message, { status: 401 });
+					}
+					logger.error("Unhandled error", { error });
+					return new Response("Internal Server Error", { status: 500 });
+				}
+
+				const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/web" });
+				return result.response ?? new Response("Not Found", { status: 404 });
+			}
+
+			if (pathname.startsWith("/auth/")) {
+				return await authService.handler(request);
+			}
+
+			if (pathname === "/health") {
+				if (request.method !== "GET") {
+					return new Response("Method Not Allowed", { status: 405 });
+				}
+				return Response.json({ status: "ok" });
+			}
+
+			return new Response("Not Found", { status: 404 });
+		};
+	};
+
+	const createRuntime = () => ({
+		async start(): Promise<RuntimeHandle> {
+			const daemons = initDaemons(logger, {
+				repos,
+				workflowRunPublisher: params.runtime?.publisher?.({
+					logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
+				}),
+				timerSortedSet: params.runtime?.timerSortedSet?.({
+					logger: logger.child({ "aiki.component": "timer-sorted-set" }),
+				}),
+				childRunCanceller,
+			});
+
+			const gracefulShutdownTimeoutMs = params.runtime?.options?.gracefulShutdownTimeoutMs ?? 5_000;
+
+			return createRuntimeHandle({
+				logger,
+				daemons,
+				gracefulShutdownTimeoutMs,
+			});
+		},
+	});
+
+	return { handler: createHandler(), runtime: createRuntime() };
+}
+
+interface RuntimeHandleDeps {
+	logger: Logger;
+	daemons: { shutdown: () => Promise<void> };
+	gracefulShutdownTimeoutMs: number;
+}
+
+function createRuntimeHandle(deps: RuntimeHandleDeps): RuntimeHandle {
+	const id = ulid() as RuntimeId;
+	let stopPromise: Promise<void> | undefined;
+
+	const _stop = async (): Promise<void> => {
+		const daemonShutdownPromise = deps.daemons.shutdown();
+
+		if (deps.gracefulShutdownTimeoutMs <= 0) {
+			await daemonShutdownPromise;
+			return;
+		}
+
+		const result = await Promise.race([
+			daemonShutdownPromise.then(() => "done" as const),
+			delay(deps.gracefulShutdownTimeoutMs).then(() => "timeout" as const),
+		]);
+		if (result === "timeout") {
+			deps.logger.warn("Runtime did not shut down within graceful timeout", {
+				"aiki.runtimeId": id,
+				"aiki.gracefulShutdownTimeoutMs": deps.gracefulShutdownTimeoutMs,
+			});
+		}
+	};
+
+	return {
+		id,
+		stop(): Promise<void> {
+			if (!stopPromise) {
+				stopPromise = _stop();
+			}
+			return stopPromise;
+		},
+	};
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -37,7 +37,6 @@ export interface ServerHandlerAuth {
 
 export interface ServerHandlerParams {
 	auth: ServerHandlerAuth;
-	cache?: CreateCache;
 }
 
 export interface ServerRuntimeOptions {
@@ -52,6 +51,7 @@ export interface ServerRuntimeParams {
 
 export interface ServerParams {
 	db: DatabaseConfig;
+	cache?: CreateCache;
 	logger?: Logger;
 	handler: ServerHandlerParams;
 	runtime?: ServerRuntimeParams;
@@ -78,7 +78,7 @@ export function server(params: ServerParams): Server {
 	const createHandler = () => {
 		const apiKeyService = createApiKeyService({
 			repos,
-			cache: params.handler.cache?.<ApiKeyAuthorizationInfo>({
+			cache: params.cache?.<ApiKeyAuthorizationInfo>({
 				logger: logger.child({ "aiki.component": "cache.apiKeyAuth" }),
 				keyPrefix: "api_key:",
 			}),

--- a/server/service/auth.ts
+++ b/server/service/auth.ts
@@ -10,7 +10,7 @@ export interface AuthOptions {
 	betterAuthSchema: BetterAuthSchema;
 	baseURL: string;
 	secret: string;
-	corsOrigins: string[];
+	trustedOrigins: string[];
 }
 
 export function createAuthService(options: AuthOptions) {
@@ -19,7 +19,7 @@ export function createAuthService(options: AuthOptions) {
 		baseURL: options.baseURL,
 		basePath: "/auth",
 		secret: options.secret,
-		trustedOrigins: options.corsOrigins,
+		trustedOrigins: options.trustedOrigins,
 		advanced: {
 			defaultCookieAttributes: {
 				sameSite: "none",

--- a/server/service/cancel-child-runs.ts
+++ b/server/service/cancel-child-runs.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/array";
 import { hashInput } from "@aikirun/lib/crypto";
+import type { Logger } from "@aikirun/lib/logger";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import {
@@ -14,7 +15,6 @@ import type {
 	WorkflowRowInsert,
 	WorkflowRunRowInsert,
 } from "server/infra/db/types";
-import type { Logger } from "server/infra/logger";
 import { ulid } from "ulidx";
 
 export interface CancelledParentRun {
@@ -48,7 +48,7 @@ export function createChildRunCanceller() {
 				return;
 			}
 
-			logger.info({ parentRunIds: parentRunIdsHavingChildren }, "Scheduling cancel-child-runs workflows");
+			logger.info("Scheduling cancel-child-runs workflows", { parentRunIds: parentRunIdsHavingChildren });
 
 			const workflowEntries: WorkflowRowInsert[] = [];
 			const inputHashPromises: Array<Promise<string>> = [];

--- a/server/service/task-state-machine.ts
+++ b/server/service/task-state-machine.ts
@@ -120,7 +120,7 @@ async function transitionStateInTx(
 			state: taskState,
 		});
 
-		context.logger.info({ runId, taskId, taskState }, "Created new task");
+		context.logger.info("Created new task", { runId, taskId, taskState });
 
 		return { id: taskId, name: taskName, state: taskState, inputHash };
 	}
@@ -176,7 +176,7 @@ async function transitionStateInTx(
 		nextAttemptAt: taskState.status === "awaiting_retry" ? new Date(taskState.nextAttemptAt) : null,
 	});
 
-	context.logger.info({ runId, taskId, taskState }, "Transitioning task state");
+	context.logger.info("Transitioning task state", { runId, taskId, taskState });
 
 	return { id: taskId, name: taskName, state: taskState, inputHash };
 }

--- a/server/service/workflow-run-state-machine.ts
+++ b/server/service/workflow-run-state-machine.ts
@@ -225,7 +225,7 @@ async function transitionStateInTx(
 	const now = Date.now();
 	let toState = convertDurationsToTimestamps(request.state, now);
 
-	context.logger.info({ runId, state: toState, attempts: run.attempts }, "Workflow state transition");
+	context.logger.info("Workflow state transition", { runId, state: toState, attempts: run.attempts });
 
 	if (fromState.status === "sleeping" && toState.status === "scheduled") {
 		await finalizeSleep(runId, fromState.sleepName, toState, now, txRepos);
@@ -355,10 +355,11 @@ async function childWorkflowRunWaitNotNeeded(
 			childWorkflowRunStateTransitionId: childRun.latestStateTransitionId,
 		});
 
-		context.logger.info(
-			{ runId, childRunId, childRunStatus: childRun.status },
-			"Child already at status, scheduling immediately"
-		);
+		context.logger.info("Child already at status, scheduling immediately", {
+			runId,
+			childRunId,
+			childRunStatus: childRun.status,
+		});
 
 		return true;
 	}
@@ -441,10 +442,11 @@ async function notifyParentOfStateChangeIfNecessary(
 		parentRunState.childWorkflowRunId === childRun.id &&
 		parentRunState.childWorkflowRunStatus === childRun.status
 	) {
-		context.logger.info(
-			{ parentRunId: parentRun.id, childRunId: childRun.id, status: childRun.status },
-			"Notifying parent of child state change"
-		);
+		context.logger.info("Notifying parent of child state change", {
+			parentRunId: parentRun.id,
+			childRunId: childRun.id,
+			status: childRun.status,
+		});
 
 		await txRepos.childWorkflowRunWaitQueue.insert({
 			id: ulid(),

--- a/server/service/workflow-run.ts
+++ b/server/service/workflow-run.ts
@@ -426,7 +426,7 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 				const runningStateTransitionId = monotonic();
 				const finalStateTransitionId = monotonic();
 
-				context.logger.info({ runId, taskId, state: request.state }, "Setting task state (new task)");
+				context.logger.info("Setting task state (new task)", { runId, taskId, state: request.state });
 
 				const runningState: TaskState = {
 					status: "running",
@@ -477,10 +477,11 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 				throw new NotFoundError(`Task not found: ${request.taskId}`);
 			}
 
-			context.logger.info(
-				{ runId, taskId: request.taskId, state: request.state },
-				"Setting task state (existing task)"
-			);
+			context.logger.info("Setting task state (existing task)", {
+				runId,
+				taskId: request.taskId,
+				state: request.state,
+			});
 
 			const attempts = existingTaskRow.attempts;
 
@@ -627,7 +628,7 @@ async function createWorkflowRunInTx(
 				}
 			}
 
-			context.logger.info({ runId: existingRun.id, referenceId }, "Returning existing run from reference ID");
+			context.logger.info("Returning existing run from reference ID", { runId: existingRun.id, referenceId });
 			return existingRun.id as WorkflowRunId;
 		}
 	}
@@ -673,7 +674,7 @@ async function createWorkflowRunInTx(
 		state,
 	});
 
-	context.logger.info({ workflowName: name, versionId, runId, referenceId, options }, "Created workflow run");
+	context.logger.info("Created workflow run", { workflowName: name, versionId, runId, referenceId, options });
 
 	return runId;
 }

--- a/types/infra/cache.ts
+++ b/types/infra/cache.ts
@@ -15,4 +15,4 @@ export interface CacheContext {
 	logger: Logger;
 }
 
-export type CreateCache<V> = (context: CacheContext) => Cache<V> | Promise<Cache<V>>;
+export type CreateCache<V> = (context: CacheContext) => Cache<V>;

--- a/types/infra/cache.ts
+++ b/types/infra/cache.ts
@@ -13,6 +13,7 @@ export interface Cache<V> {
 
 export interface CacheContext {
 	logger: Logger;
+	keyPrefix?: string;
 }
 
-export type CreateCache<V> = (context: CacheContext) => Cache<V>;
+export type CreateCache = <V>(context: CacheContext) => Cache<V>;

--- a/types/infra/queue/publisher.ts
+++ b/types/infra/queue/publisher.ts
@@ -17,4 +17,4 @@ export interface PublisherContext {
 	logger: Logger;
 }
 
-export type CreatePublisher = (context: PublisherContext) => Publisher | Promise<Publisher>;
+export type CreatePublisher = (context: PublisherContext) => Publisher;

--- a/types/infra/queue/subscriber.ts
+++ b/types/infra/queue/subscriber.ts
@@ -25,4 +25,4 @@ export interface SubscriberContext {
 	logger: Logger;
 }
 
-export type CreateSubscriber = (context: SubscriberContext) => Subscriber | Promise<Subscriber>;
+export type CreateSubscriber = (context: SubscriberContext) => Subscriber;

--- a/types/infra/timer.ts
+++ b/types/infra/timer.ts
@@ -39,4 +39,4 @@ export interface TimerSortedSetContext {
 	logger: Logger;
 }
 
-export type CreateTimerSortedSet = (context: TimerSortedSetContext) => TimerSortedSet | Promise<TimerSortedSet>;
+export type CreateTimerSortedSet = (context: TimerSortedSetContext) => TimerSortedSet;


### PR DESCRIPTION
## Motivation

`@aikirun/server`'s entrypoint was a top-level script: load env, open Redis, build repos and services, mount oRPC handlers on `Bun.serve`, register signal handlers. To embed Aiki into another process or wire it against non-Redis infra, callers had to fork the script.

A few concepts that the rest of this description leans on:

- **Infrastructure factories** — `CreatePublisher`, `CreateCache`, `CreateTimerSortedSet`, `CreateSubscriber`. Each returns the corresponding adapter from a context. Their types previously allowed async construction (`(ctx) => T | Promise<T>`), even though no implementation ever used it.
- **Daemons** — background loops that drive scheduled runs, retries, the outbox publisher, the timer-tier consumer, etc. Not optional; without them queued work stalls.
- **Logger** — the server was bound directly to pino. For `server()` to accept a user-supplied logger, the server needs to talk to a generic logger interface, not a specific implementation.

## Solution

**Infrastructure factories are sync.** `Promise<T>` is gone from all four return types. Adapters that need async setup do it lazily at first use.

**`CreateCache` is generic per call.** `<V>` moves from the outer factory to the returned function, and `keyPrefix` moves from adapter options into `CacheContext`. A single `redisCache(redis)` can now produce caches of different value types and prefixes — the call site picks both.

**Pino is adapted.** The server now talks to the SDK's logger interface throughout. The wrapper script wraps pino behind that interface so the standalone process keeps using pino while the library no longer depends on it.

**`server()` factory.** New entrypoint that constructs everything from injected dependencies and returns `{ handler, runtime }`:

- `handler` is a Fetch-API-compatible `(Request) => Promise<Response>`. The host mounts it on whatever HTTP server it wants.
- `runtime.start()` instantiates the injected infrastructure factories and boots the daemons, returning a handle with an idempotent graceful `stop()`.
- The `runtime` param controls which accelerators get wired in; daemons always start when `runtime.start()` is called. A handler-only deployment is achieved by the host not calling `runtime.start()`.

The wrapper script keeps host concerns — env loading, Redis client, CORS, `Bun.serve`, signal handlers. `server()` owns Aiki.

## Breaking changes

- `CreatePublisher`, `CreateCache`, `CreateTimerSortedSet`, `CreateSubscriber` no longer accept `Promise<T>` returns.
- `redisCache(redis)` takes no second argument and no type parameter. Move `keyPrefix` and `V` to the call site that invokes the resulting factory. `RedisCacheOptions` is gone.
- `AuthOptions.corsOrigins` is renamed to `trustedOrigins`, matching the field better-auth ultimately receives.
