### PR TITLE
Truthful publish results and fail-fast Redis availability

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -1,10 +1,12 @@
 import process from "node:process";
 import { iam } from "@aikirun/iam";
-import { redisCache, redisPublisher, redisTimerPriorityQueue } from "@aikirun/redis";
+import type { Logger } from "@aikirun/lib/logger";
+import { attachConnectionSupervisor, redisCache, redisPublisher, redisTimerPriorityQueue } from "@aikirun/redis";
 import { database, server } from "@aikirun/server";
 import { Redis } from "ioredis";
 
 import { loadConfig } from "./config/loader";
+import type { RedisConfig } from "./config/schema";
 import { createCorsHelpers } from "./cors";
 import { createLogger } from "./logger";
 
@@ -12,20 +14,10 @@ if (import.meta.main) {
 	const config = await loadConfig();
 	const logger = createLogger(config.logLevel, config.prettyLogs);
 
-	let redis: Redis | undefined;
-	if (config.redis) {
-		redis = new Redis({
-			host: config.redis.host,
-			port: config.redis.port,
-			password: config.redis.password,
-		});
-		redis.on("error", (err: Error) => {
-			logger.error("Redis connection error", { err });
-		});
-	}
+	const redis = config.redis && createRedis(config.redis, logger);
 
 	const db = database(config.db);
-	const cache = redis && redisCache(redis);
+	const cache = redis && redisCache(redis.client);
 
 	const aiki = server({
 		db,
@@ -43,8 +35,8 @@ if (import.meta.main) {
 				: undefined,
 		runtime: {
 			...(redis && {
-				publisher: redisPublisher(redis),
-				timerPriorityQueue: redisTimerPriorityQueue(redis, "aiki:timers"),
+				publisher: redisPublisher(redis.client),
+				timerPriorityQueue: redisTimerPriorityQueue(redis.client, "aiki:timers"),
 			}),
 		},
 	});
@@ -69,10 +61,10 @@ if (import.meta.main) {
 	const shutdown = () => {
 		if (!shutdownPromise) {
 			shutdownPromise = (async () => {
-				await runtimeHandle.stop();
 				if (redis) {
-					await redis.quit();
+					redis.close();
 				}
+				await runtimeHandle.stop();
 				process.exit(0);
 			})();
 		}
@@ -83,4 +75,55 @@ if (import.meta.main) {
 	process.on("SIGINT", shutdown);
 
 	logger.info(`Server running on ${config.host}:${config.port}`);
+}
+
+function createRedis(config: RedisConfig, logger: Logger) {
+	const redis = new Redis({
+		host: config.host,
+		port: config.port,
+		password: config.password,
+	});
+	const connectionSupervisor = attachConnectionSupervisor(redis, { logger });
+
+	type State =
+		| { status: "connecting"; errorReported: boolean }
+		| { status: "connected" }
+		| { status: "disconnected"; errorReported: boolean };
+
+	let currentState: State = { status: "connecting", errorReported: false };
+
+	redis.on("ready", () => {
+		if (currentState.status === "connecting") {
+			logger.info("Redis connection established");
+		} else if (currentState.status === "disconnected") {
+			logger.info("Redis connection restored");
+		}
+		currentState = { status: "connected" };
+	});
+	// A clean disconnect emits "close" without ever emitting "error" — the
+	// first "error" only arrives once a reconnect attempt fails at the
+	// socket level, which can take up to connectTimeout per attempt.
+	redis.on("close", () => {
+		if (currentState.status === "connected") {
+			logger.warn("Redis connection lost");
+			currentState = { status: "disconnected", errorReported: false };
+		}
+	});
+	redis.on("error", (err: Error) => {
+		if (currentState.status === "connected") {
+			logger.error("Redis connection error", { err });
+			currentState = { status: "disconnected", errorReported: true };
+		} else if (!currentState.errorReported) {
+			logger.error("Redis connection error", { err });
+			currentState.errorReported = true;
+		}
+	});
+
+	return {
+		client: redis,
+		close() {
+			connectionSupervisor.detach();
+			redis.disconnect();
+		},
+	};
 }

--- a/sdk/adapter/memory/src/queue/publisher.ts
+++ b/sdk/adapter/memory/src/queue/publisher.ts
@@ -1,12 +1,18 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import type { CreatePublisher, Publisher, PublisherContext, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type {
+	CreatePublisher,
+	Publisher,
+	PublisherContext,
+	PublishResult,
+	ReadyWorkflowRun,
+} from "@aikirun/types/infra/queue";
 
 import { getWorkflowQueueName } from "./key";
 import type { Queue, Store } from "./store";
 
 export function createInMemoryPublisher(store: Store): CreatePublisher {
 	return (_context: PublisherContext): Publisher => ({
-		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void> {
+		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishResult> {
 			const touchedQueues = new Map<string, Queue>();
 			for (const { id, name, versionId, rank, shard } of runs) {
 				const queueName = getWorkflowQueueName(name, versionId, shard);
@@ -20,6 +26,8 @@ export function createInMemoryPublisher(store: Store): CreatePublisher {
 					queue.waiterHandles.values().next().value?.wake(queueName);
 				}
 			}
+
+			return { published: runs, deferred: [], failed: [], declined: [] };
 		},
 	});
 }

--- a/sdk/adapter/memory/src/timer/priority-queue.ts
+++ b/sdk/adapter/memory/src/timer/priority-queue.ts
@@ -3,6 +3,7 @@ import { createMinHeap } from "@aikirun/lib/collection/heap";
 import type {
 	CreateTimerPriorityQueue,
 	DueTimer,
+	TimerAddResult,
 	TimerEntry,
 	TimerPriorityQueue,
 	TimerPriorityQueueContext,
@@ -61,7 +62,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 	}
 
 	const timerPriorityQueue: TimerPriorityQueue = {
-		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
+		async add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult> {
 			let minDueAt = timers[0].dueAt;
 			for (const timer of timers) {
 				if (timer.dueAt < minDueAt) {
@@ -71,6 +72,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 			}
 			signals.push(minDueAt);
 			waiterHandles.values().next().value?.wake();
+			return { status: "added" };
 		},
 
 		async popDue(maxRank: number, limit: number): Promise<DueTimer[]> {

--- a/sdk/adapter/redis/src/connection.ts
+++ b/sdk/adapter/redis/src/connection.ts
@@ -13,15 +13,78 @@ interface RedisConnectionSupervisorOptions {
 	logger?: Logger;
 }
 
+interface RedisConnectionTracker {
+	isAvailable(): boolean;
+	assertIsAvailable(): void;
+}
+
 /**
- * Attaches connection-lifecycle supervision to an existing Redis client. The
- * client is expected to already be configured in fail-fast mode.
- * Adds a supervisor over the "connect → ready" handshake and forces a reconnect
- * if that handshake stalls.
+ * Tracks whether a connection is usable right now by listening to it:
+ * "close" means the connection dropped, "ready" means it works.
+ *
+ * One failure emits no events at all: a connect accepted by something dead —
+ * e.g. a stopped container's forwarded port — that never answers. The
+ * connection then just waits, and the optimistic starting verdict would never
+ * be corrected. The grace check covers it: if no "ready" has arrived within
+ * the connection's own connect timeout, stop assuming it is fine.
+ *
+ * The listeners only observe — the connection is never configured or acted on.
+ */
+function createConnectionTracker(redis: Redis): RedisConnectionTracker {
+	const readyGraceMs = redis.options.connectTimeout ?? 10_000;
+	const { status } = redis;
+	let available = status !== "reconnecting" && status !== "close" && status !== "end";
+	let lastReadyObservedAt = Date.now();
+
+	redis.on("ready", () => {
+		available = true;
+		lastReadyObservedAt = Date.now();
+	});
+	redis.on("close", () => {
+		available = false;
+	});
+
+	const isAvailable = () => {
+		if (available && redis.status !== "ready" && Date.now() - lastReadyObservedAt > readyGraceMs) {
+			available = false;
+		}
+		return available;
+	};
+
+	return {
+		isAvailable,
+		assertIsAvailable() {
+			if (!isAvailable()) {
+				throw new Error("Redis connection unavailable");
+			}
+		},
+	};
+}
+
+export const connectionTracker = (() => {
+	const trackers = new WeakMap<Redis, RedisConnectionTracker>();
+	return (redis: Redis): RedisConnectionTracker => {
+		let tracker = trackers.get(redis);
+		if (!tracker) {
+			tracker = createConnectionTracker(redis);
+			trackers.set(redis, tracker);
+		}
+		return tracker;
+	};
+})();
+
+/**
+ * Attaches connection-lifecycle supervision to an existing Redis client: a
+ * watchdog over the "connect → ready" handshake that forces a reconnect if the
+ * handshake stalls. ioredis's connectTimeout only covers the TCP connect; a
+ * socket that is accepted but never served (e.g. a stopped container's
+ * forwarded port) would otherwise wedge the client in "connect" forever,
+ * emitting no events. Also installs a no-op "error" listener so a client
+ * without one cannot crash the process.
  */
 export function attachConnectionSupervisor(redis: Redis, options?: RedisConnectionSupervisorOptions) {
 	const logger = options?.logger;
-	const connectTimeoutMs = redis.options.connectTimeout ?? 5_000;
+	const connectTimeoutMs = redis.options.connectTimeout ?? 10_000;
 
 	type State =
 		| { status: "disconnected" }

--- a/sdk/adapter/redis/src/index.ts
+++ b/sdk/adapter/redis/src/index.ts
@@ -1,4 +1,5 @@
 export { redisCache } from "./cache";
+export { attachConnectionSupervisor } from "./connection";
 export { redisPublisher } from "./queue/publisher";
 export { type RedisSubscriberOptions, redisSubscriber } from "./queue/subscriber";
 export { redisTimerPriorityQueue } from "./timer/priority-queue";

--- a/sdk/adapter/redis/src/queue/publisher.ts
+++ b/sdk/adapter/redis/src/queue/publisher.ts
@@ -1,30 +1,79 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import type { CreatePublisher, Publisher, PublisherContext, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type { CreatePublisher, Publisher, PublishResult, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
 import type { Redis } from "ioredis";
 
 import { getWorkflowQueueName } from "./key";
+import { connectionTracker } from "../connection";
+
+interface QueueData {
+	runs: ReadyWorkflowRun[];
+	args: (string | number)[];
+}
 
 export function redisPublisher(redis: Redis): CreatePublisher {
-	return (_context: PublisherContext): Publisher => ({
-		async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void> {
-			const redisPipeline = redis.pipeline();
+	return ({ logger }): Publisher => {
+		const redisTracker = connectionTracker(redis);
 
-			const argsByQueueName = new Map<string, (string | number)[]>();
-			for (const { id, name, versionId, rank, shard } of runs) {
-				const queueName = getWorkflowQueueName(name, versionId, shard);
-				const args = argsByQueueName.get(queueName);
-				if (!args) {
-					argsByQueueName.set(queueName, [rank, id]);
-				} else {
-					args.push(rank, id);
+		return {
+			async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishResult> {
+				if (!redisTracker.isAvailable()) {
+					return { published: [], deferred: [], failed: runs, declined: [] };
 				}
-			}
 
-			for (const [queueName, args] of argsByQueueName) {
-				redisPipeline.zadd(queueName, ...args);
-			}
+				const dataByQueueName = new Map<string, QueueData>();
+				for (const run of runs) {
+					const queueName = getWorkflowQueueName(run.name, run.versionId, run.shard);
+					const queueData = dataByQueueName.get(queueName);
+					if (!queueData) {
+						dataByQueueName.set(queueName, { runs: [run], args: [run.rank, run.id] });
+					} else {
+						queueData.runs.push(run);
+						queueData.args.push(run.rank, run.id);
+					}
+				}
 
-			await redisPipeline.exec();
-		},
-	});
+				const redisPipeline = redis.pipeline();
+				const queueDataBatch: QueueData[] = [];
+				for (const [queueName, queueData] of dataByQueueName) {
+					redisPipeline.zadd(queueName, ...queueData.args);
+					queueDataBatch.push(queueData);
+				}
+
+				const results = await redisPipeline.exec();
+				if (results === null) {
+					logger.warn("Publish pipeline returned no results, treating runs as failed", {
+						count: runs.length,
+					});
+					return { published: [], deferred: [], failed: runs, declined: [] };
+				}
+
+				const published: ReadyWorkflowRun[] = [];
+				const failed: ReadyWorkflowRun[] = [];
+				let error: Error | undefined;
+				for (const [i, queueData] of queueDataBatch.entries()) {
+					const result = results[i];
+					const commandError = result === undefined ? new Error("Pipeline returned no result for command") : result[0];
+					if (commandError !== null) {
+						error ??= commandError;
+						for (const run of queueData.runs) {
+							failed.push(run);
+						}
+					} else {
+						for (const run of queueData.runs) {
+							published.push(run);
+						}
+					}
+				}
+
+				if (error) {
+					logger.warn("Publish command failed, treating its runs as failed", {
+						err: error,
+						count: failed.length,
+					});
+				}
+
+				return { published, deferred: [], failed, declined: [] };
+			},
+		};
+	};
 }

--- a/sdk/adapter/redis/src/timer/priority-queue.ts
+++ b/sdk/adapter/redis/src/timer/priority-queue.ts
@@ -2,6 +2,7 @@ import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type {
 	CreateTimerPriorityQueue,
 	DueTimer,
+	TimerAddResult,
 	TimerEntry,
 	TimerPriorityQueue,
 	TimerSignalWaiter,
@@ -9,7 +10,7 @@ import type {
 } from "@aikirun/types/infra/timer";
 import type { Redis } from "ioredis";
 
-import { attachConnectionSupervisor } from "../connection";
+import { attachConnectionSupervisor, connectionTracker } from "../connection";
 
 function encodeMember(type: TimerType, id: string): string {
 	return `${type}:${id}`;
@@ -73,83 +74,99 @@ return minSignal
 export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerPriorityQueue {
 	const signalKey = `${key}:signal`;
 
-	return ({ logger }): TimerPriorityQueue => ({
-		async add(timers: NonEmptyArray<TimerEntry>): Promise<void> {
-			let minDueAt = timers[0].dueAt;
-			const args: (string | number)[] = [];
-			for (const timer of timers) {
-				if (timer.dueAt < minDueAt) {
-					minDueAt = timer.dueAt;
+	return ({ logger }): TimerPriorityQueue => {
+		const redisTracker = connectionTracker(redis);
+
+		return {
+			async add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult> {
+				if (!redisTracker.isAvailable()) {
+					return { status: "failed" };
 				}
-				const member = encodeMember(timer.type, timer.id);
-				args.push(timer.rank, member);
-			}
 
-			await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minDueAt, ...args);
-		},
-
-		async popDue(maxRank: number, limit: number): Promise<DueTimer[]> {
-			const pairs = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxRank, limit)) as string[];
-			if (pairs.length === 0) {
-				return [];
-			}
-
-			const result: DueTimer[] = [];
-			for (let i = 0; i + 1 < pairs.length; i += 2) {
-				const member = pairs[i] as string;
-				const rank = Number(pairs[i + 1]);
-				result.push(decodeMember(member, rank));
-			}
-			return result;
-		},
-
-		async peekNextRank(): Promise<number | null> {
-			const result = await redis.zrangebyscore(key, "-inf", "+inf", "WITHSCORES", "LIMIT", 0, 1);
-			if (result.length < 2) {
-				return null;
-			}
-			return Number(result[1]);
-		},
-
-		createSignalWaiter(): TimerSignalWaiter {
-			const redisDuplicate = redis.duplicate({
-				maxRetriesPerRequest: 0,
-				enableOfflineQueue: false,
-			});
-			const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger });
-			let closed = false;
-
-			return {
-				/**
-				 * Blocks on the signal list, then drains any remaining signals.
-				 * Returns the minimum signal observed (combining BRPOP value with drained values).
-				 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
-				 * peek-after-pop will rediscover them.
-				 */
-				async wait(timeoutSeconds: number): Promise<number> {
-					const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
-					if (result === null) {
-						await redisDuplicate.del(signalKey);
-						return 0;
+				let minDueAt = timers[0].dueAt;
+				const args: (string | number)[] = [];
+				for (const timer of timers) {
+					if (timer.dueAt < minDueAt) {
+						minDueAt = timer.dueAt;
 					}
+					const member = encodeMember(timer.type, timer.id);
+					args.push(timer.rank, member);
+				}
 
-					const signal = Number(result[1]);
-					const minSignal = (await redisDuplicate.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
-					if (minSignal === null) {
-						return signal;
-					}
-					return Math.min(signal, minSignal);
-				},
+				try {
+					await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minDueAt, ...args);
+				} catch (err) {
+					logger.warn("Timer add command failed", { err, count: timers.length });
+					return { status: "failed" };
+				}
+				return { status: "added" };
+			},
 
-				async close(): Promise<void> {
-					if (closed) {
-						return;
-					}
-					closed = true;
-					connectionSupervisor.detach();
-					redisDuplicate.disconnect();
-				},
-			};
-		},
-	});
+			async popDue(maxRank: number, limit: number): Promise<DueTimer[]> {
+				redisTracker.assertIsAvailable();
+				const pairs = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxRank, limit)) as string[];
+				if (pairs.length === 0) {
+					return [];
+				}
+
+				const result: DueTimer[] = [];
+				for (let i = 0; i + 1 < pairs.length; i += 2) {
+					const member = pairs[i] as string;
+					const rank = Number(pairs[i + 1]);
+					result.push(decodeMember(member, rank));
+				}
+				return result;
+			},
+
+			async peekNextRank(): Promise<number | null> {
+				redisTracker.assertIsAvailable();
+				const result = await redis.zrangebyscore(key, "-inf", "+inf", "WITHSCORES", "LIMIT", 0, 1);
+				if (result.length < 2) {
+					return null;
+				}
+				return Number(result[1]);
+			},
+
+			createSignalWaiter(): TimerSignalWaiter {
+				const redisDuplicate = redis.duplicate({
+					maxRetriesPerRequest: 0,
+					enableOfflineQueue: false,
+				});
+				const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger });
+				let closed = false;
+
+				return {
+					/**
+					 * Blocks on the signal list, then drains any remaining signals.
+					 * Returns the minimum signal observed (combining BRPOP value with drained values).
+					 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
+					 * peek-after-pop will rediscover them.
+					 */
+					async wait(timeoutSeconds: number): Promise<number> {
+						const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
+						if (result === null) {
+							await redisDuplicate.del(signalKey);
+							return 0;
+						}
+
+						const signal = Number(result[1]);
+						const minSignal = (await redisDuplicate.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
+						if (minSignal === null) {
+							return signal;
+						}
+						return Math.min(signal, minSignal);
+					},
+
+					async close(): Promise<void> {
+						if (closed) {
+							return;
+						}
+						closed = true;
+						connectionSupervisor.detach();
+						redisDuplicate.disconnect();
+					},
+				};
+			},
+		};
+	};
 }

--- a/sdk/server/src/daemons/due-timers-consumer.ts
+++ b/sdk/server/src/daemons/due-timers-consumer.ts
@@ -53,11 +53,11 @@ export function spawnDueTimersConsumer(
 		{ type: "jittered", maxAttempts: Number.POSITIVE_INFINITY, baseDelayMs: 1_000, maxDelayMs: 30_000 },
 		{
 			abortSignal,
-			onError: (error) => {
+			onError: (err) => {
 				if (abortSignal.aborted) {
 					return;
 				}
-				logger.error("Due timers consumer crashed unexpectedly", { error });
+				logger.warn("Due timers consumer failed, will retry", { err });
 			},
 		}
 	).run();
@@ -114,8 +114,8 @@ async function dueTimersConsumerLoop(
 		for await (const dueTimers of streamChunks(next, { until: (chunk) => chunk.length < limit })) {
 			try {
 				await processDueTimers(context, deps, dueTimers);
-			} catch (error) {
-				context.logger.error("Failed to process due timers batch", { error });
+			} catch (err) {
+				context.logger.error("Failed to process due timers batch", { err });
 			}
 		}
 

--- a/sdk/server/src/daemons/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemons/imminent-child-run-wait-timed-out-runs.ts
@@ -6,13 +6,13 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { ChildWorkflowRunWaitQueueRowInsert } from "../infra/db/types/child-workflow-run-wait-queue";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import type { Ranked } from "../lib/rank";
 import { streamTimers } from "../lib/timer-stream";
@@ -53,7 +53,10 @@ export async function processImminentChildRunWaitTimedOutRuns(
 				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -85,8 +88,8 @@ export async function queueChildRunWaitTimedOutRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -105,7 +108,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -166,7 +169,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
 			"awaiting_child_workflow",
 			workflowRunUpdates
@@ -204,6 +207,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemons/imminent-event-wait-timed-out-runs.ts
@@ -6,13 +6,13 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { EventWaitQueueRowInsert } from "../infra/db/types/event-wait-queue";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import type { Ranked } from "../lib/rank";
 import { streamTimers } from "../lib/timer-stream";
@@ -53,7 +53,10 @@ export async function processImminentEventWaitTimedOutRuns(
 				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -85,8 +88,8 @@ export async function queueEventWaitTimedOutRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -105,7 +108,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -166,7 +169,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_event", workflowRunUpdates);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
@@ -199,6 +202,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/imminent-recurring-workflows.ts
+++ b/sdk/server/src/daemons/imminent-recurring-workflows.ts
@@ -15,11 +15,11 @@ import {
 } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { computeRank } from "../lib/rank";
 import { createTimerStreamCursorAdvancer } from "../lib/timer-stream";
 import type { DaemonContext } from "../middleware/context";
@@ -86,7 +86,10 @@ export async function processImminentRecurringWorkflows(
 				dueAt: schedule.nextRunAt,
 				rank: computeRank(schedule.nextRunAt),
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -142,7 +145,7 @@ async function processOverlapAllowSchedules(
 ) {
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: { id: string; lastOccurrence: TimestampMs; nextRunAt: TimestampMs }[] = [];
 
 	for (const schedule of schedules) {
@@ -214,7 +217,7 @@ async function processOverlapAllowSchedules(
 	});
 
 	if (workflowRunPublisher) {
-		await publishRuns(context, repos, workflowRunPublisher, outboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, outboxEntries);
 	}
 }
 
@@ -229,7 +232,7 @@ async function processOverlapSkipSchedules(
 
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: { id: string; lastOccurrence?: TimestampMs; nextRunAt: TimestampMs }[] = [];
 
 	for (const schedule of schedules) {
@@ -292,7 +295,7 @@ async function processOverlapSkipSchedules(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		if (isNonEmptyArray(workflowRunEntries) && isNonEmptyArray(stateTransitionEntries)) {
 			await txRepos.workflowRun.insert(workflowRunEntries);
 			await txRepos.stateTransition.appendBatch(stateTransitionEntries);
@@ -306,7 +309,7 @@ async function processOverlapSkipSchedules(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }
 
@@ -323,7 +326,7 @@ async function processOverlapCancelPreviousSchedules(
 
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
 	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
-	const newOutboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const newOutboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: { id: string; lastOccurrence: TimestampMs; nextRunAt: TimestampMs }[] = [];
 
 	for (const schedule of schedules) {
@@ -391,7 +394,7 @@ async function processOverlapCancelPreviousSchedules(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await deps.repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await deps.repos.transaction(async (txRepos) => {
 		// To escape the race condition that might arise when a concurrent actor moves the runId to non cancellable state,
 		// we should only insert cancellation state transitions if the cancellation occurred, otherwise, we'll have dangling transitions
 
@@ -449,7 +452,7 @@ async function processOverlapCancelPreviousSchedules(
 	});
 
 	if (deps.workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, deps.repos, deps.workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, deps.repos, deps.workflowRunPublisher, insertedOutboxEntries);
 	}
 }
 

--- a/sdk/server/src/daemons/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-runs.ts
@@ -6,12 +6,12 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import type { Ranked } from "../lib/rank";
 import { streamTimers } from "../lib/timer-stream";
@@ -53,7 +53,10 @@ export async function processImminentRetryableRuns(
 				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -74,8 +77,8 @@ export async function queueRetryableRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -90,7 +93,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -134,7 +137,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_retry", workflowRunUpdates, {
 			incrementAttempts: true,
 		});
@@ -164,6 +167,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/imminent-retryable-task-runs.ts
+++ b/sdk/server/src/daemons/imminent-retryable-task-runs.ts
@@ -7,12 +7,12 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import { computeRank, type Ranked } from "../lib/rank";
 import { createTimerStreamCursorAdvancer } from "../lib/timer-stream";
@@ -83,7 +83,10 @@ export async function processImminentRetryableTaskRuns(
 				dueAt: task.dueAt,
 				rank: computeRank(task.dueAt),
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 
 		now = Date.now();
@@ -106,8 +109,8 @@ export async function queueRetryableTaskRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -122,7 +125,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -166,7 +169,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("running", workflowRunUpdates);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
@@ -192,6 +195,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemons/imminent-scheduled-runs.ts
@@ -6,12 +6,12 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunState, WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import type { Ranked } from "../lib/rank";
 import { streamTimers } from "../lib/timer-stream";
@@ -49,7 +49,10 @@ export async function processImminentScheduledRuns(
 				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -81,8 +84,8 @@ export async function queueScheduledRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, stateTransitionsById, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -98,7 +101,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -150,7 +153,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("scheduled", workflowRunUpdates);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
@@ -176,6 +179,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
@@ -5,12 +5,12 @@ import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer"
 import type { WorkflowRunStateQueued, WorkflowStartOptions } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
-import { publishRuns } from "./publish-ready-runs";
+import { publishPendingOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
 import type { Ranked } from "../lib/rank";
 import { streamTimers } from "../lib/timer-stream";
@@ -51,7 +51,10 @@ export async function processImminentSleepElapsedRuns(
 				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
-			await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add timers to priority queue", { count: timers.length });
+			}
 		}
 	}
 }
@@ -72,8 +75,8 @@ export async function queueSleepElapsedRuns(
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
 		try {
 			await processChunk(spanCtx, repos, workflowRunPublisher, chunk, workflowsById);
-		} catch (error) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { error, chunkSize: chunk.length });
+		} catch (err) {
+			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, chunkSize: chunk.length });
 		}
 	});
 }
@@ -90,7 +93,7 @@ async function processChunk(
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
-	const outboxEntries: WorkflowRunOutboxRowInsert[] = [];
+	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 
 	for (const run of runs) {
 		const workflow = workflowsById.get(run.workflowId);
@@ -133,7 +136,7 @@ async function processChunk(
 		return;
 	}
 
-	const insertedOutboxEntries: WorkflowRunOutboxRowInsert[] = await repos.transaction(async (txRepos) => {
+	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("sleeping", workflowRunUpdates);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
@@ -161,6 +164,6 @@ async function processChunk(
 	});
 
 	if (workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishRuns(context, repos, workflowRunPublisher, insertedOutboxEntries);
+		await publishPendingOutboxEntries(context, repos, workflowRunPublisher, insertedOutboxEntries);
 	}
 }

--- a/sdk/server/src/daemons/index.ts
+++ b/sdk/server/src/daemons/index.ts
@@ -130,7 +130,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 	}
 
 	return {
-		async shutdown() {
+		async stop() {
 			const daemonPromises: Promise<unknown>[] = [];
 			for (const { abortController, promise } of daemons) {
 				abortController.abort();

--- a/sdk/server/src/daemons/publish-ready-runs.ts
+++ b/sdk/server/src/daemons/publish-ready-runs.ts
@@ -1,9 +1,12 @@
 import { streamChunks } from "@aikirun/lib/async";
-import type { NonEmptyArray } from "@aikirun/lib/collection/array";
+import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
 
 import type { Repositories } from "../infra/db/types";
-import type { WorkflowRunOutboxRowInsert } from "../infra/db/types/workflow-run-outbox";
+import type {
+	WorkflowRunOutboxRowInsert,
+	WorkflowRunOutboxRowInsertPending,
+} from "../infra/db/types/workflow-run-outbox";
 import { createRankStreamCursorAdvancer } from "../lib/rank-stream";
 import type { DaemonContext } from "../middleware/context";
 
@@ -31,20 +34,31 @@ export async function publishReadyRuns(
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		await publishRuns(context, deps.repos, deps.workflowRunPublisher, pendingEntries);
+		await publishPendingOutboxEntries(context, deps.repos, deps.workflowRunPublisher, pendingEntries);
 	}
 }
 
-export async function publishRuns(
+export async function publishPendingOutboxEntries(
 	context: DaemonContext,
 	repos: Pick<Repositories, "workflowRunOutbox">,
 	workflowRunPublisher: Publisher,
-	entries: NonEmptyArray<WorkflowRunOutboxRowInsert>
+	entries: NonEmptyArray<WorkflowRunOutboxRowInsertPending>
 ): Promise<void> {
-	const entryIds: string[] = [];
+	const publishedEntryIds = await publishOutboxEntries(context, workflowRunPublisher, entries);
+	if (isNonEmptyArray(publishedEntryIds)) {
+		await repos.workflowRunOutbox.markPublished(publishedEntryIds);
+	}
+}
+
+export async function publishOutboxEntries(
+	context: DaemonContext,
+	workflowRunPublisher: Publisher,
+	entries: NonEmptyArray<WorkflowRunOutboxRowInsert>
+): Promise<string[]> {
+	const entryIdByRunId = new Map<string, string>();
 	const runs: ReadyWorkflowRun[] = [];
 	for (const entry of entries) {
-		entryIds.push(entry.id);
+		entryIdByRunId.set(entry.workflowRunId, entry.id);
 		runs.push({
 			namespaceId: entry.namespaceId,
 			id: entry.workflowRunId,
@@ -55,8 +69,30 @@ export async function publishRuns(
 		});
 	}
 
-	await workflowRunPublisher.publishReadyRuns(runs as NonEmptyArray<ReadyWorkflowRun>);
-	context.logger.debug("Published ready workflow runs", { count: runs.length });
+	const result = await workflowRunPublisher.publishReadyRuns(runs as NonEmptyArray<ReadyWorkflowRun>);
 
-	await repos.workflowRunOutbox.markPublished(entryIds as NonEmptyArray<string>);
+	const publishedEntryIds: string[] = [];
+	if (isNonEmptyArray(result.published)) {
+		context.logger.debug("Published ready workflow runs", { count: result.published.length });
+		for (const run of result.published) {
+			const entryId = entryIdByRunId.get(run.id);
+			if (entryId !== undefined) {
+				publishedEntryIds.push(entryId);
+			}
+		}
+	}
+
+	if (isNonEmptyArray(result.deferred)) {
+		context.logger.debug("Deferred publishing workflow runs", { count: result.deferred.length });
+	}
+
+	if (isNonEmptyArray(result.failed)) {
+		context.logger.debug("Failed to publish workflow runs", { count: result.failed.length });
+	}
+
+	if (isNonEmptyArray(result.declined)) {
+		context.logger.warn("Declined to publish workflow runs", { count: result.declined.length });
+	}
+
+	return publishedEntryIds;
 }

--- a/sdk/server/src/daemons/republish-stale-runs.ts
+++ b/sdk/server/src/daemons/republish-stale-runs.ts
@@ -1,10 +1,10 @@
 import { streamChunks } from "@aikirun/lib/async";
-import type { NonEmptyArray } from "@aikirun/lib/collection/array";
+import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
-import type { Publisher, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type { Publisher } from "@aikirun/types/infra/queue";
 
+import { publishOutboxEntries } from "./publish-ready-runs";
 import type { Repositories } from "../infra/db/types";
-import type { WorkflowRunOutboxRow } from "../infra/db/types/workflow-run-outbox";
 import { createTimerStreamCursorAdvancer } from "../lib/timer-stream";
 import type { DaemonContext } from "../middleware/context";
 
@@ -37,10 +37,11 @@ export async function republishStaleRuns(
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		context.logger.info("Releasing stale outbox claims", { count: staleEntries.length });
-		await republishRuns(context, deps.workflowRunPublisher, staleEntries);
-		const staleEntryIds = staleEntries.map((entry) => entry.id) as NonEmptyArray<string>;
-		await deps.repos.workflowRunOutbox.releaseStaleClaim(staleEntryIds);
+		context.logger.debug("Releasing stale outbox claims", { count: staleEntries.length });
+		const publishedEntryIds = await publishOutboxEntries(context, deps.workflowRunPublisher, staleEntries);
+		if (isNonEmptyArray(publishedEntryIds)) {
+			await deps.repos.workflowRunOutbox.releaseStaleClaim(publishedEntryIds);
+		}
 	}
 
 	for await (const staleEntries of streamChunks(
@@ -50,27 +51,10 @@ export async function republishStaleRuns(
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		context.logger.info("Republishing stale published outbox entries", { count: staleEntries.length });
-		await republishRuns(context, deps.workflowRunPublisher, staleEntries);
-		const staleEntryIds = staleEntries.map((entry) => entry.id) as NonEmptyArray<string>;
-		await deps.repos.workflowRunOutbox.markRepublished(staleEntryIds);
+		context.logger.debug("Republishing stale published outbox entries", { count: staleEntries.length });
+		const publishedEntryIds = await publishOutboxEntries(context, deps.workflowRunPublisher, staleEntries);
+		if (isNonEmptyArray(publishedEntryIds)) {
+			await deps.repos.workflowRunOutbox.markRepublished(publishedEntryIds);
+		}
 	}
-}
-
-async function republishRuns(
-	context: DaemonContext,
-	workflowRunPublisher: Publisher,
-	entries: NonEmptyArray<WorkflowRunOutboxRow>
-): Promise<void> {
-	const runs = entries.map((entry) => ({
-		namespaceId: entry.namespaceId,
-		id: entry.workflowRunId,
-		name: entry.workflowName,
-		versionId: entry.workflowVersionId,
-		rank: entry.rank,
-		shard: entry.shard ?? undefined,
-	})) as NonEmptyArray<ReadyWorkflowRun>;
-
-	await workflowRunPublisher.publishReadyRuns(runs);
-	context.logger.debug("Published ready workflow runs", { count: runs.length });
 }

--- a/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
@@ -14,6 +14,8 @@ import { workflowRunOutbox } from "../schema";
 
 export type WorkflowRunOutboxRow = typeof workflowRunOutbox.$inferSelect;
 export type WorkflowRunOutboxRowInsert = typeof workflowRunOutbox.$inferInsert;
+export type WorkflowRunOutboxRowInsertPending = WorkflowRunOutboxRowInsert & { status: "pending" };
+export type WorkflowRunOutboxRowPending = WorkflowRunOutboxRow & { status: "pending" };
 export type WorkflowRunOutboxRowPublished = WorkflowRunOutboxRow & { status: "published"; publishedAt: TimestampMs };
 export type WorkflowRunOutboxRowClaimed = WorkflowRunOutboxRow & { status: "claimed"; claimedAt: TimestampMs };
 
@@ -52,8 +54,8 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 			_context: DaemonContext,
 			limit: number,
 			cursor?: RankStreamCursor
-		): Promise<WorkflowRunOutboxRow[]> {
-			return db
+		): Promise<WorkflowRunOutboxRowPending[]> {
+			const rows = await db
 				.select()
 				.from(workflowRunOutbox)
 				.where(
@@ -64,6 +66,8 @@ export function createWorkflowRunOutboxRepository(db: PgDb) {
 				)
 				.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
 				.limit(limit);
+
+			return rows as WorkflowRunOutboxRowPending[];
 		},
 
 		async markPublished(ids: NonEmptyArray<string>): Promise<void> {

--- a/sdk/server/src/infra/db/types/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/types/workflow-run-outbox.ts
@@ -3,5 +3,7 @@ export type {
 	WorkflowRunOutboxRow,
 	WorkflowRunOutboxRowClaimed,
 	WorkflowRunOutboxRowInsert,
+	WorkflowRunOutboxRowInsertPending,
+	WorkflowRunOutboxRowPending,
 	WorkflowRunOutboxRowPublished,
 } from "../pg/repository/workflow-run-outbox";

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -45,7 +45,7 @@ export function createRuntime(params: CreateRuntimeParams) {
 
 interface RuntimeHandleDeps {
 	logger: Logger;
-	daemons: { shutdown: () => Promise<void> };
+	daemons: { stop: () => Promise<void> };
 	gracefulShutdownTimeoutMs: number;
 }
 
@@ -54,7 +54,7 @@ function createRuntimeHandle(deps: RuntimeHandleDeps): ServerRuntimeHandle {
 	let stopPromise: Promise<void> | undefined;
 
 	const _stop = async (): Promise<void> => {
-		const daemonShutdownPromise = deps.daemons.shutdown();
+		const daemonShutdownPromise = deps.daemons.stop();
 
 		if (deps.gracefulShutdownTimeoutMs <= 0) {
 			await daemonShutdownPromise;

--- a/types/src/infra/queue/publisher.ts
+++ b/types/src/infra/queue/publisher.ts
@@ -10,8 +10,19 @@ export interface ReadyWorkflowRun {
 	shard?: string;
 }
 
+export interface PublishResult {
+	/** Delivered. */
+	published: ReadyWorkflowRun[];
+	/** Deliverable, but withheld by policy (admission, fairness, throttling). */
+	deferred: ReadyWorkflowRun[];
+	/** Could not be delivered, or delivery is uncertain. */
+	failed: ReadyWorkflowRun[];
+	/** Not handled. */
+	declined: ReadyWorkflowRun[];
+}
+
 export interface Publisher {
-	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void>;
+	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishResult>;
 }
 
 export interface PublisherContext {

--- a/types/src/infra/timer.ts
+++ b/types/src/infra/timer.ts
@@ -28,8 +28,10 @@ export interface TimerSignalWaiter {
 	close(): Promise<void>;
 }
 
+export type TimerAddResult = { status: "added" } | { status: "failed" };
+
 export interface TimerPriorityQueue {
-	add(timers: NonEmptyArray<TimerEntry>): Promise<void>;
+	add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult>;
 	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
 	peekNextRank(): Promise<number | null>;
 	createSignalWaiter(): TimerSignalWaiter;


### PR DESCRIPTION
## Background

The bundled server app creates one ioredis client and hands it to three pluggable adapters: a cache, the workflow-run publisher, and the timer priority queue. The publisher delivers ready runs onto per-workflow Redis sorted sets, where workers claim them. The timer priority queue is a Redis sorted set plus a signal list; it gives timers precision higher than the one second db scan interval. Delivery is tracked in the outbox, a db table with one row per run: a row is pending until delivered, marked published after, and a daemon republishes rows that go stale. `runtime.start()` spins up the db scanning daemons and the due-timers consumer (a blocking loop that pops due timers over its own duplicated connection because BRPOP ties up the connection it runs on).

## Problem

When Redis went down, several things broke at once:

- ioredis does not fail commands while it is disconnected. It parks them in an internal offline queue and only rejects them when the reconnect budget runs out. A daemon stuck awaiting a parked command cannot see its abort signal, so Ctrl+C hung until the graceful-shutdown timeout. The shutdown handler made this worse by calling `quit()`, which goes through the same offline queue.
- The publisher pipelined one ZADD per queue and awaited `exec()` without checking its result. `exec()` never rejects when commands fail; it resolves with an `[error, result]` tuple per command. A publish that delivered nothing looked exactly like one that succeeded, so every outbox entry was marked published — including entries whose runs never reached a queue. Workers would not see those runs until the republish daemon caught them 90 seconds later. The republish path ignored `exec()` failures the same way.
- The due timers consumer blocked on a parked sorted-set insert, breaking the design contract that timer precision degrades to at most the db scan interval when Redis is down.
- The app logged every connection error event: one per reconnect attempt.

One more failure surfaced during testing. A connect can be accepted by something dead — for example, Docker still forwarding a stopped container's port — and then never answer. ioredis's `connectTimeout` only covers the TCP connect; nothing times out the handshake that follows. The client gets stuck waiting for an answer that never comes, and emits no events at all. The adapter already protects the connections it creates itself with an internal supervisor built for exactly this. The shared client had no such protection.

One constraint shaped the fixes: the publisher and timer queue receive the user's client, and the offline-queue behavior is constructor configuration. The adapter cannot reconfigure the connection it is given and has to work with it as-is.

## Solution

**Transports report what actually happened instead of claiming success.**

```ts
// before
interface Publisher {
	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<void>;
}

// after
interface PublishResult {
	published: ReadyWorkflowRun[]; // delivered
	deferred: ReadyWorkflowRun[];  // deliverable but withheld by policy
	failed: ReadyWorkflowRun[];    // could not deliver or delivery uncertain
	declined: ReadyWorkflowRun[];  // not handled
}
interface Publisher {
	publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishResult>;
}

// and the timer queue's insert
type TimerAddResult = { status: "added" } | { status: "failed" };
```

If the adapter cannot tell whether a command was delivered — the connection died mid-flight, or the pipeline returned no result for it — it puts the affected runs in the `failed` bucket. Their outbox entries stay pending, and the publish is retried on a later tick. Publishing the same run twice is safe; putting an uncertain one in `published` would hide the run from workers until the republish daemon catches it (90 seconds later).

The Redis publisher itself only ever uses `published` and `failed`. The other two buckets are reserved for planned publisher composition: a routing publisher will `decline` runs that belong to a different transport (for example, runs delivered to HTTP endpoints instead of Redis), and a rate-limiting wrapper will `defer` runs it holds back for later. `failed` stays separate from `deferred` so a fallback transport can someday retry failures without also grabbing runs that a rate limit deliberately held back.

**The Redis adapter fails fast instead of parking.** The adapter never sends a command on a connection it knows is down. To know, each adapter watches its connection with two event listeners: `close` means it dropped, `ready` means it is back. The stuck connect from the Problem section emits neither, so there is one fallback rule: if the connection has not reported `ready` within its own connect timeout, treat it as down.

While the connection is down:

- the publisher puts every run in the `failed` bucket without sending anything;
- the timer insert returns `failed`;
- the consumer's reads throw, which triggers the consumer's abort-aware retry backoff — waiting and retrying is the only thing it can do anyway.

Even when the connection is up, individual commands can still fail, so the publisher checks every pipeline result and splits per queue: runs whose ZADD succeeded go in the `published` bucket, the rest in `failed`, with the first error logged. Reporting a bad command as `failed` instead of throwing keeps the damage local: a poisoned queue key (say, a WRONGTYPE collision) blocks only its own runs instead of failing every batch it appears in.

**Outbox bookkeeping follows the result.** An entry is marked published only when its run was actually delivered. The republish daemon follows the same rule: it releases a stale claim, or refreshes a stale published row, only when the redelivery succeeded — an entry that fails to republish stays stale and is retried on the next tick instead of waiting out another 90-second window. The scanning daemons treat a failed timer insert as expected: they log at debug, keep their one-second cadence, and let the due-now db scan pick the timers up. Timer precision degrades to at most one db scan interval during an outage, because the daemons never stall.

**Connection supervision and logging live in the app, which owns the client.** The handshake supervisor — the watchdog that forces a reconnect when a connect is accepted but `ready` never arrives — is now exported, and the app attaches it to the shared client. The app's connection logging is rewritten as a small state machine so each fact logs once: one "lost" line the moment the connection drops, one error line with the cause per down period, one "restored" line on recovery. "Lost" comes from the `close` event; a clean disconnect never emits `error`, so logging only on errors would report the drop late or never.

Shutdown now disconnects the client before stopping the runtime. A manual disconnect makes ioredis reject everything parked in its offline queue, so any daemon still awaiting a command unblocks and sees its abort. The supervisor is detached first, so its watchdog cannot schedule a reconnect during shutdown.

Two smaller fixes are included. Outbox entry types now carry the pending status in the type, so passing non-pending entries to the pending publish path fails to compile. And daemon logs put error values under the `err` key — pino only serializes errors under that key; an error under any other key logs as `{}`.

## Breaking changes

`Publisher.publishReadyRuns` returns `Promise<PublishResult>` instead of `Promise<void>`, and `TimerPriorityQueue.add` returns `Promise<TimerAddResult>` instead of `Promise<void>`. Both are pluggable contracts, so external implementations must adopt the new shapes.