### PR TITLE
Skip schema validation microtask when no schema is defined

### DIFF
--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -129,7 +129,8 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		handle[INTERNAL].assertExecutionAllowed();
 
 		const inputRaw = args[0];
-		const input = await this.parse(handle, this.params.schema?.input, inputRaw, run.logger);
+		const inputSchema = this.params.schema?.input;
+		const input = inputSchema ? await this.parse(handle, inputSchema, inputRaw, run.logger) : (inputRaw as Input);
 		const inputHash = await hashInput(input);
 		const address = getTaskAddress(this.name, inputHash) as TaskAddress;
 
@@ -190,7 +191,10 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		const existingTaskState = existingTaskInfo.state;
 
 		if (existingTaskState.status === "completed") {
-			return this.parse(handle, this.params.schema?.output, existingTaskState.output, run.logger);
+			const outputSchema = this.params.schema?.output;
+			return outputSchema
+				? this.parse(handle, outputSchema, existingTaskState.output, run.logger)
+				: (existingTaskState.output as Output);
 		}
 
 		if (existingTaskState.status === "failed") {
@@ -300,7 +304,8 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		while (true) {
 			try {
 				const outputRaw = await this.params.handler(input);
-				const output = await this.parse(handle, this.params.schema?.output, outputRaw, logger);
+				const outputSchema = this.params.schema?.output;
+				const output = outputSchema ? await this.parse(handle, outputSchema, outputRaw, logger) : (outputRaw as Output);
 				return { output, lastAttempt: attempts };
 			} catch (err) {
 				if (
@@ -366,14 +371,10 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 
 	private async parse<T>(
 		handle: UnknownWorkflowRunHandle,
-		schema: StandardSchemaV1<T> | undefined,
+		schema: StandardSchemaV1<T>,
 		data: unknown,
 		logger: Logger
 	): Promise<T> {
-		if (!schema) {
-			return data as T;
-		}
-
 		const schemaValidation = schema["~standard"].validate(data);
 		const schemaValidationResult = schemaValidation instanceof Promise ? await schemaValidation : schemaValidation;
 		if (!schemaValidationResult.issues) {

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -165,7 +165,8 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		const { client } = parentRunHandle[INTERNAL];
 
 		const inputRaw = args[0];
-		const input = await this.parse(parentRunHandle, this.params.schema?.input, inputRaw, parentRun.logger);
+		const inputSchema = this.params.schema?.input;
+		const input = inputSchema ? await this.parse(parentRunHandle, inputSchema, inputRaw, parentRun.logger) : inputRaw;
 		const inputHash = await hashInput(input);
 
 		const referenceId = startOptions.reference?.id;
@@ -176,8 +177,9 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			const existingRunInfo = replayManifest.consumeNextChildWorkflowRun(address);
 			if (existingRunInfo) {
 				const { run: existingRun } = await client.api.workflowRun.getByIdV1({ id: existingRunInfo.id });
-				if (existingRun.state.status === "completed") {
-					await this.parse(parentRunHandle, this.params.schema?.output, existingRun.state.output, parentRun.logger);
+				const outputSchema = this.params.schema?.output;
+				if (existingRun.state.status === "completed" && outputSchema) {
+					await this.parse(parentRunHandle, outputSchema, existingRun.state.output, parentRun.logger);
 				}
 
 				const logger = parentRun.logger.child({
@@ -305,7 +307,10 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		while (true) {
 			try {
 				const outputRaw = await this.params.handler(run, input);
-				const output = await this.parse(handle, this.params.schema?.output, outputRaw, run.logger);
+				const outputSchema = this.params.schema?.output;
+				const output = outputSchema
+					? await this.parse(handle, outputSchema, outputRaw, run.logger)
+					: (outputRaw as Output);
 				return output;
 			} catch (err) {
 				if (
@@ -357,14 +362,10 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 
 	private async parse<T>(
 		handle: WorkflowRunHandle<unknown, unknown, unknown, EventsDefinition>,
-		schema: StandardSchemaV1<T> | undefined,
+		schema: StandardSchemaV1<T>,
 		data: unknown,
 		logger: Logger
 	): Promise<T> {
-		if (!schema) {
-			return data as T;
-		}
-
 		const schemaValidation = schema["~standard"].validate(data);
 		const schemaValidationResult = schemaValidation instanceof Promise ? await schemaValidation : schemaValidation;
 		if (!schemaValidationResult.issues) {


### PR DESCRIPTION
## Problem

Workflow versions and tasks accept an optional `schema` field for validating inputs and outputs via Standard Schema. When no schema is provided, the `parse` method was still called — and because it's `async`, every call created a microtask just to hit the `if (!schema) return data` early-return path. Most users don't define schemas, so this overhead applied to the common case on every workflow execution and task start.

## Solution

Guard schema validation at each call site: only call `parse` when a schema is actually defined. The `parse` method's `schema` parameter is now non-optional, and the `if (!schema)` early return is removed. Call sites extract the schema first and ternary between `await this.parse(...)` and a synchronous cast.

This applies to both `WorkflowVersionImpl` (workflow input/output validation) and `TaskImpl` (task input/output validation), covering all six call sites across the two files.