### PR TITLE
Move drizzle config to the CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,6 @@
         "aiki": "./dist/index.js",
       },
       "dependencies": {
-        "@aikirun/lib": "workspace:*",
         "@aikirun/server": "workspace:*",
         "cac": "^6.7.14",
         "dotenv": "^16.4.5",
@@ -72,6 +71,7 @@
         "postgres": "^3.4.8",
       },
       "devDependencies": {
+        "@aikirun/lib": "workspace:*",
         "drizzle-kit": "^0.31.8",
       },
     },
@@ -80,6 +80,9 @@
       "version": "0.27.0",
       "dependencies": {
         "dotenv": "^16.4.5",
+      },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
       },
     },
     "lib": {
@@ -92,6 +95,9 @@
       "dependencies": {
         "@aikirun/types": "workspace:*",
       },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
     "sdk/adapter/redis": {
       "name": "@aikirun/redis",
@@ -99,6 +105,9 @@
       "dependencies": {
         "@aikirun/types": "workspace:*",
         "ioredis": "^5.4.1",
+      },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
       },
     },
     "sdk/client": {
@@ -108,6 +117,9 @@
         "@aikirun/types": "workspace:*",
         "@orpc/client": "^1.9.3",
       },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
     "sdk/endpoint": {
       "name": "@aikirun/endpoint",
@@ -116,12 +128,14 @@
         "@aikirun/types": "workspace:*",
         "@aikirun/workflow": "workspace:*",
       },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
     "sdk/server": {
       "name": "@aikirun/server",
       "version": "0.27.0",
       "dependencies": {
-        "@aikirun/lib": "workspace:*",
         "@aikirun/types": "workspace:*",
         "@orpc/contract": "^1.9.3",
         "@orpc/server": "^1.9.3",
@@ -133,7 +147,7 @@
         "ulidx": "^2.4.1",
       },
       "devDependencies": {
-        "drizzle-kit": "^0.31.8",
+        "@aikirun/lib": "workspace:*",
       },
     },
     "sdk/worker": {
@@ -144,6 +158,9 @@
         "@aikirun/workflow": "workspace:*",
         "ulidx": "^2.4.1",
       },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
     "sdk/workflow": {
       "name": "@aikirun/workflow",
@@ -152,10 +169,16 @@
         "@aikirun/types": "workspace:*",
         "@standard-schema/spec": "^1.1.0",
       },
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
     "types": {
       "name": "@aikirun/types",
       "version": "0.27.0",
+      "devDependencies": {
+        "@aikirun/lib": "workspace:*",
+      },
     },
   },
   "packages": {

--- a/cli/drizzle.config.ts
+++ b/cli/drizzle.config.ts
@@ -1,6 +1,5 @@
+import { type DatabaseProvider, loadDatabaseConfig } from "@aikirun/server/config";
 import type { Config as DrizzleConfig } from "drizzle-kit";
-
-import { type DatabaseProvider, loadDatabaseConfig } from "../../config";
 
 const providerDialects: Record<DatabaseProvider, DrizzleConfig["dialect"]> = {
 	pg: "postgresql",

--- a/cli/src/commands/migrate-generate.ts
+++ b/cli/src/commands/migrate-generate.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { loadDatabaseConfig } from "@aikirun/server/config";
+import { fileURLToPath } from "node:url";
+import { type DatabaseProvider, loadDatabaseConfig } from "@aikirun/server/config";
 
 import { loadEnv } from "../lib/env";
 import { resolveServerRoot } from "../lib/resolve-server";
@@ -13,10 +14,12 @@ interface MigrateGenerateOptions {
 
 export async function migrateGenerate(options: MigrateGenerateOptions): Promise<void> {
 	loadEnv(options.envFile);
-	loadDatabaseConfig();
+	const dbConfig = loadDatabaseConfig();
 
 	const serverRoot = resolveServerRoot();
-	const configPath = resolveDrizzleConfigPath(serverRoot);
+	ensureWorkspaceMode(serverRoot, dbConfig.provider);
+
+	const configPath = resolveDrizzleConfigPath();
 	const args = ["drizzle-kit", "generate", "--config", configPath];
 	if (options.custom) {
 		args.push("--custom");
@@ -25,14 +28,26 @@ export async function migrateGenerate(options: MigrateGenerateOptions): Promise<
 	await spawnDrizzle(args, serverRoot);
 }
 
-function resolveDrizzleConfigPath(serverRoot: string): string {
-	const configPath = path.join(serverRoot, "infra", "db", "drizzle.config.ts");
-	if (!fs.existsSync(configPath)) {
+function ensureWorkspaceMode(serverRoot: string, provider: DatabaseProvider): void {
+	const schemaDir = path.join(serverRoot, "infra", "db", provider, "schema");
+	if (!fs.existsSync(schemaDir)) {
 		throw new Error(
 			"aiki migrate generate is only supported inside the Aiki monorepo. Schema generation is a maintainer operation; end users do not need it."
 		);
 	}
-	return configPath;
+}
+
+function resolveDrizzleConfigPath(): string {
+	// Source mode runs from cli/src/commands/, compiled mode runs from cli/dist/.
+	// Walk up until we hit the first package.json — in both layouts that's the cli package root.
+	let dir = path.dirname(fileURLToPath(import.meta.url));
+	while (dir !== path.dirname(dir)) {
+		if (fs.existsSync(path.join(dir, "package.json"))) {
+			return path.join(dir, "drizzle.config.ts");
+		}
+		dir = path.dirname(dir);
+	}
+	throw new Error("Could not locate @aikirun/cli root for drizzle.config.ts");
 }
 
 function spawnDrizzle(args: string[], cwd: string): Promise<void> {

--- a/sdk/server/package.json
+++ b/sdk/server/package.json
@@ -34,8 +34,7 @@
 		"ulidx": "^2.4.1"
 	},
 	"devDependencies": {
-		"@aikirun/lib": "workspace:*",
-		"drizzle-kit": "^0.31.8"
+		"@aikirun/lib": "workspace:*"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
The `drizzle.config.ts` consumed by `aiki migrate generate` was living in `@aikirun/server`. That forced the runtime library to carry a `drizzle-kit` devDependency it had no other use for, and co-located a maintainer-only artifact (the config exists only to drive schema generation, which is itself workspace-only) with the runtime library.

It now lives in `@aikirun/cli` next to the command that consumes it. `@aikirun/server` no longer depends on `drizzle-kit`. `aiki migrate apply` is unchanged.