### PR TITLE
Optional client API key

### DIFF
--- a/sdk/client/src/client.ts
+++ b/sdk/client/src/client.ts
@@ -56,9 +56,7 @@ class ClientImpl<AppContext> implements Client<AppContext> {
 
 		const rpcLink = new RPCLink({
 			url: `${params.url}/api`,
-			headers: () => ({
-				Authorization: `Bearer ${apiKey}`,
-			}),
+			headers: () => (apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
 		});
 		// Type safety: The server package has compile-time tests (see server/contract/workflow-run/procedure.ts)
 		// that verify the contract matches WorkflowRunApi. If the contract changes, server won't compile.

--- a/types/src/client.ts
+++ b/types/src/client.ts
@@ -7,7 +7,7 @@ import type { WorkflowRun } from "./workflow/run";
 
 export interface ClientParams<AppContext = null> {
 	url: string;
-	apiKey: string;
+	apiKey?: string;
 	logger?: Logger;
 	appContext?: (run: Readonly<WorkflowRun>) => AppContext | Promise<AppContext>;
 }


### PR DESCRIPTION
## Motivation

The noop authorizer landed on the server side but the client still required an `apiKey`. A noop deployment has no key to issue, so the zero-friction path stopped at the server boundary — embedders had to pass a placeholder string just to satisfy the type.

## Solution

Make `apiKey` optional. When absent, the client omits the `Authorization` header entirely rather than sending an empty `Bearer ` value. Real deployments pass a key exactly as before; noop deployments simply leave it off.