### PR TITLE
Make IAM optional in app/server binary

### DIFF
--- a/app/server/.env.example
+++ b/app/server/.env.example
@@ -1,7 +1,9 @@
 AIKI_SERVER_HOST=0.0.0.0
 AIKI_SERVER_PORT=9850
-AIKI_SERVER_BASE_URL=http://localhost:9850
-AIKI_SERVER_AUTH_SECRET=yourSecretKey
+
+# Optional: Set if auth is needed
+# AIKI_SERVER_BASE_URL=http://localhost:9850
+# AIKI_SERVER_AUTH_SECRET=yourSecretKey
 
 CORS_ORIGINS=http://localhost:9851
 

--- a/app/server/src/config/loader.ts
+++ b/app/server/src/config/loader.ts
@@ -23,6 +23,12 @@ export async function loadConfig(): Promise<Config> {
 			}
 		: undefined;
 
+	const auth = process.env.AIKI_SERVER_AUTH_SECRET
+		? {
+				secret: process.env.AIKI_SERVER_AUTH_SECRET,
+			}
+		: undefined;
+
 	const raw = {
 		host: process.env.AIKI_SERVER_HOST,
 		port: process.env.AIKI_SERVER_PORT,
@@ -30,9 +36,7 @@ export async function loadConfig(): Promise<Config> {
 		corsOrigins: process.env.CORS_ORIGINS,
 		redis,
 		db: readDatabaseEnv(),
-		auth: {
-			secret: process.env.AIKI_SERVER_AUTH_SECRET,
-		},
+		auth,
 		logLevel: process.env.LOG_LEVEL,
 		prettyLogs: process.env.PRETTY_LOGS,
 	};

--- a/app/server/src/config/schema.ts
+++ b/app/server/src/config/schema.ts
@@ -29,13 +29,22 @@ export const authConfigSchema = type({
 export const configSchema = type({
 	host: "string > 0 = '0.0.0.0'",
 	port: "string.integer.parse | number.integer > 0 = 9850",
-	baseURL: "string > 0",
+	"baseURL?": "string > 0",
 	corsOrigins: uniqueCommaSeparatedToItems,
 	"redis?": redisConfigSchema.or(type("undefined")),
 	db: databaseConfigSchema,
-	auth: authConfigSchema,
+	"auth?": authConfigSchema.or(type("undefined")),
 	logLevel: type.enumerated(...logLevels).default("info"),
 	prettyLogs: type("boolean").or(coerceBool).default(false),
+}).narrow((config, context) => {
+	if (config.auth && !config.baseURL) {
+		return context.reject({
+			code: "predicate",
+			path: ["baseURL"],
+			expected: "set when auth is configured",
+		});
+	}
+	return true;
 });
 
 export type RedisConfig = typeof redisConfigSchema.infer;

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -31,13 +31,16 @@ if (import.meta.main) {
 		db,
 		cache,
 		logger,
-		iam: iam({
-			db,
-			cache,
-			secret: config.auth.secret,
-			baseURL: config.baseURL,
-			trustedOrigins: config.corsOrigins,
-		}),
+		iam:
+			config.auth && config.baseURL
+				? iam({
+						db,
+						cache,
+						secret: config.auth.secret,
+						baseURL: config.baseURL,
+						trustedOrigins: config.corsOrigins,
+					})
+				: undefined,
 		runtime: {
 			...(redis && {
 				publisher: redisPublisher(redis),


### PR DESCRIPTION
The `app/server` binary unconditionally constructed an IAM (identity/authorization) layer, requiring `AIKI_SERVER_AUTH_SECRET` and `AIKI_SERVER_BASE_URL` to be set even though the server SDK already accepts `iam` as optional and falls back to a no-op authorizer. Redis was already optional in the same entry point; IAM now follows that pattern.

`auth` and `baseURL` are optional in the config schema, and IAM is constructed only when both are present. A cross-field narrow rejects configs that set `auth` without `baseURL`.