### PR TITLE
Noop Api authorizer

### DIFF
--- a/sdk/server/src/middleware/context.ts
+++ b/sdk/server/src/middleware/context.ts
@@ -49,7 +49,9 @@ export async function createNamespaceRequestContext(params: {
 	const { request, logger, authorizer } = params;
 	const traceId = request.headers.get("x-trace-id") ?? ulid();
 	const spanId = ulid();
-	const authorization = await authorizer(request);
+	const authorization = authorizer(request);
+	const { organizationId, namespaceId, userId } =
+		authorization instanceof Promise ? await authorization : authorization;
 
 	return {
 		type: "request",
@@ -65,9 +67,9 @@ export async function createNamespaceRequestContext(params: {
 		headers: request.headers,
 		method: request.method,
 		url: request.url,
-		organizationId: authorization.organizationId,
-		namespaceId: authorization.namespaceId,
-		userId: authorization.userId,
+		organizationId,
+		namespaceId,
+		userId,
 	};
 }
 

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -1,11 +1,13 @@
 import { delay } from "@aikirun/lib/async";
 import { UnauthorizedError } from "@aikirun/lib/error";
 import { ConsoleLogger, type Logger } from "@aikirun/lib/logger";
-import type { Iam } from "@aikirun/types/iam";
+import type { ApiAuthorizer, Iam, IamContext } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
 import type { Database } from "@aikirun/types/infra/db";
 import type { CreatePublisher } from "@aikirun/types/infra/queue";
 import type { CreateTimerSortedSet } from "@aikirun/types/infra/timer";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { OrganizationId } from "@aikirun/types/organization";
 import { RPCHandler } from "@orpc/server/fetch";
 import { ulid } from "ulidx";
 
@@ -33,7 +35,7 @@ export interface ServerRuntimeParams {
 
 export interface ServerParams {
 	db: Database;
-	iam: Iam;
+	iam?: Iam;
 	cache?: CreateCache;
 	logger?: Logger;
 	runtime?: ServerRuntimeParams;
@@ -58,8 +60,8 @@ export function server(params: ServerParams): Server {
 	const childRunCanceller = createChildRunCanceller();
 
 	const createHandler = () => {
-		const apiAuthorizer = params.iam.api?.({ logger });
-		const dashboardIam = params.iam.dashboard?.({ logger });
+		const apiAuthorizer = (params.iam?.api ?? noopApiAuthorizer)({ logger });
+		const dashboardIam = params.iam?.dashboard?.({ logger });
 
 		const workflowRunStateMachineService = createWorkflowRunStateMachineService({
 			repos,
@@ -90,10 +92,6 @@ export function server(params: ServerParams): Server {
 			const pathname = new URL(request.url).pathname;
 
 			if (pathname.startsWith("/api/")) {
-				if (!apiAuthorizer) {
-					return new Response("Not Found", { status: 404 });
-				}
-
 				let context: NamespaceRequestContext;
 				try {
 					context = await createNamespaceRequestContext({ request, logger, authorizer: apiAuthorizer });
@@ -158,6 +156,16 @@ export function server(params: ServerParams): Server {
 	});
 
 	return { handler: createHandler(), runtime: createRuntime() };
+}
+
+function noopApiAuthorizer(_context: IamContext): ApiAuthorizer {
+	const noopOrganizationId = "00000000000000000000000000" as OrganizationId;
+	const noopNamespaceId = "00000000000000000000000000" as NamespaceId;
+
+	return async () => ({
+		organizationId: noopOrganizationId,
+		namespaceId: noopNamespaceId,
+	});
 }
 
 interface RuntimeHandleDeps {

--- a/types/src/iam.ts
+++ b/types/src/iam.ts
@@ -9,7 +9,7 @@ export interface ApiAuthorization {
 	userId?: string;
 }
 
-export type ApiAuthorizer = (request: Request) => Promise<ApiAuthorization>;
+export type ApiAuthorizer = (request: Request) => ApiAuthorization | Promise<ApiAuthorization>;
 export type DashboardAuthenticator = (request: Request) => Promise<Response>;
 export type OrganizationDashboardHandler = (request: Request) => Promise<Response>;
 


### PR DESCRIPTION
## Motivation

The server's pluggable identity & access management (IAM) layer — a slot the embedder fills with an authorizer that resolves each incoming request to an `organizationId` and a `namespaceId` — is required today. Even a single-tenant local-dev or trusted-network deployment has to pick (or implement) an authorizer before the server will start. That closes off the zero-friction path: open a database, point the server at it, send workflow API calls from anywhere.

## Solution

Make the IAM config optional. When the embedder omits it, the server falls back to a built-in noop authorizer that assigns every request to a single sentinel tenant — both the organization and namespace identifiers are the all-zero ULID, which parses as a valid ULID, sorts before any real value, and is recognizable at a glance. No DB writes, no row seeding, no "default tenant" enum, no rediscovery on restart.

The dashboard surface is untouched for. With no IAM configured there is no authenticated browser flow and no organization to manage, so the dashboard and auth route prefixes continue to return 404. There may be a need for authless dashboards; I will come to this at a later time.

The authorizer signature also relaxes to permit a synchronous return. The noop has no I/O to await, and the dispatch call site already branches on `Promise` to avoid an unnecessary microtask in that hot path.