### PR TITLE
SDK testing foundation: fake client and data factories

### DIFF
--- a/app/dashboard/Dockerfile
+++ b/app/dashboard/Dockerfile
@@ -18,6 +18,7 @@ COPY cli/package.json ./cli/
 COPY app/server/package.json ./app/server/
 COPY app/dashboard/package.json ./app/dashboard/
 COPY examples/package.json ./examples/
+COPY testing/package.json ./testing/
 
 RUN bun install --frozen-lockfile
 

--- a/app/server/Dockerfile
+++ b/app/server/Dockerfile
@@ -18,6 +18,7 @@ COPY cli/package.json ./cli/
 COPY app/server/package.json ./app/server/
 COPY app/dashboard/package.json ./app/dashboard/
 COPY examples/package.json ./examples/
+COPY testing/package.json ./testing/
 
 RUN bun install --frozen-lockfile
 

--- a/bun.lock
+++ b/bun.lock
@@ -228,6 +228,15 @@
       },
       "devDependencies": {
         "@aikirun/lib": "workspace:*",
+        "@aikirun/testing": "workspace:*",
+      },
+    },
+    "testing": {
+      "name": "@aikirun/testing",
+      "version": "0.30.0",
+      "dependencies": {
+        "@aikirun/types": "workspace:*",
+        "fishery": "^2.4.0",
       },
     },
     "types": {
@@ -265,6 +274,8 @@
     "@aikirun/redis": ["@aikirun/redis@workspace:sdk/adapter/redis"],
 
     "@aikirun/server": ["@aikirun/server@workspace:sdk/server"],
+
+    "@aikirun/testing": ["@aikirun/testing@workspace:testing"],
 
     "@aikirun/types": ["@aikirun/types@workspace:types"],
 
@@ -550,15 +561,15 @@
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
-    "arkregex": ["arkregex@0.0.5", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw=="],
+    "arkregex": ["arkregex@0.0.6", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-9mvuMKQuibfWhBrsNYhsKhNb6k9oEHoAJ/FvDiqe8h+E9Siwe0/cro1WVOGgpajXQ9ZHd24yCOf2k35Q/QqUQw=="],
 
-    "arktype": ["arktype@2.2.0", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.5" } }, "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ=="],
+    "arktype": ["arktype@2.2.1", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.6" } }, "sha512-CWPJxNoSxrS+NYGB3ufwc/blFonESEW5vBQyYPVS0rf4STu8VWoAWfKJSl5vVVm56h4yxpwbODeYwy6XFKvojA=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.37", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
 
     "better-auth": ["better-auth@1.6.11", "", { "dependencies": { "@better-auth/core": "1.6.11", "@better-auth/drizzle-adapter": "1.6.11", "@better-auth/kysely-adapter": "1.6.11", "@better-auth/memory-adapter": "1.6.11", "@better-auth/mongo-adapter": "1.6.11", "@better-auth/prisma-adapter": "1.6.11", "@better-auth/telemetry": "1.6.11", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ=="],
 
@@ -626,7 +637,7 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.374", "", {}, "sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.375", "", {}, "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -653,6 +664,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fishery": ["fishery@2.4.0", "", { "dependencies": { "lodash.mergewith": "^4.6.2" } }, "sha512-QgeTlvgNhVGuMztrfAhlSIBs3rD3l9RMjl9I15yb/lnrx3njrOhvegr2L3LWdqvXwYfQjdQGpglyAfHH2J8DRA=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
@@ -718,6 +731,8 @@
 
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
+    "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
+
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
@@ -746,7 +761,7 @@
 
     "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
 
-    "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
+    "node-releases": ["node-releases@2.0.48", "", {}, "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 

--- a/lib/src/async/delay.test.ts
+++ b/lib/src/async/delay.test.ts
@@ -2,11 +2,17 @@ import { delay } from "./delay";
 import { describe, expect, test } from "bun:test";
 
 describe("delay", () => {
-	test("resolves after the specified duration", async () => {
-		const start = performance.now();
-		await delay(50);
-		const elapsed = performance.now() - start;
-		expect(elapsed).toBeGreaterThanOrEqual(50);
+	test("does not resolve synchronously and resolves after the timer fires", async () => {
+		let resolved = false;
+		const promise = delay(10).then(() => {
+			resolved = true;
+		});
+
+		// Resolution is deferred to the timer — nothing has run on this synchronous tick yet.
+		expect(resolved).toBe(false);
+
+		await promise;
+		expect(resolved).toBe(true);
 	});
 
 	test("rejects immediately when abort signal is already aborted", async () => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"sdk/server",
 		"sdk/worker",
 		"sdk/workflow",
+		"testing",
 		"types"
 	],
 	"scripts": {

--- a/sdk/workflow/package.json
+++ b/sdk/workflow/package.json
@@ -22,7 +22,8 @@
 		"@standard-schema/spec": "^1.1.0"
 	},
 	"devDependencies": {
-		"@aikirun/lib": "workspace:*"
+		"@aikirun/lib": "workspace:*",
+		"@aikirun/testing": "workspace:*"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/sdk/workflow/src/run/replay-manifest.test.ts
+++ b/sdk/workflow/src/run/replay-manifest.test.ts
@@ -1,0 +1,275 @@
+import { childWorkflowRunInfoFactory, runningWorkflowRunRecordFactory } from "@aikirun/testing/workflow/run";
+import { completedTaskInfoFactory } from "@aikirun/testing/workflow/task";
+import type { WorkflowRunAddress } from "@aikirun/types/workflow/run";
+import type { TaskAddress } from "@aikirun/types/workflow/task";
+
+import { createReplayManifest } from "./replay-manifest";
+import { describe, expect, test } from "bun:test";
+
+const taskAddressA = "task-addr-a" as TaskAddress;
+const taskAddressB = "task-addr-b" as TaskAddress;
+const childRunAddressA = "child-addr-a" as WorkflowRunAddress;
+const childRunAddressB = "child-addr-b" as WorkflowRunAddress;
+
+describe("createReplayManifest", () => {
+	describe("consumeNextTask", () => {
+		test("returns the tasks for an address in order", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: {
+						[taskAddressA]: {
+							tasks: [completedTaskInfoFactory.build({ id: "t1" }), completedTaskInfoFactory.build({ id: "t2" })],
+						},
+					},
+				})
+			);
+
+			expect(manifest.consumeNextTask(taskAddressA)?.id).toBe("t1");
+			expect(manifest.consumeNextTask(taskAddressA)?.id).toBe("t2");
+		});
+
+		test("returns the complete task info", () => {
+			const task = completedTaskInfoFactory.build({ id: "t1" });
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({ taskQueues: { [taskAddressA]: { tasks: [task] } } })
+			);
+
+			expect(manifest.consumeNextTask(taskAddressA)).toEqual(task);
+		});
+
+		test("returns undefined once an address is exhausted", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: { [taskAddressA]: { tasks: [completedTaskInfoFactory.build()] } },
+				})
+			);
+
+			manifest.consumeNextTask(taskAddressA);
+			expect(manifest.consumeNextTask(taskAddressA)).toBeUndefined();
+		});
+
+		test("returns undefined for an unknown address", () => {
+			const manifest = createReplayManifest(runningWorkflowRunRecordFactory.build());
+
+			expect(manifest.consumeNextTask(taskAddressA)).toBeUndefined();
+		});
+
+		test("tracks a separate cursor per address", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: {
+						[taskAddressA]: {
+							tasks: [completedTaskInfoFactory.build({ id: "a1" }), completedTaskInfoFactory.build({ id: "a2" })],
+						},
+						[taskAddressB]: { tasks: [completedTaskInfoFactory.build({ id: "b1" })] },
+					},
+				})
+			);
+
+			expect(manifest.consumeNextTask(taskAddressA)?.id).toBe("a1");
+			expect(manifest.consumeNextTask(taskAddressB)?.id).toBe("b1");
+			expect(manifest.consumeNextTask(taskAddressA)?.id).toBe("a2");
+			expect(manifest.consumeNextTask(taskAddressB)).toBeUndefined();
+		});
+	});
+
+	describe("consumeNextChildWorkflowRun", () => {
+		test("returns the child runs for an address in order", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: {
+						[childRunAddressA]: {
+							childWorkflowRuns: [
+								childWorkflowRunInfoFactory.build({ id: "c1" }),
+								childWorkflowRunInfoFactory.build({ id: "c2" }),
+							],
+						},
+					},
+				})
+			);
+
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)?.id).toBe("c1");
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)?.id).toBe("c2");
+		});
+
+		test("returns the complete child run info", () => {
+			const childRun = childWorkflowRunInfoFactory.build({ id: "c1" });
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: { [childRunAddressA]: { childWorkflowRuns: [childRun] } },
+				})
+			);
+
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)).toEqual(childRun);
+		});
+
+		test("returns undefined once an address is exhausted", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: { [childRunAddressA]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build()] } },
+				})
+			);
+
+			manifest.consumeNextChildWorkflowRun(childRunAddressA);
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)).toBeUndefined();
+		});
+
+		test("returns undefined for an unknown address", () => {
+			const manifest = createReplayManifest(runningWorkflowRunRecordFactory.build());
+
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)).toBeUndefined();
+		});
+
+		test("tracks a separate cursor per address", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: {
+						[childRunAddressA]: {
+							childWorkflowRuns: [
+								childWorkflowRunInfoFactory.build({ id: "a1" }),
+								childWorkflowRunInfoFactory.build({ id: "a2" }),
+							],
+						},
+						[childRunAddressB]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build({ id: "b1" })] },
+					},
+				})
+			);
+
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)?.id).toBe("a1");
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressB)?.id).toBe("b1");
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressA)?.id).toBe("a2");
+			expect(manifest.consumeNextChildWorkflowRun(childRunAddressB)).toBeUndefined();
+		});
+	});
+
+	describe("hasUnconsumedEntries", () => {
+		test("is false for an empty manifest", () => {
+			const manifest = createReplayManifest(runningWorkflowRunRecordFactory.build());
+
+			expect(manifest.hasUnconsumedEntries()).toBe(false);
+		});
+
+		test("is true while tasks remain and false once consumed", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: { [taskAddressA]: { tasks: [completedTaskInfoFactory.build()] } },
+				})
+			);
+
+			expect(manifest.hasUnconsumedEntries()).toBe(true);
+			manifest.consumeNextTask(taskAddressA);
+			expect(manifest.hasUnconsumedEntries()).toBe(false);
+		});
+
+		test("is true while child runs remain and false once consumed", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: { [childRunAddressA]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build()] } },
+				})
+			);
+
+			expect(manifest.hasUnconsumedEntries()).toBe(true);
+			manifest.consumeNextChildWorkflowRun(childRunAddressA);
+			expect(manifest.hasUnconsumedEntries()).toBe(false);
+		});
+
+		test("stays true until both tasks and child runs are consumed", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: { [taskAddressA]: { tasks: [completedTaskInfoFactory.build()] } },
+					childWorkflowRunQueues: { [childRunAddressA]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build()] } },
+				})
+			);
+
+			expect(manifest.hasUnconsumedEntries()).toBe(true);
+			manifest.consumeNextTask(taskAddressA);
+			expect(manifest.hasUnconsumedEntries()).toBe(true);
+			manifest.consumeNextChildWorkflowRun(childRunAddressA);
+			expect(manifest.hasUnconsumedEntries()).toBe(false);
+		});
+	});
+
+	describe("getUnconsumedEntries", () => {
+		test("lists all task and child run ids initially", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: {
+						[taskAddressA]: {
+							tasks: [completedTaskInfoFactory.build({ id: "t1" }), completedTaskInfoFactory.build({ id: "t2" })],
+						},
+						[taskAddressB]: { tasks: [completedTaskInfoFactory.build({ id: "t3" })] },
+					},
+					childWorkflowRunQueues: {
+						[childRunAddressA]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build({ id: "c1" })] },
+					},
+				})
+			);
+
+			expect(manifest.getUnconsumedEntries()).toEqual({
+				taskIds: ["t1", "t2", "t3"],
+				childWorkflowRunIds: ["c1"],
+			});
+		});
+
+		test("omits consumed tasks across addresses", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: {
+						[taskAddressA]: {
+							tasks: [completedTaskInfoFactory.build({ id: "t1" }), completedTaskInfoFactory.build({ id: "t2" })],
+						},
+						[taskAddressB]: { tasks: [completedTaskInfoFactory.build({ id: "t3" })] },
+					},
+				})
+			);
+
+			manifest.consumeNextTask(taskAddressA);
+
+			expect(manifest.getUnconsumedEntries()).toEqual({
+				taskIds: ["t2", "t3"],
+				childWorkflowRunIds: [],
+			});
+		});
+
+		test("omits consumed child runs", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					childWorkflowRunQueues: {
+						[childRunAddressA]: {
+							childWorkflowRuns: [
+								childWorkflowRunInfoFactory.build({ id: "c1" }),
+								childWorkflowRunInfoFactory.build({ id: "c2" }),
+							],
+						},
+					},
+				})
+			);
+
+			manifest.consumeNextChildWorkflowRun(childRunAddressA);
+
+			expect(manifest.getUnconsumedEntries()).toEqual({
+				taskIds: [],
+				childWorkflowRunIds: ["c2"],
+			});
+		});
+
+		test("is empty after full consumption", () => {
+			const manifest = createReplayManifest(
+				runningWorkflowRunRecordFactory.build({
+					taskQueues: { [taskAddressA]: { tasks: [completedTaskInfoFactory.build({ id: "t1" })] } },
+					childWorkflowRunQueues: {
+						[childRunAddressA]: { childWorkflowRuns: [childWorkflowRunInfoFactory.build({ id: "c1" })] },
+					},
+				})
+			);
+
+			manifest.consumeNextTask(taskAddressA);
+			manifest.consumeNextChildWorkflowRun(childRunAddressA);
+
+			expect(manifest.getUnconsumedEntries()).toEqual({
+				taskIds: [],
+				childWorkflowRunIds: [],
+			});
+		});
+	});
+});

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -1,0 +1,141 @@
+import {
+	cronScheduleActivateRequestFactory,
+	intervalScheduleActivateRequestFactory,
+} from "@aikirun/testing/api/schedule";
+import { fakeClient } from "@aikirun/testing/client";
+import { cronScheduleFactory, intervalScheduleFactory } from "@aikirun/testing/schedule";
+import type { ScheduleId } from "@aikirun/types/schedule";
+
+import { schedule } from "./schedule";
+import { workflow } from "./workflow";
+import { describe, expect, test } from "bun:test";
+
+const syncInventoryWorkflow = workflow({ name: "sync-inventory" }).v<{ warehouseId: string }>("1.0.0", {
+	handler: async () => {},
+});
+
+const intervalScheduleActivateRequest = intervalScheduleActivateRequestFactory.params({
+	workflowName: syncInventoryWorkflow.name,
+	workflowVersionId: syncInventoryWorkflow.versionId,
+	input: { warehouseId: "wh-1" },
+});
+const cronScheduleActivateRequest = cronScheduleActivateRequestFactory.params({
+	workflowName: syncInventoryWorkflow.name,
+	workflowVersionId: syncInventoryWorkflow.versionId,
+	input: { warehouseId: "wh-1" },
+});
+
+describe("schedule", () => {
+	describe("activate", () => {
+		test("maps the interval to everyMs and carries the overlap policy", async () => {
+			using client = fakeClient();
+			client.api.schedule.activateV1.once(
+				intervalScheduleActivateRequest.build({
+					spec: { type: "interval", overlapPolicy: "cancel_previous", everyMs: 5_000 },
+				}),
+				{ schedule: intervalScheduleFactory.build() }
+			);
+
+			await schedule({ type: "interval", every: { seconds: 5 }, overlapPolicy: "cancel_previous" }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+		});
+
+		test("passes a cron spec through unchanged", async () => {
+			using client = fakeClient();
+			client.api.schedule.activateV1.once(
+				cronScheduleActivateRequest.build({
+					spec: { type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" },
+				}),
+				{ schedule: cronScheduleFactory.build() }
+			);
+
+			await schedule({ type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+		});
+
+		test("returns a handle carrying the activated schedule id", async () => {
+			using client = fakeClient();
+			const activatedSchedule = intervalScheduleFactory.build();
+
+			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+
+			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+
+			expect(handle.id).toBe(activatedSchedule.id as ScheduleId);
+		});
+	});
+
+	describe("with builder", () => {
+		test("opt sets the options sent to activate", async () => {
+			using client = fakeClient();
+			client.api.schedule.activateV1.once(
+				intervalScheduleActivateRequest.build({
+					options: { reference: { id: "ref-1" } },
+				}),
+				{ schedule: intervalScheduleFactory.build() }
+			);
+
+			await schedule({ type: "interval", every: { seconds: 1 } })
+				.with()
+				.opt("reference.id", "ref-1")
+				.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
+		});
+	});
+
+	describe("handle operations", () => {
+		test("pause calls pauseV1 with the schedule id", async () => {
+			using client = fakeClient();
+			const activatedSchedule = intervalScheduleFactory.build();
+
+			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+			client.api.schedule.pauseV1.once({ id: activatedSchedule.id });
+
+			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+			await handle.pause();
+		});
+
+		test("resume calls resumeV1 with the schedule id", async () => {
+			using client = fakeClient();
+			const activatedSchedule = intervalScheduleFactory.build();
+
+			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+			client.api.schedule.resumeV1.once({ id: activatedSchedule.id });
+
+			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+			await handle.resume();
+		});
+
+		test("delete calls deleteV1 with the schedule id", async () => {
+			using client = fakeClient();
+			const activatedSchedule = intervalScheduleFactory.build();
+
+			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+			client.api.schedule.deleteV1.once({ id: activatedSchedule.id });
+
+			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+				client,
+				syncInventoryWorkflow,
+				{ warehouseId: "wh-1" }
+			);
+			await handle.delete();
+		});
+	});
+});

--- a/testing/package.json
+++ b/testing/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@aikirun/testing",
+	"version": "0.30.0",
+	"private": true,
+	"description": "Testing utilities for Aiki - a fake client and fishery data factories for testing SDK code (in-repo; not yet published)",
+	"type": "module",
+	"exports": {
+		"./api/schedule": "./src/api/schedule.ts",
+		"./client": "./src/client.ts",
+		"./schedule": "./src/schedule.ts",
+		"./workflow/task": "./src/workflow/task.ts",
+		"./workflow/run": "./src/workflow/run.ts"
+	},
+	"dependencies": {
+		"@aikirun/types": "workspace:*",
+		"fishery": "^2.4.0"
+	},
+	"license": "Apache-2.0"
+}

--- a/testing/src/api/schedule.ts
+++ b/testing/src/api/schedule.ts
@@ -1,0 +1,21 @@
+import type { ScheduleActivateRequestV1 } from "@aikirun/types/api/schedule";
+import type { CronScheduleSpec, IntervalScheduleSpec } from "@aikirun/types/schedule";
+import { Factory } from "fishery";
+
+export const intervalScheduleActivateRequestFactory = Factory.define<
+	ScheduleActivateRequestV1 & { spec: IntervalScheduleSpec }
+>(() => ({
+	workflowName: "workflow",
+	workflowVersionId: "1.0.0",
+	options: {},
+	spec: { type: "interval", everyMs: 1_000 },
+}));
+
+export const cronScheduleActivateRequestFactory = Factory.define<
+	ScheduleActivateRequestV1 & { spec: CronScheduleSpec }
+>(() => ({
+	workflowName: "workflow",
+	workflowVersionId: "1.0.0",
+	options: {},
+	spec: { type: "cron", expression: "* * * * *" },
+}));

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -1,0 +1,148 @@
+import { createConsoleLogger } from "@aikirun/lib/logger";
+import type { ApiClient, Client } from "@aikirun/types/client";
+import { INTERNAL } from "@aikirun/types/symbols";
+
+import { expect, type Mock, mock } from "bun:test";
+
+type MockEndpoint<Args extends unknown[], Return> = Mock<(...args: Args) => Return> & {
+	/**
+	 * Queues a single expected call: the next call to this endpoint asserts its request
+	 * `toEqual`s `request` and resolves with `response`. Each `once` covers exactly one call;
+	 * queue several to expect several calls, matched in order.
+	 *
+	 * The match is EXACT by default — every field must be accounted for. For a partial match,
+	 * pass an asymmetric matcher, e.g. `expect.objectContaining({ ... })` or `expect.anything()`.
+	 *
+	 * A queued `once` that is never called fails `verify()`.
+	 * A call with no queued expectation throws.
+	 *
+	 * The `response` argument is omitted for endpoints that resolve to `void`.
+	 */
+	once(
+		request: Args[0],
+		...response: Awaited<Return> extends void ? [] : [response: Awaited<Return>]
+	): MockEndpoint<Args, Return>;
+};
+
+/** Every API method becomes a `MockEndpoint` of its own signature. */
+type MockApi<T> = {
+	[K in keyof T]: T[K] extends (...args: infer Args) => infer Return ? MockEndpoint<Args, Return> : MockApi<T[K]>;
+};
+
+export interface FakeClient<Context = null> extends Client<Context>, Disposable {
+	api: MockApi<ApiClient>;
+	/**
+	 * Throws if any call queued via `once` was never made. Runs automatically on scope exit
+	 * when the client is declared with `using` (via `[Symbol.dispose]`).
+	 */
+	verify(): void;
+}
+
+interface QueuedCall {
+	request: unknown;
+	response: unknown;
+}
+
+interface RegisteredEndpoint {
+	name: string;
+	queuedCalls: QueuedCall[];
+}
+
+/**
+ * A `Client` whose every API endpoint is an auto-created mock augmented with `once`.
+ * Queue the calls a test expects; any call with no queued expectation throws.
+ *
+ * Declare it with `using` so `verify()` runs automatically on scope exit:
+ *
+ * @example
+ * test("activates a schedule", async () => {
+ *   using client = fakeClient();
+ *   client.api.schedule.activateV1.once({ spec: mySpec }, { schedule: intervalScheduleFactory.build() });
+ *   await schedule(myParams).activate(client, myWorkflow, input);
+ * });
+ */
+export function fakeClient<Context = null>(): FakeClient<Context> {
+	const endpoints: RegisteredEndpoint[] = [];
+
+	const createEndpoint = (endpointName: string): unknown => {
+		const queuedCalls: QueuedCall[] = [];
+		endpoints.push({ name: endpointName, queuedCalls });
+
+		const handler = async (actual: unknown) => {
+			const call = queuedCalls.shift();
+			if (call === undefined) {
+				throw new Error(`Fake client: unexpected call to ${endpointName}(${Bun.inspect(actual)})`);
+			}
+			expect(actual).toEqual(call.request);
+			return call.response;
+		};
+		const endpoint = mock(handler) as Mock<typeof handler> & {
+			once: (request: unknown, response?: unknown) => unknown;
+		};
+
+		endpoint.once = (request, response) => {
+			queuedCalls.push({ request, response });
+			return endpoint;
+		};
+
+		return endpoint;
+	};
+
+	const createSubApi = (subApiName: string): unknown => {
+		const subApiEndpoints = new Map<string, unknown>();
+
+		return new Proxy(
+			{},
+			{
+				get(_target, endpointName) {
+					if (typeof endpointName === "symbol") {
+						return undefined;
+					}
+					const existingEndpoint = subApiEndpoints.get(endpointName);
+					if (existingEndpoint !== undefined) {
+						return existingEndpoint;
+					}
+					const createdEndpoint = createEndpoint(`${subApiName}.${endpointName}`);
+					subApiEndpoints.set(endpointName, createdEndpoint);
+					return createdEndpoint;
+				},
+			}
+		);
+	};
+
+	const subApis = new Map<string, unknown>();
+	const api = new Proxy(
+		{},
+		{
+			get(_target, subApiName) {
+				if (typeof subApiName === "symbol") {
+					return undefined;
+				}
+				const existingSubApi = subApis.get(subApiName);
+				if (existingSubApi !== undefined) {
+					return existingSubApi;
+				}
+				const createdSubApi = createSubApi(subApiName);
+				subApis.set(subApiName, createdSubApi);
+				return createdSubApi;
+			},
+		}
+	) as MockApi<ApiClient>;
+
+	const verify = () => {
+		const unconsumed = endpoints
+			.filter((endpoint) => endpoint.queuedCalls.length > 0)
+			.flatMap((endpoint) => endpoint.queuedCalls.map((call) => `${endpoint.name}(${Bun.inspect(call.request)})`));
+		if (unconsumed.length > 0) {
+			throw new Error(`Fake client: expected calls were never made: ${unconsumed.join(", ")}`);
+		}
+	};
+
+	return {
+		api,
+		logger: createConsoleLogger({ level: "DEBUG" }),
+		[INTERNAL]: {},
+		verify,
+		[Symbol.dispose]: verify,
+	};
+}

--- a/testing/src/schedule.ts
+++ b/testing/src/schedule.ts
@@ -1,0 +1,24 @@
+import type { CronScheduleSpec, IntervalScheduleSpec, Schedule } from "@aikirun/types/schedule";
+import { Factory } from "fishery";
+
+export const intervalScheduleFactory = Factory.define<Schedule & { spec: IntervalScheduleSpec }>(({ sequence }) => ({
+	id: `schedule-${sequence}`,
+	workflowName: "workflow",
+	workflowVersionId: "1.0.0",
+	status: "active",
+	spec: { type: "interval", everyMs: 1_000 },
+	createdAt: 0,
+	updatedAt: 0,
+	nextRunAt: 0,
+}));
+
+export const cronScheduleFactory = Factory.define<Schedule & { spec: CronScheduleSpec }>(({ sequence }) => ({
+	id: `schedule-${sequence}`,
+	workflowName: "workflow",
+	workflowVersionId: "1.0.0",
+	status: "active",
+	spec: { type: "cron", expression: "* * * * *" },
+	createdAt: 0,
+	updatedAt: 0,
+	nextRunAt: 0,
+}));

--- a/testing/src/workflow/run.ts
+++ b/testing/src/workflow/run.ts
@@ -1,0 +1,32 @@
+import type { ChildWorkflowRunInfo, WorkflowRunRecord, WorkflowRunStateRunning } from "@aikirun/types/workflow/run";
+import { Factory } from "fishery";
+
+export const childWorkflowRunInfoFactory = Factory.define<ChildWorkflowRunInfo>(({ sequence }) => ({
+	id: `child-run-${sequence}`,
+	name: "child-run",
+	versionId: "1.0.0",
+	inputHash: "hash",
+	childWorkflowRunWaitQueues: {
+		cancelled: { childWorkflowRunWaits: [] },
+		completed: { childWorkflowRunWaits: [] },
+		failed: { childWorkflowRunWaits: [] },
+	},
+}));
+
+export const runningWorkflowRunRecordFactory = Factory.define<WorkflowRunRecord & { state: WorkflowRunStateRunning }>(
+	({ sequence }) => ({
+		id: `run-${sequence}`,
+		name: "workflow",
+		versionId: "1.0.0",
+		createdAt: 0,
+		revision: 0,
+		stateTransitionId: "transition",
+		inputHash: "hash",
+		attempts: 1,
+		state: { status: "running" },
+		taskQueues: {},
+		sleepQueues: {},
+		eventWaitQueues: {},
+		childWorkflowRunQueues: {},
+	})
+);

--- a/testing/src/workflow/task.ts
+++ b/testing/src/workflow/task.ts
@@ -1,0 +1,11 @@
+import type { TaskInfo, TaskStateCompleted } from "@aikirun/types/workflow/task";
+import { Factory } from "fishery";
+
+export const completedTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateCompleted<unknown> }>(
+	({ sequence }) => ({
+		id: `task-${sequence}`,
+		name: "task",
+		inputHash: "hash",
+		state: { status: "completed", attempts: 1, output: undefined },
+	})
+);

--- a/testing/tsconfig.json
+++ b/testing/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../tsconfig.json",
+	"include": ["./src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 			"@aikirun/redis": ["./sdk/adapter/redis/src/index.ts"],
 			"@aikirun/server": ["./sdk/server/src/index.ts"],
 			"@aikirun/server/*": ["./sdk/server/src/*.ts", "./sdk/server/src/*/index.ts"],
+			"@aikirun/testing/*": ["./testing/src/*.ts", "./testing/src/*/index.ts"],
 			"@aikirun/types/*": ["./types/src/*.ts", "./types/src/*/index.ts"],
 			"@aikirun/worker": ["./sdk/worker/src/index.ts"],
 			"@aikirun/workflow": ["./sdk/workflow/src/index.ts"]
@@ -34,6 +35,15 @@
 
 		"types": ["bun-types", "@types/node"]
 	},
-	"include": ["lib/**/*", "types/**/*", "sdk/**/*", "app/server/**/*", "cli/**/*", "examples/**/*", "scripts/**/*"],
+	"include": [
+		"lib/**/*",
+		"types/**/*",
+		"sdk/**/*",
+		"testing/**/*",
+		"app/server/**/*",
+		"cli/**/*",
+		"examples/**/*",
+		"scripts/**/*"
+	],
 	"exclude": ["node_modules", "**/dist"]
 }


### PR DESCRIPTION
## Motivation

Aiki's deployable units — server, workers, endpoints — reach the backend through a **client**: a typed connection whose methods are the API endpoints. SDK surface code (starting and scheduling workflows, controlling runs) touches the backend only through that client.

Only `@aikirun/lib` had tests. The SDK packages — workflow, worker, server, client — had none. Unit-testing SDK surface code without a running backend needs two things that didn't exist:

- a stand-in for the client that lets a test say "for this request, return this response" and fails if an expected call never happens;
- a way to build valid domain objects (workflow run records, task info, schedules) without assembling every field by hand.

## Solution

A private `@aikirun/testing` package providing both, plus the first tests that use them.

**Fake client.** `fakeClient()` returns a real `Client` whose every endpoint is a mock. A test queues the calls it expects:

```ts
test("activates a schedule", async () => {
  using client = fakeClient();
  client.api.schedule.activateV1.once(activateRequest, { schedule });

  const handle = await schedule({ type: "interval", every: { seconds: 5 } })
    .activate(client, syncInventory, { warehouseId: "wh-1" });

  expect(handle.id).toBe(schedule.id);
});
```

- `once(request, response)` queues one expected call: the next call to that endpoint asserts its argument `toEqual`s `request` (exact by default — pass `expect.objectContaining`/`expect.anything()` for a partial match) and resolves with `response`. Queue several to expect several calls, matched in order.
- It is strict — a call with no queued expectation throws.
- The client is `Disposable`, so declaring it with `using` runs verification on scope exit: a queued call that was never made fails the test. Both the unexpected-call throw and the verification name the offending request, so a failure points at the specific call.

Coupling request and response in one place, and checking that every queued call happened, is the model request/response interaction libraries like nock use. A fresh client per test keeps tests isolated and safe to run in parallel.

**Data factories.** Typed builders (using fishery) for the core domain objects, mirroring the types package tree, so a test writes `runningWorkflowRunRecordFactory.build({ ...overrides })` instead of hand-assembling a record. A discriminated-union field — a schedule's interval-vs-cron spec, a run's state — gets one factory per variant, each narrowed to its variant, so overriding toward the wrong variant is a compile error rather than a silently malformed object.

**First tests.** Schedule operations (interval/cron spec mapping, builder options, handle pause/resume/delete) and the workflow run replay manifest — the cursor that feeds a run's recorded task and child-run results back to a re-executing handler.

**Packaging.** The package is consumed as source in-repo: its exports point at TypeScript source, `tsc` resolves it through path mappings, and bun runs the source directly in tests. It is not built, because nothing built or published consumes it — only test files, which run as source. Both Dockerfiles copy its `package.json` so the frozen-lockfile install resolves it as a workspace member during the image build.

Also de-flakes a lib timing test: delay's test asserted a wall-clock lower bound on a setTimeout, which fails when the timer fires a hair early relative to performance.now(). It now asserts delay's actual contract — resolution is deferred, not synchronous — with no wall-clock dependence.

## Test plan

- `bun test` — the full suite, including the new schedule and replay-manifest tests.