### PR TITLE
Discard in-flight tasks on workflow cancel

### DIFF
--- a/sdk/server/src/daemons/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-runs.ts
@@ -141,7 +141,7 @@ async function processChunk(
 			return [];
 		}
 
-		await discardStaleTasks(transitionedRunIds, txRepos);
+		await discardStaleTasks(transitionedRunIds, ["running", "awaiting_retry", "failed"], txRepos);
 
 		let stateTransitionEntriesToInsert = stateTransitionEntries;
 		let outboxEntriesToInsert = outboxEntries;

--- a/sdk/server/src/service/discard-stale-tasks.ts
+++ b/sdk/server/src/service/discard-stale-tasks.ts
@@ -6,15 +6,14 @@ import { ulid } from "ulidx";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 
+type DiscardableTaskStatus = "running" | "awaiting_retry" | "failed";
+
 export async function discardStaleTasks(
 	workflowRunIds: string | NonEmptyArray<string>,
+	staleStatuses: NonEmptyArray<DiscardableTaskStatus>,
 	txRepos: Pick<Repositories, "task" | "stateTransition">
 ): Promise<void> {
-	const staleTasks = await txRepos.task.listByWorkflowRunIdsAndStatuses(workflowRunIds, [
-		"running",
-		"awaiting_retry",
-		"failed",
-	]);
+	const staleTasks = await txRepos.task.listByWorkflowRunIdsAndStatuses(workflowRunIds, staleStatuses);
 	if (!isNonEmptyArray(staleTasks)) {
 		return;
 	}

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -264,7 +264,7 @@ async function transitionStateInTx(
 	}
 
 	if (toState.status === "scheduled" && toState.reason === "retry") {
-		await discardStaleTasks(runId, txRepos);
+		await discardStaleTasks(runId, ["running", "awaiting_retry", "failed"], txRepos);
 	}
 
 	if (toState.status === "awaiting_child_workflow") {

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -49,6 +49,7 @@ import type { WorkflowRepository, WorkflowRow } from "../infra/db/types/workflow
 import type { WorkflowRunRow } from "../infra/db/types/workflow-run";
 import type { NamespaceRequestContext } from "../middleware/context";
 import type { CancelledParentRun, ChildRunCanceller } from "../service/cancel-child-runs";
+import { discardStaleTasks } from "../service/discard-stale-tasks";
 import type { WorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
 
 export interface WorkflowRunServiceDeps {
@@ -536,6 +537,8 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 			if (!isNonEmptyArray(cancelledRunIds)) {
 				return { cancelledIds: [] };
 			}
+
+			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
 
 			const cancelledRuns = await txRepos.workflowRun.getByIds(context.namespaceId, cancelledRunIds);
 


### PR DESCRIPTION
## Motivation

A workflow run is composed of tasks, each with its own status (`running`, `awaiting_retry`, `failed`, `completed`, `discarded`). A daemon scans for tasks ready to retry by querying the task table for rows in `awaiting_retry` whose `next_attempt_at` has passed. 

Cancelling a workflow run only flipped the run's own status to `cancelled` — it left the run's tasks untouched. This meant that a cancelled run's `awaiting_retry` task kept getting picked up by the daemon. The daemon had a correctness defense against this - filtering out those tasks whose parent run are in a terminal state. Nevertheless, it was a performance killer because the set of such tasks monotonically increases, therefore burdening the daemon with a larger haystack to filter out.

## Solution

Cancellation now discards the cancelled run's `awaiting_retry` and `running` tasks. The `awaiting_retry` rows are what the daemon would otherwise keep scanning — discarding them nulls out `next_attempt_at` and drops them out of the scan window. The `running` rows represent in-flight work on a worker that can no longer contribute to a cancelled run.

`failed` tasks are deliberately left alone. They're already terminal, and rewriting them to `discarded` would erase the historical record that the task tried and failed before the workflow was killed.
