### PR TITLE
Outbox cleanup on task retry and bulk cancel

### DIFF
--- a/sdk/server/src/daemons/imminent-recurring-workflows.ts
+++ b/sdk/server/src/daemons/imminent-recurring-workflows.ts
@@ -404,10 +404,11 @@ async function processOverlapCancelPreviousSchedules(
 			? await txRepos.workflowRun.bulkTransitionToCancelled(runIdsToCancel)
 			: [];
 
-		// Step 2: Discard in-flight tasks for the cancelled runs, then insert cancel state transitions
-		// only for actually cancelled runs and set latestStateTransitionId
+		// Step 2: Discard in-flight tasks and outbox entries for the cancelled runs, then insert
+		// cancel state transitions only for actually cancelled runs and set latestStateTransitionId
 		if (isNonEmptyArray(cancelledRunIds)) {
 			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
+			await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
 			const cancelledRunIdsSet = new Set(cancelledRunIds);
 			const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];

--- a/sdk/server/src/daemons/imminent-retryable-task-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-task-runs.ts
@@ -186,13 +186,6 @@ async function processChunk(
 		}
 
 		await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
-
-		const workflowRunIds = outboxEntriesToInsert.map((entry) => entry.workflowRunId) as NonEmptyArray<string>;
-		// Outbox entries are only deleted on workflow suspension or termination.
-		// In our case, the workflow is still running, hence the outbox entry is still in claimed state.
-		// It needs to be deleted to avoid conflict.
-		// Upsert is another option, but one needs think carefully about which columns get updated.
-		await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(context, workflowRunIds);
 		await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 		return outboxEntriesToInsert;
 	});

--- a/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
@@ -43,7 +43,7 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			await db.insert(workflowRunOutbox).values(rows);
 		},
 
-		async deleteByWorkflowRunIds(_context: DaemonContext, workflowRunIds: NonEmptyArray<string>): Promise<void> {
+		async deleteByWorkflowRunIds(workflowRunIds: NonEmptyArray<string>): Promise<void> {
 			await db.delete(workflowRunOutbox).where(inArray(workflowRunOutbox.workflowRunId, workflowRunIds));
 		},
 

--- a/sdk/server/src/service/task-state-machine.ts
+++ b/sdk/server/src/service/task-state-machine.ts
@@ -47,7 +47,7 @@ export function isTaskStateTransitionToRunning(
 }
 
 export interface TaskStateMachineServiceDeps {
-	repos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "transaction">;
+	repos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox" | "transaction">;
 }
 
 export function createTaskStateMachineService(deps: TaskStateMachineServiceDeps) {
@@ -56,7 +56,7 @@ export function createTaskStateMachineService(deps: TaskStateMachineServiceDeps)
 		async transitionState(
 			context: NamespaceRequestContext,
 			request: WorkflowRunTransitionTaskStateRequestV1,
-			txRepos?: Pick<Repositories, "workflowRun" | "task" | "stateTransition">
+			txRepos?: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 		): Promise<TaskInfo> {
 			if (txRepos) {
 				return transitionStateInTx(context, request, txRepos);
@@ -72,7 +72,7 @@ export type TaskStateMachineService = ReturnType<typeof createTaskStateMachineSe
 async function transitionStateInTx(
 	context: NamespaceRequestContext,
 	request: WorkflowRunTransitionTaskStateRequestV1,
-	txRepos: Pick<Repositories, "workflowRun" | "task" | "stateTransition">
+	txRepos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 ): Promise<TaskInfo> {
 	const namespaceId = context.namespaceId;
 	const runId = request.id as WorkflowRunId;
@@ -177,6 +177,15 @@ async function transitionStateInTx(
 		latestStateTransitionId: stateTransitionId,
 		nextAttemptAt: taskState.status === "awaiting_retry" ? new Date(taskState.nextAttemptAt) : null,
 	});
+
+	if (taskState.status === "awaiting_retry") {
+		// The workflow run stays in `running` while the task waits for its retry, so the outbox row
+		// is not cleared by the workflow state machine. Delete it here so `republish-stale-runs`
+		// cannot re-dispatch the run before `imminent-retryable-task-runs` requeues it at the
+		// task's nextAttemptAt. The retry-tasks daemon will reinsert a fresh outbox row when it
+		// transitions the workflow to `queued`.
+		await txRepos.workflowRunOutbox.deleteByWorkflowRunId(namespaceId, runId);
+	}
 
 	context.logger.info("Transitioning task state", { runId, taskId, taskState });
 

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -539,12 +539,13 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 			}
 
 			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
+			await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
 			const cancelledRuns = await txRepos.workflowRun.getByIds(context.namespaceId, cancelledRunIds);
 
 			const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
 			const cancelledRunStateTransitionUpdates: { id: string; stateTransitionId: string }[] = [];
-			const cancelledParentRuns: CancelledParentRun[] = [];
+			const cancelledRunsMeta: CancelledParentRun[] = [];
 
 			for (const run of cancelledRuns) {
 				const stateTransitionId = ulid();
@@ -554,10 +555,10 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 					type: "workflow_run",
 					status: "cancelled",
 					attempt: run.attempts,
-					state: { status: "cancelled", reason: "Bulk cancel" } satisfies WorkflowRunStateCancelled,
+					state: { status: "cancelled", reason: "Cancelled" } satisfies WorkflowRunStateCancelled,
 				});
 				cancelledRunStateTransitionUpdates.push({ id: run.id, stateTransitionId });
-				cancelledParentRuns.push({
+				cancelledRunsMeta.push({
 					namespaceId: context.namespaceId,
 					runId: run.id,
 					shard: (run.options as WorkflowStartOptions | null)?.shard,
@@ -569,8 +570,8 @@ export function createWorkflowRunService(deps: WorkflowRunServiceDeps) {
 				await txRepos.workflowRun.bulkSetLatestStateTransitionId(cancelledRunStateTransitionUpdates);
 			}
 
-			if (isNonEmptyArray(cancelledParentRuns)) {
-				await childRunCanceller.cancel(cancelledParentRuns, txRepos, context.logger);
+			if (isNonEmptyArray(cancelledRunsMeta)) {
+				await childRunCanceller.cancel(cancelledRunsMeta, txRepos, context.logger);
 			}
 
 			return { cancelledIds: cancelledRunIds };


### PR DESCRIPTION
## Motivation

The workflow run outbox is the table that signals which runs are ready for worker dispatch. An outbox row carries one of three statuses — `pending`, `published`, or `claimed` — and a `claimedAt` timestamp that the worker refreshes through heartbeats while it is executing the workflow.

The safety net for crashed workers is the `republish-stale-runs` daemon. It scans for `claimed` rows whose `claimedAt` is older than `claimMinIdleTimeMs` (90s by default) and republishes them on the assumption the worker died.

Until now the only thing that deleted an outbox row was the workflow state machine, specifically when a run is suspended or hits a terminal state. Three state-change paths bypass that and leave outbox rows behind.

**Task waiting on a retry.** When a task throws with retries remaining, the system marks the task `awaiting_retry` with a future `nextAttemptAt` and exits the workflow handler. The workflow run itself stays `running` — only the task is suspended — so the outbox row stays `claimed`, but the worker has stopped heartbeating. After 90s `republish-stale-runs` misclassifies the row as a crashed claim and republishes it, bypassing the task's `nextAttemptAt` whenever the configured retry delay exceeds 90s.

**Bulk cancel.** `cancelByIds` flips N runs to `cancelled` via a single SQL update, never going through the workflow state machine; the outbox rows for those runs are left around.

**Schedule overlap cancellation.** The `imminent-recurring-workflows` daemon's `cancel_previous` policy cancels the previous active run the same way, with the same outbox leak.

The stale rows do not corrupt anything — a worker that picks one up fetches the run, sees the state and skips operating on the workflow, but they waste dispatch cycles and, in the task-retry case, defeat the configured retry delay.

## Solution

Each state-change site that bypasses the workflow state machine now also deletes the outbox row(s) for the affected run(s) in the same transaction:

- The task state machine deletes the outbox row when transitioning a task to `awaiting_retry`. `imminent-retryable-task-runs` reinserts a fresh row when it later transitions the workflow back to `queued`.
- Bulk `cancelByIds` deletes outbox rows for the cancelled ids alongside the existing status flip and stale-task discard.
- The schedule overlap `cancel_previous` path does the same.