### PR TITLE
Noop dashboard via capabilities probe

### DIFF
--- a/app/dashboard/Dockerfile
+++ b/app/dashboard/Dockerfile
@@ -23,6 +23,7 @@ RUN bun install --frozen-lockfile
 COPY lib/ ./lib/
 COPY types/ ./types/
 COPY sdk/iam/ ./sdk/iam/
+COPY sdk/server/ ./sdk/server/
 COPY app/dashboard/ ./app/dashboard/
 COPY tsconfig.json ./
 

--- a/app/dashboard/package.json
+++ b/app/dashboard/package.json
@@ -19,6 +19,7 @@
 	},
 	"devDependencies": {
 		"@aikirun/iam": "workspace:*",
+		"@aikirun/server": "workspace:*",
 		"@orpc/contract": "^1.4.3",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",

--- a/app/dashboard/src/App.tsx
+++ b/app/dashboard/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { useAuth } from "./auth/AuthProvider";
+import { useCapabilities } from "./capabilities/CapabilitiesProvider";
 import { NotFound } from "./components/common/NotFound";
 import { AppShell } from "./components/layout/AppShell";
 import { SettingsLayout } from "./components/layout/SettingsLayout";
@@ -17,32 +18,45 @@ import { SchedulesList } from "./pages/SchedulesList";
 import { OnboardingRoute, ProtectedRoute } from "./routes/ProtectedRoute";
 
 export default function App() {
+	const { iam } = useCapabilities();
+
 	return (
 		<Routes>
-			{/* Public auth routes */}
-			<Route path="/auth/sign-in" element={<SignIn />} />
-			<Route path="/auth/sign-up" element={<SignUp />} />
+			{iam.dashboard ? (
+				<>
+					{/* Public auth routes */}
+					<Route path="/auth/sign-in" element={<SignIn />} />
+					<Route path="/auth/sign-up" element={<SignUp />} />
 
-			{/* Public: invitation acceptance — handles its own auth redirect logic */}
-			<Route path="/invite/:invitationId" element={<AcceptInvitation />} />
+					{/* Public: invitation acceptance — handles its own auth redirect logic */}
+					<Route path="/invite/:invitationId" element={<AcceptInvitation />} />
 
-			{/* Onboarding routes - authenticated but may not have org/namespace */}
-			<Route
-				path="/onboarding/organization"
-				element={
-					<OnboardingRoute>
-						<CreateOrganization />
-					</OnboardingRoute>
-				}
-			/>
-			<Route
-				path="/onboarding/namespace"
-				element={
-					<OnboardingRoute>
-						<CreateNamespace />
-					</OnboardingRoute>
-				}
-			/>
+					{/* Onboarding routes - authenticated but may not have org/namespace */}
+					<Route
+						path="/onboarding/organization"
+						element={
+							<OnboardingRoute>
+								<CreateOrganization />
+							</OnboardingRoute>
+						}
+					/>
+					<Route
+						path="/onboarding/namespace"
+						element={
+							<OnboardingRoute>
+								<CreateNamespace />
+							</OnboardingRoute>
+						}
+					/>
+				</>
+			) : (
+				<>
+					{/* Noop mode: dashboard-only paths redirect home */}
+					<Route path="/auth/*" element={<Navigate to="/" replace />} />
+					<Route path="/onboarding/*" element={<Navigate to="/" replace />} />
+					<Route path="/invite/*" element={<Navigate to="/" replace />} />
+				</>
+			)}
 
 			{/* Protected routes - require full auth with org and namespace */}
 			<Route
@@ -56,11 +70,15 @@ export default function App() {
 				<Route path="/runs/:id" element={<RunDetail />} />
 				<Route path="/schedules" element={<SchedulesList />} />
 
-				<Route path="/settings" element={<SettingsLayout />}>
-					<Route index element={<SettingsRedirect />} />
-					<Route path="api-keys" element={<ApiKeys />} />
-					<Route path="organization" element={<OrganizationSettings />} />
-				</Route>
+				{iam.dashboard ? (
+					<Route path="/settings" element={<SettingsLayout />}>
+						<Route index element={<SettingsRedirect />} />
+						<Route path="api-keys" element={<ApiKeys />} />
+						<Route path="organization" element={<OrganizationSettings />} />
+					</Route>
+				) : (
+					<Route path="/settings/*" element={<Navigate to="/" replace />} />
+				)}
 
 				{/* Redirects from old routes */}
 				<Route path="/workflow/:name/run/:id" element={<OldRunRedirect />} />

--- a/app/dashboard/src/api/client.ts
+++ b/app/dashboard/src/api/client.ts
@@ -6,7 +6,7 @@ import { createORPCClient } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { ContractRouterClient } from "@orpc/contract";
 
-const AIKI_SERVER_URL = import.meta.env.VITE_AIKI_SERVER_URL || "http://localhost:9850";
+import { AIKI_SERVER_URL } from "../config";
 
 const fetchWithCredentials = (url: RequestInfo | URL, options?: RequestInit) =>
 	fetch(url, { ...options, credentials: "include" });

--- a/app/dashboard/src/auth/AuthProvider.tsx
+++ b/app/dashboard/src/auth/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, type ReactNode, useCallback, useContext, useEffect, useS
 
 import { authClient } from "./client";
 import { namespaceManagementClient } from "../api/client";
+import { useCapabilities } from "../capabilities/CapabilitiesProvider";
 
 interface Organization {
 	id: string;
@@ -44,7 +45,51 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+const NOOP_SENTINEL_ID = "00000000000000000000000000";
+
+const NOOP_ORGANIZATION: Organization = {
+	id: NOOP_SENTINEL_ID,
+	name: "default",
+	slug: "default",
+	createdAt: new Date(0),
+};
+
+const NOOP_NAMESPACE: Namespace = {
+	id: NOOP_SENTINEL_ID,
+	name: "default",
+	role: "admin",
+	createdAt: new Date(0),
+};
+
+const NOOP_CONTEXT_VALUE: AuthContextValue = {
+	isLoading: false,
+	isAuthenticated: true,
+	user: null,
+	organizations: [NOOP_ORGANIZATION],
+	namespaces: [NOOP_NAMESPACE],
+	activeOrganization: NOOP_ORGANIZATION,
+	activeNamespace: NOOP_NAMESPACE,
+	setActiveOrganization: async () => {},
+	setActiveNamespace: async () => {},
+	refreshOrganizations: async () => {},
+	refreshNamespaces: async () => {},
+	signOut: async () => {},
+	refetchSession: async () => {},
+};
+
 export function AuthProvider({ children }: { children: ReactNode }) {
+	const { iam } = useCapabilities();
+	if (!iam.dashboard) {
+		return <NoopAuthProvider>{children}</NoopAuthProvider>;
+	}
+	return <FullAuthProvider>{children}</FullAuthProvider>;
+}
+
+function NoopAuthProvider({ children }: { children: ReactNode }) {
+	return <AuthContext.Provider value={NOOP_CONTEXT_VALUE}>{children}</AuthContext.Provider>;
+}
+
+function FullAuthProvider({ children }: { children: ReactNode }) {
 	const queryClient = useQueryClient();
 	const { data: session, isPending: sessionLoading, refetch } = authClient.useSession();
 

--- a/app/dashboard/src/auth/client.ts
+++ b/app/dashboard/src/auth/client.ts
@@ -1,7 +1,7 @@
 import { organizationClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
-const AIKI_SERVER_URL = import.meta.env.VITE_AIKI_SERVER_URL || "http://localhost:9850";
+import { AIKI_SERVER_URL } from "../config";
 
 export const authClient = createAuthClient({
 	baseURL: AIKI_SERVER_URL,

--- a/app/dashboard/src/capabilities/CapabilitiesProvider.tsx
+++ b/app/dashboard/src/capabilities/CapabilitiesProvider.tsx
@@ -1,0 +1,21 @@
+import type { Capabilities } from "@aikirun/server/capabilities";
+import { createContext, type ReactNode, useContext } from "react";
+
+const CapabilitiesContext = createContext<Capabilities | null>(null);
+
+interface CapabilitiesProviderProps {
+	value: Capabilities;
+	children: ReactNode;
+}
+
+export function CapabilitiesProvider({ value, children }: CapabilitiesProviderProps) {
+	return <CapabilitiesContext.Provider value={value}>{children}</CapabilitiesContext.Provider>;
+}
+
+export function useCapabilities(): Capabilities {
+	const value = useContext(CapabilitiesContext);
+	if (!value) {
+		throw new Error("useCapabilities must be called within a CapabilitiesProvider");
+	}
+	return value;
+}

--- a/app/dashboard/src/components/layout/Sidebar.tsx
+++ b/app/dashboard/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../auth/AuthProvider";
+import { useCapabilities } from "../../capabilities/CapabilitiesProvider";
 import { getNamespaceDotColor } from "../../constants/namespace";
 import { useTheme } from "../../hooks/useTheme";
 
@@ -24,6 +25,7 @@ export function Sidebar() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const { signOut, user } = useAuth();
+	const { iam } = useCapabilities();
 
 	useEffect(() => {
 		const mql = window.matchMedia(SMALL_SCREEN_QUERY);
@@ -83,10 +85,12 @@ export function Sidebar() {
 			</div>
 
 			{/* Org & Namespace Switchers */}
-			<div style={{ padding: collapsed ? "0 6px 10px" : "0 8px 10px" }}>
-				<OrgSwitcher collapsed={collapsed} />
-				<NamespaceSwitcher collapsed={collapsed} />
-			</div>
+			{iam.dashboard && (
+				<div style={{ padding: collapsed ? "0 6px 10px" : "0 8px 10px" }}>
+					<OrgSwitcher collapsed={collapsed} />
+					<NamespaceSwitcher collapsed={collapsed} />
+				</div>
+			)}
 
 			{/* Navigation */}
 			<nav
@@ -108,13 +112,15 @@ export function Sidebar() {
 			<div
 				style={{ padding: collapsed ? "0 6px 12px" : "0 8px 12px", display: "flex", flexDirection: "column", gap: 2 }}
 			>
-				<NavButton
-					icon="⚙"
-					label="Settings"
-					active={location.pathname.startsWith("/settings")}
-					collapsed={collapsed}
-					onClick={() => navigate("/settings")}
-				/>
+				{iam.dashboard && (
+					<NavButton
+						icon="⚙"
+						label="Settings"
+						active={location.pathname.startsWith("/settings")}
+						collapsed={collapsed}
+						onClick={() => navigate("/settings")}
+					/>
+				)}
 
 				<ThemeToggle collapsed={collapsed} />
 

--- a/app/dashboard/src/config.ts
+++ b/app/dashboard/src/config.ts
@@ -1,0 +1,1 @@
+export const AIKI_SERVER_URL = import.meta.env.VITE_AIKI_SERVER_URL || "http://localhost:9850";

--- a/app/dashboard/src/main.tsx
+++ b/app/dashboard/src/main.tsx
@@ -1,3 +1,4 @@
+import type { Capabilities } from "@aikirun/server/capabilities";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -5,7 +6,9 @@ import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 import { AuthProvider } from "./auth/AuthProvider";
+import { CapabilitiesProvider } from "./capabilities/CapabilitiesProvider";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { AIKI_SERVER_URL } from "./config";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -25,17 +28,76 @@ const queryClient = new QueryClient({
 	},
 });
 
+async function loadCapabilities(): Promise<Capabilities> {
+	const response = await fetch(`${AIKI_SERVER_URL}/capabilities`);
+	if (!response.ok) {
+		throw new Error(`Failed to load capabilities: HTTP ${response.status}`);
+	}
+	return response.json();
+}
+
+function CapabilitiesError({ error }: { error: unknown }) {
+	const message = error instanceof Error ? error.message : String(error);
+	return (
+		<div
+			style={{
+				minHeight: "100vh",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 24,
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			<div style={{ maxWidth: 420, textAlign: "center" }}>
+				<h1 style={{ fontSize: 18, fontWeight: 700, marginBottom: 12 }}>Unable to reach Aiki server</h1>
+				<p style={{ fontSize: 13, color: "#888", lineHeight: 1.5, marginBottom: 16 }}>
+					Could not load server capabilities from <code>{AIKI_SERVER_URL}</code>. Check that the server is running and
+					reachable.
+				</p>
+				<pre
+					style={{
+						fontSize: 11,
+						background: "#f5f5f5",
+						padding: 8,
+						borderRadius: 4,
+						color: "#444",
+						overflow: "auto",
+						textAlign: "left",
+						display: "inline-block",
+						maxWidth: "100%",
+						margin: 0,
+					}}
+				>
+					{message}
+				</pre>
+			</div>
+		</div>
+	);
+}
+
 // biome-ignore lint/style/noNonNullAssertion: root element is guaranteed to exist
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<ErrorBoundary>
-			<QueryClientProvider client={queryClient}>
-				<BrowserRouter>
-					<AuthProvider>
-						<App />
-					</AuthProvider>
-				</BrowserRouter>
-			</QueryClientProvider>
-		</ErrorBoundary>
-	</StrictMode>
+const root = createRoot(document.getElementById("root")!);
+
+loadCapabilities().then(
+	(capabilities) => {
+		root.render(
+			<StrictMode>
+				<ErrorBoundary>
+					<CapabilitiesProvider value={capabilities}>
+						<QueryClientProvider client={queryClient}>
+							<BrowserRouter>
+								<AuthProvider>
+									<App />
+								</AuthProvider>
+							</BrowserRouter>
+						</QueryClientProvider>
+					</CapabilitiesProvider>
+				</ErrorBoundary>
+			</StrictMode>
+		);
+	},
+	(error) => {
+		root.render(<CapabilitiesError error={error} />);
+	}
 );

--- a/app/dashboard/tsconfig.json
+++ b/app/dashboard/tsconfig.json
@@ -5,6 +5,8 @@
 			"@aikirun/iam": ["./sdk/iam/src/index.ts"],
 			"@aikirun/iam/*": ["./sdk/iam/src/*.ts", "./sdk/iam/src/*/index.ts"],
 			"@aikirun/lib/*": ["./lib/src/*/index.ts"],
+			"@aikirun/server": ["./sdk/server/src/index.ts"],
+			"@aikirun/server/*": ["./sdk/server/src/*.ts", "./sdk/server/src/*/index.ts"],
 			"@aikirun/types": ["./types/src/index.ts"],
 			"@aikirun/types/*": ["./types/src/*.ts", "./types/src/*/index.ts"]
 		},

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@aikirun/iam": "workspace:*",
+        "@aikirun/server": "workspace:*",
         "@orpc/contract": "^1.4.3",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",

--- a/sdk/iam/src/dashboard-session.ts
+++ b/sdk/iam/src/dashboard-session.ts
@@ -25,8 +25,8 @@ import { createNamespaceService } from "./service/namespace";
 
 export interface OrganizationDashboardAuthorization {
 	organizationId: OrganizationId;
-	userId: string;
 	organizationRole: OrganizationRole;
+	userId: string;
 }
 
 export interface DashboardSessionIamParams {

--- a/sdk/server/src/capabilities.ts
+++ b/sdk/server/src/capabilities.ts
@@ -1,0 +1,5 @@
+export interface Capabilities {
+	iam: {
+		dashboard: boolean;
+	};
+}

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -11,6 +11,7 @@ import type { OrganizationId } from "@aikirun/types/organization";
 import { RPCHandler } from "@orpc/server/fetch";
 import { ulid } from "ulidx";
 
+import type { Capabilities } from "./capabilities";
 import { initDaemons } from "./daemons";
 import { createRepos } from "./infra/db/repo";
 import { createNamespaceRequestContext, type NamespaceRequestContext } from "./middleware/context";
@@ -108,17 +109,26 @@ export function server(params: ServerParams): Server {
 			}
 
 			if (pathname.startsWith("/dashboard/")) {
-				if (!dashboardIam) {
+				if (!dashboardIam?.organization) {
 					return new Response("Not Found", { status: 404 });
 				}
 				return dashboardIam.organization(request);
 			}
 
 			if (pathname.startsWith("/auth/")) {
-				if (!dashboardIam) {
+				if (!dashboardIam?.authenticator) {
 					return new Response("Not Found", { status: 404 });
 				}
 				return dashboardIam.authenticator(request);
+			}
+
+			if (pathname === "/capabilities") {
+				if (request.method !== "GET") {
+					return new Response("Method Not Allowed", { status: 405 });
+				}
+				return Response.json({
+					iam: { dashboard: dashboardIam !== undefined },
+				} satisfies Capabilities);
 			}
 
 			if (pathname === "/health") {


### PR DESCRIPTION
## Motivation

Aiki's IAM is pluggable: `server({ db })` without an `iam` config make it run in **noop mode** — `/api/*` is served by a built-in noop authorizer that returns hardcoded sentinel organization and namespace IDs, and the `/dashboard/*` and `/auth/*` route branches return 404 because no IAM is mounted. This is the zero-config path for users who don't want to deploy authentication.

The browser-facing app (`@aikirun/app-dashboard`) had no knowledge of this mode. It mounted Better Auth unconditionally, the routing tree always included `/auth/sign-in`, the protected-route gate always redirected unauthenticated users there, and the sidebar always exposed admin pages whose data layer talks to `/dashboard/*`. Against a noop server, sign-in 404s, admin pages 404, and the user is funneled into a flow that has no backend to talk to.

This PR closes that gap by introducing a **capabilities probe** — a one-shot signal from the server describing which IAM slots are wired up — and adapting the frontend to render only the surface that actually has a backend behind it.

## Solution

**Server side.** A new public `GET /capabilities` endpoint returns the IAM configuration shape as a small JSON object. The endpoint is unauthenticated by necessity (the caller doesn't yet know whether authentication is required) and is mounted alongside `/health` rather than through the oRPC layer — both are HTTP-idiomatic ops endpoints (GET, no envelope, curl-able, consumable by load balancers and bootstrap code), and the dashboard's probe runs before the React tree (and therefore the RPC client) exists. The response shape is:
```typescript
interface Capabilities {
	iam: {
		dashboard: boolean;
	};
}
```
This gives room for additional per-slot signals later without breaking consumers.

**Type ownership.** The `Capabilities` interface lives in the server package and is consumed by the dashboard via a tsconfig path alias, matching the pattern already used for `@aikirun/iam/contract` types. The types package stays reserved for contracts shared across SDKs packages.

**Frontend.** The dashboard fetches `/capabilities` in `main.tsx` before mounting any React subtree and provides the result through a context. Probe failure (server unreachable, network error) renders a self-contained error page in place of the app — no half-mounted UI. From there, three pieces adapt to the capability:

- **Routing.** Routes that only make sense with a dashboard IAM (`/auth/*`, `/onboarding/*`, `/invite/*`, `/settings/*`) are conditionally registered. In noop mode those paths redirect to `/` instead of falling through to a `NotFound` page.

- **AuthProvider.** Splits into two implementations. The full provider is unchanged: Better Auth session + dashboard CRUD for org/namespace lists. The noop provider is a thin context that synthesizes a sentinel organization and namespace (matching the server-side sentinel IDs) with role `admin` and `user: null`. This lets the existing `ProtectedRoute` / `AppShell` gates pass without threading capability awareness through every guard — they already check for an active org/namespace, and the synthesized sentinels satisfy that check.

- **Sidebar.** Org and namespace selectors and the Settings nav are gated by the capability. The user menu hides naturally because `user === null` in noop mode.

All `/dashboard/*` fetches in the codebase live either inside the full AuthProvider or inside pages reachable only from gated routes, so no per-fetch guard is needed; the structural gating is sufficient.

**Shared server-URL config.** The `import.meta.env.VITE_AIKI_SERVER_URL || "http://localhost:9850"` literal that previously appeared in two API client files (and would have made a third copy here) is extracted to a single module.

## Behavior comparison

| | Noop mode | Full mode |
|---|---|---|
| Workflow viewing (runs, schedules) | rendered | rendered | | `/auth/sign-in` | redirects to `/` | sign-in form | | `/settings/*` | redirects to `/` | API keys + org settings | | `/invite/:id` | redirects to `/` | invitation acceptance | | Sidebar org/namespace selectors | hidden | shown | | Sidebar Settings nav | hidden | shown |
| User menu + sign-out | hidden (no user) | shown | | `/api/*` workflow calls | sentinel-tenant routing | session/API-key routing |