### PR TITLE
Lazy DB provider loading

### DIFF
--- a/sdk/iam/package.json
+++ b/sdk/iam/package.json
@@ -29,6 +29,14 @@
 		"drizzle-orm": "^0.45.1",
 		"ulidx": "^2.4.1"
 	},
+	"peerDependencies": {
+		"postgres": "^3.4.8"
+	},
+	"peerDependenciesMeta": {
+		"postgres": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@aikirun/cli": "workspace:*",
 		"@aikirun/lib": "workspace:*",

--- a/sdk/iam/src/api-authorizer.ts
+++ b/sdk/iam/src/api-authorizer.ts
@@ -1,16 +1,16 @@
 import { UnauthorizedError } from "@aikirun/lib/error";
-import type { ApiAuthorizer, CreateApiAuthorizer } from "@aikirun/types/iam";
+import type { ApiAuthorizer, CreateApiAuthorizer, IamContext } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
-import type { Database } from "@aikirun/types/infra/db";
+import type { CreateDatabase } from "@aikirun/types/infra/db";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { OrganizationId } from "@aikirun/types/organization";
 
-import { type AuthService, createAuthService } from "./auth";
+import type { AuthService } from "./auth";
 import { createRepos } from "./infra/db/repo";
 import { type ApiKeyAuthorizationInfo, createApiKeyService } from "./service/api-key";
 
 export interface ApiAuthorizerParams {
-	db: Database;
+	db: CreateDatabase;
 	cache?: CreateCache;
 	secret: string;
 	baseURL: string;
@@ -18,12 +18,12 @@ export interface ApiAuthorizerParams {
 }
 
 export interface ApiAuthorizerKeyParams {
-	db: Database;
+	db: CreateDatabase;
 	cache?: CreateCache;
 }
 
 export interface ApiAuthorizerSessionParams {
-	db: Database;
+	db: CreateDatabase;
 	secret: string;
 	baseURL: string;
 	trustedOrigins: string[];
@@ -39,34 +39,44 @@ function extractBearerToken(headers: Headers): string | null {
 	return null;
 }
 
-function createApiKeyAuthorizer(
-	params: ApiAuthorizerKeyParams,
-	{ logger }: { logger: import("@aikirun/lib/logger").Logger }
-): ApiAuthorizer {
-	const repos = createRepos(params.db);
-	const apiKeyService = createApiKeyService({
-		repos,
-		cache: params.cache?.<ApiKeyAuthorizationInfo>({
-			logger: logger.child({ "aiki.component": "cache.apiKeyAuth" }),
-			keyPrefix: "api_key:",
-		}),
-	});
+function createApiKeyAuthorizer(params: ApiAuthorizerKeyParams, context: IamContext): ApiAuthorizer {
+	let authorizer: ApiAuthorizer | undefined;
+	let createAuthorizerPromise: Promise<ApiAuthorizer> | undefined;
 
-	return async (request: Request) => {
-		const apiKey = extractBearerToken(request.headers);
-		if (!apiKey) {
-			throw new UnauthorizedError("Invalid API key");
-		}
+	return (request: Request) => {
+		if (authorizer) return authorizer(request);
+		return (async () => {
+			createAuthorizerPromise ??= (async () => {
+				const db = await params.db();
+				const repos = await createRepos(db);
+				const apiKeyService = createApiKeyService({
+					repos,
+					cache: params.cache?.<ApiKeyAuthorizationInfo>({
+						logger: context.logger.child({ "aiki.component": "cache.apiKeyAuth" }),
+						keyPrefix: "api_key:",
+					}),
+				});
 
-		const result = await apiKeyService.verify(apiKey);
-		if (!result) {
-			throw new UnauthorizedError("Invalid API key");
-		}
+				return async (request: Request) => {
+					const apiKey = extractBearerToken(request.headers);
+					if (!apiKey) {
+						throw new UnauthorizedError("Invalid API key");
+					}
 
-		return {
-			organizationId: result.organizationId as OrganizationId,
-			namespaceId: result.namespaceId as NamespaceId,
-		};
+					const result = await apiKeyService.verify(apiKey);
+					if (!result) {
+						throw new UnauthorizedError("Invalid API key");
+					}
+
+					return {
+						organizationId: result.organizationId as OrganizationId,
+						namespaceId: result.namespaceId as NamespaceId,
+					};
+				};
+			})();
+			authorizer = await createAuthorizerPromise;
+			return authorizer(request);
+		})();
 	};
 }
 
@@ -75,29 +85,47 @@ function key(params: ApiAuthorizerKeyParams): CreateApiAuthorizer {
 }
 
 function createSessionAuthorizer(params: ApiAuthorizerSessionParams): ApiAuthorizer {
-	const authService: AuthService = createAuthService(params);
+	let authorizer: ApiAuthorizer | undefined;
+	let createAuthorizerPromise: Promise<ApiAuthorizer> | undefined;
 
-	return async (request: Request) => {
-		const session = await authService.api.getSession({ headers: request.headers });
-		if (!session?.session) {
-			throw new UnauthorizedError("Not authenticated");
-		}
+	return (request: Request) => {
+		if (authorizer) return authorizer(request);
+		return (async () => {
+			createAuthorizerPromise ??= (async () => {
+				const [{ createAuthService }, db] = await Promise.all([import("./auth"), params.db()]);
+				const authService: AuthService = await createAuthService({
+					db,
+					baseURL: params.baseURL,
+					secret: params.secret,
+					trustedOrigins: params.trustedOrigins,
+				});
 
-		const activeOrganizationId = session.session.activeOrganizationId;
-		if (!activeOrganizationId) {
-			throw new UnauthorizedError("No active organization selected");
-		}
+				return async (request: Request) => {
+					const session = await authService.api.getSession({ headers: request.headers });
+					if (!session?.session) {
+						throw new UnauthorizedError("Not authenticated");
+					}
 
-		const activeNamespaceId = session.session.activeTeamId;
-		if (!activeNamespaceId) {
-			throw new UnauthorizedError("No active namespace selected");
-		}
+					const activeOrganizationId = session.session.activeOrganizationId;
+					if (!activeOrganizationId) {
+						throw new UnauthorizedError("No active organization selected");
+					}
 
-		return {
-			organizationId: activeOrganizationId as OrganizationId,
-			namespaceId: activeNamespaceId as NamespaceId,
-			userId: session.session.userId,
-		};
+					const activeNamespaceId = session.session.activeTeamId;
+					if (!activeNamespaceId) {
+						throw new UnauthorizedError("No active namespace selected");
+					}
+
+					return {
+						organizationId: activeOrganizationId as OrganizationId,
+						namespaceId: activeNamespaceId as NamespaceId,
+						userId: session.session.userId,
+					};
+				};
+			})();
+			authorizer = await createAuthorizerPromise;
+			return authorizer(request);
+		})();
 	};
 }
 

--- a/sdk/iam/src/auth.ts
+++ b/sdk/iam/src/auth.ts
@@ -2,36 +2,42 @@ import type { Database } from "@aikirun/types/infra/db";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
-import { drizzle } from "drizzle-orm/postgres-js";
 
 import type { PgClient } from "./infra/db/pg/provider";
-import * as schema from "./infra/db/pg/schema";
 import { extractDbClient } from "./infra/db/repo";
 
-const pgBetterAuthSchema = {
-	user: schema.user,
-	session: schema.session,
-	account: schema.account,
-	verification: schema.verification,
-	organization: schema.organization,
-	organization_member: schema.organizationMember,
-	organization_invitation: schema.organizationInvitation,
-	namespace: schema.namespace,
-	namespace_member: schema.namespaceMember,
-};
+type BetterAuthSchema = Record<
+	| "user"
+	| "session"
+	| "account"
+	| "verification"
+	| "organization"
+	| "organization_member"
+	| "organization_invitation"
+	| "namespace"
+	| "namespace_member",
+	unknown
+>;
 
-// Inferred from PG's betterAuthSchema — enforces that all providers
-// export a schema object with the same keys.
-// The values are `unknown` because PG uses pgTable objects and SQLite
-// uses sqliteTable objects — different types, same key structure.
-// type BetterAuthSchema = Record<keyof typeof pgBetterAuthSchema, unknown>;
-
-function createDrizzleAdapter(db: Database) {
+async function createDrizzleAdapter(db: Database) {
 	switch (db.provider) {
 		case "pg": {
+			const schema = await import("./infra/db/pg/schema");
+			const betterAuthSchema = {
+				user: schema.user,
+				session: schema.session,
+				account: schema.account,
+				verification: schema.verification,
+				organization: schema.organization,
+				organization_member: schema.organizationMember,
+				organization_invitation: schema.organizationInvitation,
+				namespace: schema.namespace,
+				namespace_member: schema.namespaceMember,
+			} satisfies BetterAuthSchema;
 			const client = extractDbClient(db) as PgClient;
-			const handle = drizzle(client, { schema: pgBetterAuthSchema });
-			return drizzleAdapter(handle, { provider: db.provider, schema: pgBetterAuthSchema });
+			const { drizzle } = await import("drizzle-orm/postgres-js");
+			const handle = drizzle(client, { schema: betterAuthSchema });
+			return drizzleAdapter(handle, { provider: db.provider, schema: betterAuthSchema });
 		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
@@ -49,9 +55,9 @@ export interface AuthServiceParams {
 	trustedOrigins: string[];
 }
 
-export function createAuthService(params: AuthServiceParams) {
+export async function createAuthService(params: AuthServiceParams) {
 	return betterAuth({
-		database: createDrizzleAdapter(params.db),
+		database: await createDrizzleAdapter(params.db),
 		baseURL: params.baseURL,
 		basePath: "/auth",
 		secret: params.secret,
@@ -119,4 +125,4 @@ export function createAuthService(params: AuthServiceParams) {
 	});
 }
 
-export type AuthService = ReturnType<typeof createAuthService>;
+export type AuthService = Awaited<ReturnType<typeof createAuthService>>;

--- a/sdk/iam/src/dashboard-session.ts
+++ b/sdk/iam/src/dashboard-session.ts
@@ -9,12 +9,12 @@ import type {
 	OrganizationDashboardHandler,
 } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
-import type { Database } from "@aikirun/types/infra/db";
+import type { CreateDatabase } from "@aikirun/types/infra/db";
 import type { OrganizationId } from "@aikirun/types/organization";
 import { RPCHandler } from "@orpc/server/fetch";
 import { ulid } from "ulidx";
 
-import { type AuthService, createAuthService } from "./auth";
+import type { AuthService } from "./auth";
 import type { OrganizationSessionRequestContext } from "./context";
 import type { OrganizationRole } from "./infra/db/constants/organization";
 import { createRepos } from "./infra/db/repo";
@@ -30,12 +30,30 @@ export interface OrganizationDashboardAuthorization {
 }
 
 export interface DashboardSessionIamParams {
-	db: Database;
+	db: CreateDatabase;
 	cache?: CreateCache;
 	secret: string;
 	baseURL: string;
 	trustedOrigins: string[];
 }
+
+function authService(params: DashboardSessionIamParams) {
+	let authServicePromise: Promise<AuthService> | undefined;
+	return (): Promise<AuthService> => {
+		authServicePromise ??= (async () => {
+			const [{ createAuthService }, db] = await Promise.all([import("./auth"), params.db()]);
+			return createAuthService({
+				db,
+				baseURL: params.baseURL,
+				secret: params.secret,
+				trustedOrigins: params.trustedOrigins,
+			});
+		})();
+		return authServicePromise;
+	};
+}
+
+type GetAuthService = ReturnType<typeof authService>;
 
 async function authorizeOrganizationSession(
 	authService: AuthService,
@@ -64,72 +82,102 @@ async function authorizeOrganizationSession(
 	};
 }
 
-function createAuthenticator(authService: AuthService): DashboardAuthenticator {
-	return (request) => authService.handler(request);
+function createAuthenticator(getAuthService: GetAuthService): DashboardAuthenticator {
+	let authenticator: DashboardAuthenticator | undefined;
+	let createAuthenticatorPromise: Promise<DashboardAuthenticator> | undefined;
+
+	return (request: Request) => {
+		if (authenticator) return authenticator(request);
+		return (async () => {
+			createAuthenticatorPromise ??= (async () => {
+				const authService = await getAuthService();
+				return (request: Request) => authService.handler(request);
+			})();
+			authenticator = await createAuthenticatorPromise;
+			return authenticator(request);
+		})();
+	};
 }
 
 function authenticator(params: DashboardSessionIamParams): CreateDashboardAuthenticator {
-	return (_context) => createAuthenticator(createAuthService(params));
+	return (_context) => createAuthenticator(authService(params));
 }
 
 function createOrganizationHandler(
 	params: DashboardSessionIamParams,
 	context: IamContext,
-	authService: AuthService
+	getAuthService: GetAuthService
 ): OrganizationDashboardHandler {
-	const repos = createRepos(params.db);
-	const apiKeyCache = params.cache?.<ApiKeyAuthorizationInfo>({
-		logger: context.logger.child({ "aiki.component": "cache.apiKeyAuth" }),
-		keyPrefix: "api_key:",
-	});
-	const apiKeyService = createApiKeyService({ repos, cache: apiKeyCache });
-	const namespaceService = createNamespaceService({ repos, apiKeyCache });
-	const router = createOrganizationAuthedRouter({ apiKeyService, namespaceService });
-	const rpcHandler = new RPCHandler(router, {});
+	let handler: OrganizationDashboardHandler | undefined;
+	let createHandlerPromise: Promise<OrganizationDashboardHandler> | undefined;
 
-	return async (request) => {
-		let authorization: OrganizationDashboardAuthorization;
-		try {
-			authorization = await authorizeOrganizationSession(authService, repos.organization, request);
-		} catch (error) {
-			if (error instanceof UnauthorizedError) {
-				return new Response(error.message, { status: 401 });
-			}
-			context.logger.error("Unhandled error", { error });
-			return new Response("Internal Server Error", { status: 500 });
-		}
+	return (request: Request) => {
+		if (handler) return handler(request);
+		return (async () => {
+			createHandlerPromise ??= (async () => {
+				const db = await params.db();
+				const repos = await createRepos(db);
+				const authService = await getAuthService();
+				const apiKeyCache = params.cache?.<ApiKeyAuthorizationInfo>({
+					logger: context.logger.child({ "aiki.component": "cache.apiKeyAuth" }),
+					keyPrefix: "api_key:",
+				});
+				const apiKeyService = createApiKeyService({ repos, cache: apiKeyCache });
+				const namespaceService = createNamespaceService({ repos, apiKeyCache });
+				const router = createOrganizationAuthedRouter({ apiKeyService, namespaceService });
+				const rpcHandler = new RPCHandler(router, {});
 
-		const traceId = request.headers.get("x-trace-id") ?? ulid();
-		const spanId = ulid();
-		const organizationSessionContext: OrganizationSessionRequestContext = {
-			type: "request",
-			traceId,
-			spanId,
-			logger: context.logger.child({ method: request.method, url: request.url, traceId, spanId }),
-			requestType: "authed",
-			headers: request.headers,
-			method: request.method,
-			url: request.url,
-			organizationId: authorization.organizationId,
-			userId: authorization.userId,
-			organizationRole: authorization.organizationRole,
-		};
+				return async (request: Request): Promise<Response> => {
+					let authorization: OrganizationDashboardAuthorization;
+					try {
+						authorization = await authorizeOrganizationSession(authService, repos.organization, request);
+					} catch (error) {
+						if (error instanceof UnauthorizedError) {
+							return new Response(error.message, { status: 401 });
+						}
+						context.logger.error("Unhandled error", { error });
+						return new Response("Internal Server Error", { status: 500 });
+					}
 
-		const result = await rpcHandler.handle(request, { context: organizationSessionContext, prefix: "/dashboard" });
-		return result.response ?? new Response("Not Found", { status: 404 });
+					const traceId = request.headers.get("x-trace-id") ?? ulid();
+					const spanId = ulid();
+					const organizationSessionContext: OrganizationSessionRequestContext = {
+						type: "request",
+						traceId,
+						spanId,
+						logger: context.logger.child({ method: request.method, url: request.url, traceId, spanId }),
+						requestType: "authed",
+						headers: request.headers,
+						method: request.method,
+						url: request.url,
+						organizationId: authorization.organizationId,
+						userId: authorization.userId,
+						organizationRole: authorization.organizationRole,
+					};
+
+					const result = await rpcHandler.handle(request, {
+						context: organizationSessionContext,
+						prefix: "/dashboard",
+					});
+					return result.response ?? new Response("Not Found", { status: 404 });
+				};
+			})();
+			handler = await createHandlerPromise;
+			return handler(request);
+		})();
 	};
 }
 
 function organization(params: DashboardSessionIamParams): CreateOrganizationDashboardHandler {
-	return (context) => createOrganizationHandler(params, context, createAuthService(params));
+	return (context) => createOrganizationHandler(params, context, authService(params));
 }
 
 function dashboardSessionIamFn(params: DashboardSessionIamParams): CreateDashboardIam {
 	return (context): DashboardIam => {
-		const authService = createAuthService(params);
+		const getAuthService = authService(params);
 		return {
-			authenticator: createAuthenticator(authService),
-			organization: createOrganizationHandler(params, context, authService),
+			authenticator: createAuthenticator(getAuthService),
+			organization: createOrganizationHandler(params, context, getAuthService),
 		};
 	};
 }

--- a/sdk/iam/src/iam.ts
+++ b/sdk/iam/src/iam.ts
@@ -1,12 +1,12 @@
 import type { Iam } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
-import type { Database } from "@aikirun/types/infra/db";
+import type { CreateDatabase } from "@aikirun/types/infra/db";
 
 import { apiAuthorizer } from "./api-authorizer";
 import { dashboardSessionIam } from "./dashboard-session";
 
 export interface IamParams {
-	db: Database;
+	db: CreateDatabase;
 	secret: string;
 	baseURL: string;
 	trustedOrigins: string[];

--- a/sdk/iam/src/infra/db/pg/index.ts
+++ b/sdk/iam/src/infra/db/pg/index.ts
@@ -1,11 +1,12 @@
-import type { PgDb, PgHandle } from "./provider";
+import { createPgHandle, type PgClient, type PgDb } from "./provider";
 import { createApiKeyRepository } from "./repository/api-key";
 import { createNamespaceRepository } from "./repository/namespace";
 import { createOrganizationRepository } from "./repository/organization";
 import { createSessionRepository } from "./repository/session";
 import type { Repositories } from "../types";
 
-export function createPgRepos(db: PgHandle): Repositories {
+export function createPgRepos(client: PgClient): Repositories {
+	const db = createPgHandle(client);
 	return {
 		...createRepos(db),
 		async transaction<T>(fn: (txRepos: Omit<Repositories, "transaction">) => Promise<T>): Promise<T> {

--- a/sdk/iam/src/infra/db/repo.ts
+++ b/sdk/iam/src/infra/db/repo.ts
@@ -1,8 +1,7 @@
 import type { Database } from "@aikirun/types/infra/db";
 import { INTERNAL } from "@aikirun/types/symbols";
 
-import { createPgRepos } from "./pg";
-import { createPgHandle, type PgClient } from "./pg/provider";
+import type { PgClient } from "./pg/provider";
 import type { Repositories } from "./types";
 
 export function extractDbClient(db: Database): unknown {
@@ -13,18 +12,18 @@ export function extractDbClient(db: Database): unknown {
 	return internal.client;
 }
 
-export function createRepos(database: Database): Repositories {
-	switch (database.provider) {
+export async function createRepos(db: Database): Promise<Repositories> {
+	switch (db.provider) {
 		case "pg": {
-			const client = extractDbClient(database) as PgClient;
-			const handle = createPgHandle(client);
-			return createPgRepos(handle);
+			const { createPgRepos } = await import("./pg");
+			const client = extractDbClient(db) as PgClient;
+			return createPgRepos(client);
 		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
 		case "sqlite":
 			throw new Error("SQLite support not yet implemented");
 		default:
-			return database.provider satisfies never;
+			return db.provider satisfies never;
 	}
 }

--- a/sdk/server/package.json
+++ b/sdk/server/package.json
@@ -27,12 +27,20 @@
 		"arktype": "^2.1.29",
 		"cron-parser": "^5.4.0",
 		"drizzle-orm": "^0.45.1",
-		"postgres": "^3.4.8",
 		"ulidx": "^2.4.1"
+	},
+	"peerDependencies": {
+		"postgres": "^3.4.8"
+	},
+	"peerDependenciesMeta": {
+		"postgres": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@aikirun/cli": "workspace:*",
-		"@aikirun/lib": "workspace:*"
+		"@aikirun/lib": "workspace:*",
+		"postgres": "^3.4.8"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/sdk/server/src/handler.ts
+++ b/sdk/server/src/handler.ts
@@ -1,0 +1,121 @@
+import { UnauthorizedError } from "@aikirun/lib/error";
+import { SENTINEL_ULID } from "@aikirun/lib/id";
+import type { Logger } from "@aikirun/lib/logger";
+import type { ApiAuthorizer, Iam, IamContext } from "@aikirun/types/iam";
+import type { CreateCache } from "@aikirun/types/infra/cache";
+import type { Database } from "@aikirun/types/infra/db";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { OrganizationId } from "@aikirun/types/organization";
+import { RPCHandler } from "@orpc/server/fetch";
+
+import type { Capabilities } from "./capabilities";
+import { createRepos } from "./infra/db/repo";
+import { createNamespaceRequestContext, type NamespaceRequestContext } from "./middleware/context";
+import { createNamespaceAuthedRouter } from "./router/index";
+import { createChildRunCanceller } from "./service/cancel-child-runs";
+import { createScheduleService } from "./service/schedule";
+import { createTaskStateMachineService } from "./service/task-state-machine";
+import { createWorkflowService } from "./service/workflow";
+import { createWorkflowRunService } from "./service/workflow-run";
+import { createWorkflowRunOutboxService } from "./service/workflow-run-outbox";
+import { createWorkflowRunStateMachineService } from "./service/workflow-run-state-machine";
+
+export interface CreateHandlerParams {
+	db: Database;
+	logger: Logger;
+	iam?: Iam;
+	cache?: CreateCache;
+}
+
+export async function createHandler(params: CreateHandlerParams) {
+	const { logger, iam } = params;
+	const repos = await createRepos(params.db);
+	const childRunCanceller = createChildRunCanceller();
+
+	const apiAuthorizer = (iam?.api ?? noopApiAuthorizer)({ logger });
+	const dashboardIam = iam?.dashboard?.({ logger });
+
+	const workflowRunStateMachineService = createWorkflowRunStateMachineService({
+		repos,
+		childRunCanceller,
+	});
+	const taskStateMachineService = createTaskStateMachineService({ repos });
+	const workflowRunService = createWorkflowRunService({
+		repos,
+		childRunCanceller,
+		workflowRunStateMachineService,
+	});
+	const workflowService = createWorkflowService({ repos });
+	const scheduleService = createScheduleService({ repos });
+	const workflowRunOutboxService = createWorkflowRunOutboxService({ repos });
+
+	const namespaceAuthedRouter = createNamespaceAuthedRouter({
+		workflowRunService,
+		workflowRunStateMachineService,
+		taskStateMachineService,
+		workflowService,
+		scheduleService,
+		workflowRunOutboxService,
+	});
+
+	const namespaceAuthedHandler = new RPCHandler(namespaceAuthedRouter, {});
+
+	return async (request: Request): Promise<Response> => {
+		const pathname = new URL(request.url).pathname;
+
+		if (pathname.startsWith("/api/")) {
+			let context: NamespaceRequestContext;
+			try {
+				context = await createNamespaceRequestContext({ request, logger, authorizer: apiAuthorizer });
+			} catch (error) {
+				if (error instanceof UnauthorizedError) {
+					return new Response(error.message, { status: 401 });
+				}
+				logger.error("Unhandled error", { error });
+				return new Response("Internal Server Error", { status: 500 });
+			}
+
+			const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/api" });
+			return result.response ?? new Response("Not Found", { status: 404 });
+		}
+
+		if (pathname.startsWith("/dashboard/")) {
+			if (!dashboardIam?.organization) {
+				return new Response("Not Found", { status: 404 });
+			}
+			return dashboardIam.organization(request);
+		}
+
+		if (pathname.startsWith("/auth/")) {
+			if (!dashboardIam?.authenticator) {
+				return new Response("Not Found", { status: 404 });
+			}
+			return dashboardIam.authenticator(request);
+		}
+
+		if (pathname === "/capabilities") {
+			if (request.method !== "GET") {
+				return new Response("Method Not Allowed", { status: 405 });
+			}
+			return Response.json({
+				iam: { dashboard: dashboardIam !== undefined },
+			} satisfies Capabilities);
+		}
+
+		if (pathname === "/health") {
+			if (request.method !== "GET") {
+				return new Response("Method Not Allowed", { status: 405 });
+			}
+			return Response.json({ status: "ok" });
+		}
+
+		return new Response("Not Found", { status: 404 });
+	};
+}
+
+function noopApiAuthorizer(_context: IamContext): ApiAuthorizer {
+	return async () => ({
+		organizationId: SENTINEL_ULID as OrganizationId,
+		namespaceId: SENTINEL_ULID as NamespaceId,
+	});
+}

--- a/sdk/server/src/infra/db/index.ts
+++ b/sdk/server/src/infra/db/index.ts
@@ -1,26 +1,35 @@
-import type { Database } from "@aikirun/types/infra/db";
+import type { CreateDatabase, Database } from "@aikirun/types/infra/db";
 import { INTERNAL } from "@aikirun/types/symbols";
 import { type } from "arktype";
 
-import { createPgClient } from "./pg/provider";
 import { type DatabaseConfig, databaseConfigSchema } from "../../config";
 
-export function database(params: DatabaseConfig): Database {
-	const validationResult = databaseConfigSchema(params);
+export function database(config: DatabaseConfig): CreateDatabase {
+	const validationResult = databaseConfigSchema(config);
 	if (validationResult instanceof type.errors) {
 		throw new Error(`Invalid database config: ${validationResult.summary}`);
 	}
 
-	switch (params.provider) {
+	let createDatabasePromise: Promise<Database> | undefined;
+	return () => {
+		if (!createDatabasePromise) {
+			createDatabasePromise = createDatabase(config);
+		}
+		return createDatabasePromise;
+	};
+}
+
+async function createDatabase(config: DatabaseConfig): Promise<Database> {
+	switch (config.provider) {
 		case "pg": {
-			const client = createPgClient(params);
-			return { provider: params.provider, [INTERNAL]: { client } };
+			const { createPgClient } = await import("./pg/provider");
+			return { provider: "pg", [INTERNAL]: { client: createPgClient(config) } };
 		}
 		case "sqlite":
 			throw new Error("SQLite support not yet implemented");
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
 		default:
-			return params satisfies never;
+			return config satisfies never;
 	}
 }

--- a/sdk/server/src/infra/db/repo.ts
+++ b/sdk/server/src/infra/db/repo.ts
@@ -1,7 +1,6 @@
 import type { Database } from "@aikirun/types/infra/db";
 import { INTERNAL } from "@aikirun/types/symbols";
 
-import { createPgRepos } from "./pg";
 import type { PgClient } from "./pg/provider";
 import type { Repositories } from "./types";
 
@@ -13,10 +12,13 @@ function extractDbClient(db: Database): unknown {
 	return internal.client;
 }
 
-export function createRepos(db: Database): Repositories {
+export async function createRepos(db: Database): Promise<Repositories> {
 	switch (db.provider) {
-		case "pg":
-			return createPgRepos(extractDbClient(db) as PgClient);
+		case "pg": {
+			const { createPgRepos } = await import("./pg");
+			const client = extractDbClient(db) as PgClient;
+			return createPgRepos(client);
+		}
 		case "mysql":
 			throw new Error("MySQL support not yet implemented");
 		case "sqlite":

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -1,0 +1,85 @@
+import { delay } from "@aikirun/lib/async";
+import type { Logger } from "@aikirun/lib/logger";
+import type { Database } from "@aikirun/types/infra/db";
+import { ulid } from "ulidx";
+
+import { initDaemons } from "./daemons";
+import { createRepos } from "./infra/db/repo";
+import type { ServerRuntimeHandle, ServerRuntimeId, ServerRuntimeParams } from "./server";
+import { createChildRunCanceller } from "./service/cancel-child-runs";
+
+export interface CreateRuntimeParams {
+	db: Database;
+	logger: Logger;
+	runtime?: ServerRuntimeParams;
+}
+
+export function createRuntime(params: CreateRuntimeParams) {
+	return {
+		async start(): Promise<ServerRuntimeHandle> {
+			const { logger } = params;
+			const repos = await createRepos(params.db);
+			const childRunCanceller = createChildRunCanceller();
+
+			const daemons = initDaemons(logger, {
+				repos,
+				workflowRunPublisher: params.runtime?.publisher?.({
+					logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
+				}),
+				timerPriorityQueue: params.runtime?.timerPriorityQueue?.({
+					logger: logger.child({ "aiki.component": "timer-sorted-set" }),
+				}),
+				childRunCanceller,
+			});
+
+			const gracefulShutdownTimeoutMs = params.runtime?.options?.gracefulShutdownTimeoutMs ?? 5_000;
+
+			return createRuntimeHandle({
+				logger,
+				daemons,
+				gracefulShutdownTimeoutMs,
+			});
+		},
+	};
+}
+
+interface RuntimeHandleDeps {
+	logger: Logger;
+	daemons: { shutdown: () => Promise<void> };
+	gracefulShutdownTimeoutMs: number;
+}
+
+function createRuntimeHandle(deps: RuntimeHandleDeps): ServerRuntimeHandle {
+	const id = ulid() as ServerRuntimeId;
+	let stopPromise: Promise<void> | undefined;
+
+	const _stop = async (): Promise<void> => {
+		const daemonShutdownPromise = deps.daemons.shutdown();
+
+		if (deps.gracefulShutdownTimeoutMs <= 0) {
+			await daemonShutdownPromise;
+			return;
+		}
+
+		const result = await Promise.race([
+			daemonShutdownPromise.then(() => "done" as const),
+			delay(deps.gracefulShutdownTimeoutMs).then(() => "timeout" as const),
+		]);
+		if (result === "timeout") {
+			deps.logger.warn("Runtime did not shut down within graceful timeout", {
+				"aiki.runtimeId": id,
+				"aiki.gracefulShutdownTimeoutMs": deps.gracefulShutdownTimeoutMs,
+			});
+		}
+	};
+
+	return {
+		id,
+		stop(): Promise<void> {
+			if (!stopPromise) {
+				stopPromise = _stop();
+			}
+			return stopPromise;
+		},
+	};
+}

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -1,29 +1,9 @@
-import { delay } from "@aikirun/lib/async";
-import { UnauthorizedError } from "@aikirun/lib/error";
-import { SENTINEL_ULID } from "@aikirun/lib/id";
 import { ConsoleLogger, type Logger } from "@aikirun/lib/logger";
-import type { ApiAuthorizer, Iam, IamContext } from "@aikirun/types/iam";
+import type { Iam } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
-import type { Database } from "@aikirun/types/infra/db";
+import type { CreateDatabase } from "@aikirun/types/infra/db";
 import type { CreatePublisher } from "@aikirun/types/infra/queue";
 import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
-import type { NamespaceId } from "@aikirun/types/namespace";
-import type { OrganizationId } from "@aikirun/types/organization";
-import { RPCHandler } from "@orpc/server/fetch";
-import { ulid } from "ulidx";
-
-import type { Capabilities } from "./capabilities";
-import { initDaemons } from "./daemons";
-import { createRepos } from "./infra/db/repo";
-import { createNamespaceRequestContext, type NamespaceRequestContext } from "./middleware/context";
-import { createNamespaceAuthedRouter } from "./router/index";
-import { createChildRunCanceller } from "./service/cancel-child-runs";
-import { createScheduleService } from "./service/schedule";
-import { createTaskStateMachineService } from "./service/task-state-machine";
-import { createWorkflowService } from "./service/workflow";
-import { createWorkflowRunService } from "./service/workflow-run";
-import { createWorkflowRunOutboxService } from "./service/workflow-run-outbox";
-import { createWorkflowRunStateMachineService } from "./service/workflow-run-state-machine";
 
 export interface ServerRuntimeOptions {
 	gracefulShutdownTimeoutMs?: number;
@@ -36,7 +16,7 @@ export interface ServerRuntimeParams {
 }
 
 export interface ServerParams {
-	db: Database;
+	db: CreateDatabase;
 	iam?: Iam;
 	cache?: CreateCache;
 	logger?: Logger;
@@ -57,162 +37,29 @@ export interface Server {
 
 export function server(params: ServerParams): Server {
 	const logger: Logger = params.logger ?? new ConsoleLogger();
-	const repos = createRepos(params.db);
 
-	const childRunCanceller = createChildRunCanceller();
-
-	const createHandler = () => {
-		const apiAuthorizer = (params.iam?.api ?? noopApiAuthorizer)({ logger });
-		const dashboardIam = params.iam?.dashboard?.({ logger });
-
-		const workflowRunStateMachineService = createWorkflowRunStateMachineService({
-			repos,
-			childRunCanceller,
-		});
-		const taskStateMachineService = createTaskStateMachineService({ repos });
-		const workflowRunService = createWorkflowRunService({
-			repos,
-			childRunCanceller,
-			workflowRunStateMachineService,
-		});
-		const workflowService = createWorkflowService({ repos });
-		const scheduleService = createScheduleService({ repos });
-		const workflowRunOutboxService = createWorkflowRunOutboxService({ repos });
-
-		const namespaceAuthedRouter = createNamespaceAuthedRouter({
-			workflowRunService,
-			workflowRunStateMachineService,
-			taskStateMachineService,
-			workflowService,
-			scheduleService,
-			workflowRunOutboxService,
-		});
-
-		const namespaceAuthedHandler = new RPCHandler(namespaceAuthedRouter, {});
-
-		return async (request: Request): Promise<Response> => {
-			const pathname = new URL(request.url).pathname;
-
-			if (pathname.startsWith("/api/")) {
-				let context: NamespaceRequestContext;
-				try {
-					context = await createNamespaceRequestContext({ request, logger, authorizer: apiAuthorizer });
-				} catch (error) {
-					if (error instanceof UnauthorizedError) {
-						return new Response(error.message, { status: 401 });
-					}
-					logger.error("Unhandled error", { error });
-					return new Response("Internal Server Error", { status: 500 });
-				}
-
-				const result = await namespaceAuthedHandler.handle(request, { context, prefix: "/api" });
-				return result.response ?? new Response("Not Found", { status: 404 });
-			}
-
-			if (pathname.startsWith("/dashboard/")) {
-				if (!dashboardIam?.organization) {
-					return new Response("Not Found", { status: 404 });
-				}
-				return dashboardIam.organization(request);
-			}
-
-			if (pathname.startsWith("/auth/")) {
-				if (!dashboardIam?.authenticator) {
-					return new Response("Not Found", { status: 404 });
-				}
-				return dashboardIam.authenticator(request);
-			}
-
-			if (pathname === "/capabilities") {
-				if (request.method !== "GET") {
-					return new Response("Method Not Allowed", { status: 405 });
-				}
-				return Response.json({
-					iam: { dashboard: dashboardIam !== undefined },
-				} satisfies Capabilities);
-			}
-
-			if (pathname === "/health") {
-				if (request.method !== "GET") {
-					return new Response("Method Not Allowed", { status: 405 });
-				}
-				return Response.json({ status: "ok" });
-			}
-
-			return new Response("Not Found", { status: 404 });
-		};
-	};
-
-	const createRuntime = () => ({
-		async start(): Promise<ServerRuntimeHandle> {
-			const daemons = initDaemons(logger, {
-				repos,
-				workflowRunPublisher: params.runtime?.publisher?.({
-					logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
-				}),
-				timerPriorityQueue: params.runtime?.timerPriorityQueue?.({
-					logger: logger.child({ "aiki.component": "timer-sorted-set" }),
-				}),
-				childRunCanceller,
-			});
-
-			const gracefulShutdownTimeoutMs = params.runtime?.options?.gracefulShutdownTimeoutMs ?? 5_000;
-
-			return createRuntimeHandle({
-				logger,
-				daemons,
-				gracefulShutdownTimeoutMs,
-			});
-		},
-	});
-
-	return { handler: createHandler(), runtime: createRuntime() };
-}
-
-function noopApiAuthorizer(_context: IamContext): ApiAuthorizer {
-	return async () => ({
-		organizationId: SENTINEL_ULID as OrganizationId,
-		namespaceId: SENTINEL_ULID as NamespaceId,
-	});
-}
-
-interface RuntimeHandleDeps {
-	logger: Logger;
-	daemons: { shutdown: () => Promise<void> };
-	gracefulShutdownTimeoutMs: number;
-}
-
-function createRuntimeHandle(deps: RuntimeHandleDeps): ServerRuntimeHandle {
-	const id = ulid() as ServerRuntimeId;
-	let stopPromise: Promise<void> | undefined;
-
-	const _stop = async (): Promise<void> => {
-		const daemonShutdownPromise = deps.daemons.shutdown();
-
-		if (deps.gracefulShutdownTimeoutMs <= 0) {
-			await daemonShutdownPromise;
-			return;
-		}
-
-		const result = await Promise.race([
-			daemonShutdownPromise.then(() => "done" as const),
-			delay(deps.gracefulShutdownTimeoutMs).then(() => "timeout" as const),
-		]);
-		if (result === "timeout") {
-			deps.logger.warn("Runtime did not shut down within graceful timeout", {
-				"aiki.runtimeId": id,
-				"aiki.gracefulShutdownTimeoutMs": deps.gracefulShutdownTimeoutMs,
-			});
-		}
-	};
+	let handler: Server["handler"] | undefined;
+	let createHandlerPromise: Promise<Server["handler"]> | undefined;
 
 	return {
-		id,
-		stop(): Promise<void> {
-			if (!stopPromise) {
-				stopPromise = _stop();
-			}
-			return stopPromise;
+		handler: (request) => {
+			if (handler) return handler(request);
+			return (async () => {
+				createHandlerPromise ??= (async () => {
+					const db = await params.db();
+					const { createHandler } = await import("./handler");
+					return createHandler({ db, logger, iam: params.iam, cache: params.cache });
+				})();
+				handler = await createHandlerPromise;
+				return handler(request);
+			})();
+		},
+		runtime: {
+			async start(): Promise<ServerRuntimeHandle> {
+				const db = await params.db();
+				const { createRuntime } = await import("./runtime");
+				return createRuntime({ db, logger, runtime: params.runtime }).start();
+			},
 		},
 	};
 }

--- a/types/src/infra/db.ts
+++ b/types/src/infra/db.ts
@@ -16,3 +16,5 @@ export interface Database {
 	readonly provider: DatabaseProvider;
 	readonly [INTERNAL]: { client: unknown };
 }
+
+export type CreateDatabase = () => Promise<Database>;


### PR DESCRIPTION
## Motivation

Both `@aikirun/server` and `@aikirun/iam` eagerly load the pg driver layer at module import time — `@aikirun/server` imports `postgres` directly; `@aikirun/iam` imports `drizzle-orm/postgres-js` (the drizzle adapter for `postgres`) — even though `Database`, the opaque pluggable DB handle the SDKs accept, is intentionally provider-agnostic and will one day support sqlite and mysql too. A sqlite-only deployment can't avoid pulling pg machinery into its working set.

iam goes further. The moment anything imports `@aikirun/iam`, it also pulls in `better-auth` and the iam pg schema definitions. `better-auth` is needed by every iam path that validates a cookie-session. The only iam authorization path that doesn't touch `better-auth` is API-key authorization. Yet a deployment wiring only API-key authorization, with no dashboard configured, still pays the load.

The cause is structural. `database(config)` produced a fully-resolved `Database` synchronously, with the driver client baked in. `server({ db })` was a sync constructor that built every repo, service, router, and the entire HTTP fetch handler graph at construction time, sharing imports between the handler subsystem (HTTP-side, mounted on whatever fetch-API server the host uses) and the runtime subsystem (the daemon orchestrator that drives state transitions and queue publishing). iam's drizzle-adapter setup statically imported `drizzle-orm/postgres-js` from the top of its auth module to construct the better-auth adapter. There was no seam through which a non-pg consumer could opt out of the pg code path.

## Solution

```ts
// Before
function database(config: DatabaseConfig): Database;

interface ServerParams {
  db: Database;
  iam?: Iam;
  // ...
}

// After
function database(config: DatabaseConfig): CreateDatabase;
type CreateDatabase = () => Promise<Database>;

interface ServerParams {
  db: CreateDatabase;
  iam?: Iam;
  // ...
}
```

`Database` is now a runtime resource produced by a memoized async factory. The dispatcher behind `CreateDatabase` routes to its provider via dynamic import, so the pg driver only resolves when the pg branch fires. `server({ db })` and `iam({ db })` share the same factory — the first awaiter opens the pool, the rest reuse the cached promise.

`server({ ... })` itself stays sync. Its handler and runtime are independently lazy — the handler initializes on the first request, the runtime when `start()` is called. Each pulls in its own module, so a handler-only deployment never loads daemon-only code and a runtime-only deployment never loads handler-only code.

iam mirrors the same shape — its per-request callables defer setup to first use. `createAuthService` becomes async and dynamic-imports both `drizzle-orm/postgres-js` and the iam pg schema inside the pg branch. The cross-provider contract for the better-auth schema, previously implicit, is now an explicit key-union type that each provider's schema object satisfies. A deployment wiring only API-key authorization, with no dashboard configured, never evaluates `better-auth`, the iam pg schema, or `drizzle-orm/pg-core`.

`postgres` becomes an optional peer dependency on both SDK packages. Pg consumers must declare it themselves; sqlite-only consumers (when sqlite support lands) don't pull it at all.

## Breaking changes

- The `db` field on the public params of `@aikirun/server` and `@aikirun/iam` now takes `CreateDatabase` instead of `Database`. The call shape `database(config)` is unchanged at the consumer side.
- `postgres` is no longer pulled by `@aikirun/server` or `@aikirun/iam`. Pg deployments must declare it.