### PR TITLE
Fix dangling state_transition rows in queueing daemons

### DIFF
--- a/sdk/server/src/daemons/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemons/imminent-child-run-wait-timed-out-runs.ts
@@ -161,26 +161,43 @@ async function processChunk(
 		});
 	}
 
-	if (
-		!isNonEmptyArray(childRunWaitEntries) ||
-		!isNonEmptyArray(stateTransitionEntries) ||
-		!isNonEmptyArray(workflowRunUpdates)
-	) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.childWorkflowRunWaitQueue.insert(childRunWaitEntries);
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
 			"awaiting_child_workflow",
 			workflowRunUpdates
 		);
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}
+
+		let childRunWaitEntriesToInsert = childRunWaitEntries;
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			childRunWaitEntriesToInsert = childRunWaitEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.parentWorkflowRunId)
+			);
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (
+			!isNonEmptyArray(childRunWaitEntriesToInsert) ||
+			!isNonEmptyArray(stateTransitionEntriesToInsert) ||
+			!isNonEmptyArray(outboxEntriesToInsert)
+		) {
+			return [];
+		}
+
+		await txRepos.childWorkflowRunWaitQueue.insert(childRunWaitEntriesToInsert);
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});

--- a/sdk/server/src/daemons/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemons/imminent-event-wait-timed-out-runs.ts
@@ -161,23 +161,38 @@ async function processChunk(
 		});
 	}
 
-	if (
-		!isNonEmptyArray(eventWaitEntries) ||
-		!isNonEmptyArray(stateTransitionEntries) ||
-		!isNonEmptyArray(workflowRunUpdates)
-	) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.eventWaitQueue.insert(eventWaitEntries);
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_event", workflowRunUpdates);
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}
+
+		let eventWaitEntriesToInsert = eventWaitEntries;
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			eventWaitEntriesToInsert = eventWaitEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (
+			!isNonEmptyArray(eventWaitEntriesToInsert) ||
+			!isNonEmptyArray(stateTransitionEntriesToInsert) ||
+			!isNonEmptyArray(outboxEntriesToInsert)
+		) {
+			return [];
+		}
+
+		await txRepos.eventWaitQueue.insert(eventWaitEntriesToInsert);
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});

--- a/sdk/server/src/daemons/imminent-recurring-workflows.ts
+++ b/sdk/server/src/daemons/imminent-recurring-workflows.ts
@@ -395,8 +395,8 @@ async function processOverlapCancelPreviousSchedules(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await deps.repos.transaction(async (txRepos) => {
-		// To espace the race condition that might arise when a concurrent actor moves the runId to non cancellable state,
-		// we should only insert cancellation state transistions if the cancellation occurred, otherwise, we'll have dangling transitions
+		// To escape the race condition that might arise when a concurrent actor moves the runId to non cancellable state,
+		// we should only insert cancellation state transitions if the cancellation occurred, otherwise, we'll have dangling transitions
 
 		// Step 1: Cancel active runs (without setting latestStateTransitionId)
 		const cancelledRunIds = isNonEmptyArray(runIdsToCancel)

--- a/sdk/server/src/daemons/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-runs.ts
@@ -129,12 +129,11 @@ async function processChunk(
 		});
 	}
 
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_retry", workflowRunUpdates, {
 			incrementAttempts: true,
 		});
@@ -144,11 +143,21 @@ async function processChunk(
 
 		await discardStaleTasks(transitionedRunIds, txRepos);
 
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (!isNonEmptyArray(stateTransitionEntriesToInsert) || !isNonEmptyArray(outboxEntriesToInsert)) {
 			return [];
 		}
+
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});

--- a/sdk/server/src/daemons/imminent-retryable-task-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-task-runs.ts
@@ -161,18 +161,32 @@ async function processChunk(
 		});
 	}
 
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("running", workflowRunUpdates);
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}
+
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (!isNonEmptyArray(stateTransitionEntriesToInsert) || !isNonEmptyArray(outboxEntriesToInsert)) {
+			return [];
+		}
+
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
+
 		const workflowRunIds = outboxEntriesToInsert.map((entry) => entry.workflowRunId) as NonEmptyArray<string>;
 		// Outbox entries are only deleted on workflow suspension or termination.
 		// In our case, the workflow is still running, hence the outbox entry is still in claimed state.

--- a/sdk/server/src/daemons/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemons/imminent-scheduled-runs.ts
@@ -145,18 +145,31 @@ async function processChunk(
 		});
 	}
 
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("scheduled", workflowRunUpdates);
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}
+
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (!isNonEmptyArray(stateTransitionEntriesToInsert) || !isNonEmptyArray(outboxEntriesToInsert)) {
+			return [];
+		}
+
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});

--- a/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
@@ -130,19 +130,32 @@ async function processChunk(
 		});
 	}
 
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(workflowRunUpdates)) {
+	if (!isNonEmptyArray(workflowRunUpdates)) {
 		return;
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
 		await txRepos.sleepQueue.bulkCompleteByWorkflowRunIds(workflowRunIds, completedAt);
-		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("sleeping", workflowRunUpdates);
-		const transitionedRunIdsSet = new Set(transitionedRunIds);
-		const outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
-		if (!isNonEmptyArray(outboxEntriesToInsert)) {
+		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}
+
+		let stateTransitionEntriesToInsert = stateTransitionEntries;
+		let outboxEntriesToInsert = outboxEntries;
+		if (transitionedRunIds.length !== stateTransitionEntries.length) {
+			const transitionedRunIdsSet = new Set(transitionedRunIds);
+			stateTransitionEntriesToInsert = stateTransitionEntries.filter((entry) =>
+				transitionedRunIdsSet.has(entry.workflowRunId)
+			);
+			outboxEntriesToInsert = outboxEntries.filter((entry) => transitionedRunIdsSet.has(entry.workflowRunId));
+		}
+
+		if (!isNonEmptyArray(stateTransitionEntriesToInsert) || !isNonEmptyArray(outboxEntriesToInsert)) {
+			return [];
+		}
+
+		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});


### PR DESCRIPTION
## Motivation

Six daemons in `sdk/server` watch for due timers and promote workflow runs to the `queued` state once their wait condition (sleep, retry backoff, task-retry backoff, scheduled launch, event-wait timeout, child-run-wait timeout) is satisfied. Each scans for runs whose timer has fired, does transitions on the runs and publishes them to a queue.

The transition has three coordinated effects per run, all written inside one transaction:

- An append to `state_transition`, the history table that records every status change a `workflow_run` undergoes.
- An UPDATE on `workflow_run` that updates `status`, increments `revision`, and points `latest_state_transition_id` at the new history row. The UPDATE is gated on `revision = <expected>` for optimistic concurrency, so any row a concurrent writer has already moved (e.g. via cancellation) fails its filter clause and is skipped.
- An insert into `workflow_run_outbox` for queue publishing.

Because the `state_transition` insert ran **before** the revision-gated UPDATE, a run that lost the race left an orphan history row: a `state_transition` entry whose corresponding `workflow_run` never actually transitioned, and which no `workflow_run.latest_state_transition_id` points to.

## Solution

Reorder the operations inside the transaction so the revision-gated UPDATE runs first and returns the IDs that actually transitioned. Filter the prepared `state_transition` and `workflow_run_outbox` entries against that set, then insert only the confirmed-transitioned ones. When the returned ID count matches the input count (the common case — no concurrent contention), the original arrays are reused and the Set is never constructed.

There is no DB-level foreign key from `workflow_run.latest_state_transition_id` to `state_transition.id` — the relation is declared at the ORM layer only. So setting the pointer in the UPDATE before its target row exists is safe within the transaction: the new pointer is visible only to the in-flight transaction, and the row is appended before commit.

Two of the daemons (event-wait timeout, child-run-wait timeout) had an analogous problem with their respective wait queues — a `status: "timeout"` entry was written for every input run before the transition, so a revision mismatch left the wait queue claiming a timeout for a run that did not time out. The same filter-after-transition shape is applied to those side-effect inserts.

The recurring-workflow daemon's cancel-overlap path already solves the same logical problem with a different shape: its transition operation does not set `latest_state_transition_id` at all, so the daemon transitions first, filters, appends history rows, then sets the pointer in a second UPDATE.