### PR TITLE
Config provider exposes a snapshot, not path reads

### DIFF
--- a/sdk/server/src/config/provider.ts
+++ b/sdk/server/src/config/provider.ts
@@ -1,5 +1,4 @@
 import { delay, fireAndForget } from "@aikirun/lib/async";
-import { getByPath } from "@aikirun/lib/object";
 import { withRetry } from "@aikirun/lib/retry";
 import type { CreateConfigProvider } from "@aikirun/types/infra/config";
 
@@ -10,14 +9,9 @@ import { parseServerConfig, type ServerConfig, type ServerConfigOverrides } from
  * Pass `overrides` to change any setting; omit them for the defaults.
  */
 export function staticConfigProvider(overrides?: ServerConfigOverrides): CreateConfigProvider<ServerConfig> {
-	return () => {
-		const config = parseServerConfig(overrides ?? {});
-		return {
-			get(path) {
-				return getByPath(config, path);
-			},
-		};
-	};
+	return () => ({
+		config: parseServerConfig(overrides ?? {}),
+	});
 }
 
 /**
@@ -70,8 +64,8 @@ export function dynamicConfigProvider(params: {
 		});
 
 		return {
-			get(path) {
-				return getByPath(config, path);
+			get config() {
+				return config;
 			},
 			stop() {
 				abortController.abort();

--- a/sdk/server/src/daemons/due-timers-consumer.ts
+++ b/sdk/server/src/daemons/due-timers-consumer.ts
@@ -90,7 +90,7 @@ async function dueTimersConsumerLoop(
 	while (!abortSignal.aborted) {
 		await withRetry(
 			async () => {
-				const { limit, overshootMs } = deps.configProvider.get("daemons.dueTimersConsumer");
+				const { limit, overshootMs } = deps.configProvider.config.daemons.dueTimersConsumer;
 				let signal = 0;
 
 				if (nextTimerDueAtMs === null) {

--- a/sdk/server/src/daemons/index.ts
+++ b/sdk/server/src/daemons/index.ts
@@ -1,6 +1,5 @@
 import { delay } from "@aikirun/lib/async";
 import type { Logger } from "@aikirun/lib/logger";
-import type { PathFromObject, TypeOfValueAtPath } from "@aikirun/lib/object";
 import { withRetry } from "@aikirun/lib/retry";
 import type { ConfigProvider } from "@aikirun/types/infra/config";
 import type { Publisher } from "@aikirun/types/infra/queue";
@@ -30,18 +29,11 @@ export interface InitDaemonsDeps {
 	childRunCanceller: ChildRunCanceller;
 }
 
-type DaemonConfigPath<Path extends string> = Path extends `daemons.${infer SubPath}`
-	? SubPath extends `${string}.${string}`
-		? never
-		: Path
-	: never;
-type PollingDaemonConfigPath = Exclude<DaemonConfigPath<PathFromObject<ServerConfig>>, "daemons.dueTimersConsumer">;
-
-function initDaemon<Deps, ConfigPath extends PollingDaemonConfigPath>(
+function initDaemon<Deps, DaemonOptions>(
 	logger: Logger,
 	configProvider: ConfigProvider<ServerConfig>,
-	configPath: ConfigPath,
-	fn: (context: DaemonContext, deps: Deps, options: TypeOfValueAtPath<ServerConfig, ConfigPath>) => Promise<void>,
+	getDaemonConfig: (config: ServerConfig) => DaemonOptions & { intervalMs: number },
+	fn: (context: DaemonContext, deps: Deps, options: DaemonOptions) => Promise<void>,
 	deps: Deps
 ) {
 	const name = fn.name;
@@ -54,11 +46,11 @@ function initDaemon<Deps, ConfigPath extends PollingDaemonConfigPath>(
 			const start = performance.now();
 			await withRetry(
 				async () => {
-					const config = configProvider.get(configPath);
-					await fn(context, deps, config);
+					const daemonConfig = getDaemonConfig(configProvider.config);
+					await fn(context, deps, daemonConfig);
 					const durationMs = Math.round(performance.now() - start);
 					context.logger.debug("Completed", { durationMs });
-					const delayMs = config.intervalMs - durationMs;
+					const delayMs = daemonConfig.intervalMs - durationMs;
 					if (delayMs > 0) {
 						await delay(delayMs, { abortSignal: signal });
 					}
@@ -84,27 +76,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 	const { configProvider } = deps;
 
 	const daemons = [
-		initDaemon(logger, configProvider, "daemons.imminentScheduledRuns", processImminentScheduledRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
-		initDaemon(logger, configProvider, "daemons.imminentSleepElapsedRuns", processImminentSleepElapsedRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
-		initDaemon(logger, configProvider, "daemons.imminentRetryableRuns", processImminentRetryableRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
-		initDaemon(logger, configProvider, "daemons.imminentRetryableTaskRuns", processImminentRetryableTaskRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
-		initDaemon(logger, configProvider, "daemons.imminentEventWaitTimedOutRuns", processImminentEventWaitTimedOutRuns, {
+		initDaemon(logger, configProvider, (config) => config.daemons.imminentScheduledRuns, processImminentScheduledRuns, {
 			repos: deps.repos,
 			workflowRunPublisher: deps.workflowRunPublisher,
 			timerPriorityQueue: deps.timerPriorityQueue,
@@ -112,7 +84,45 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 		initDaemon(
 			logger,
 			configProvider,
-			"daemons.imminentChildRunWaitTimedOutRuns",
+			(config) => config.daemons.imminentSleepElapsedRuns,
+			processImminentSleepElapsedRuns,
+			{
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
+		initDaemon(logger, configProvider, (config) => config.daemons.imminentRetryableRuns, processImminentRetryableRuns, {
+			repos: deps.repos,
+			workflowRunPublisher: deps.workflowRunPublisher,
+			timerPriorityQueue: deps.timerPriorityQueue,
+		}),
+		initDaemon(
+			logger,
+			configProvider,
+			(config) => config.daemons.imminentRetryableTaskRuns,
+			processImminentRetryableTaskRuns,
+			{
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
+		initDaemon(
+			logger,
+			configProvider,
+			(config) => config.daemons.imminentEventWaitTimedOutRuns,
+			processImminentEventWaitTimedOutRuns,
+			{
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
+		initDaemon(
+			logger,
+			configProvider,
+			(config) => config.daemons.imminentChildRunWaitTimedOutRuns,
 			processImminentChildRunWaitTimedOutRuns,
 			{
 				repos: deps.repos,
@@ -120,21 +130,27 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 				timerPriorityQueue: deps.timerPriorityQueue,
 			}
 		),
-		initDaemon(logger, configProvider, "daemons.imminentRecurringWorkflows", processImminentRecurringWorkflows, {
-			repos: deps.repos,
-			childRunCanceller: deps.childRunCanceller,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
+		initDaemon(
+			logger,
+			configProvider,
+			(config) => config.daemons.imminentRecurringWorkflows,
+			processImminentRecurringWorkflows,
+			{
+				repos: deps.repos,
+				childRunCanceller: deps.childRunCanceller,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
 	];
 
 	if (deps.workflowRunPublisher) {
 		daemons.push(
-			initDaemon(logger, configProvider, "daemons.publishReadyRuns", publishReadyRuns, {
+			initDaemon(logger, configProvider, (config) => config.daemons.publishReadyRuns, publishReadyRuns, {
 				repos: deps.repos,
 				workflowRunPublisher: deps.workflowRunPublisher,
 			}),
-			initDaemon(logger, configProvider, "daemons.republishStaleRuns", republishStaleRuns, {
+			initDaemon(logger, configProvider, (config) => config.daemons.republishStaleRuns, republishStaleRuns, {
 				repos: deps.repos,
 				workflowRunPublisher: deps.workflowRunPublisher,
 			})

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -57,7 +57,7 @@ function createRuntimeHandle({ configProvider, daemonsHandle, logger }: RuntimeH
 	let stopPromise: Promise<void> | undefined;
 
 	const _stop = async (): Promise<void> => {
-		const gracefulShutdownTimeoutMs = configProvider.get("gracefulShutdownTimeoutMs");
+		const gracefulShutdownTimeoutMs = configProvider.config.gracefulShutdownTimeoutMs;
 		const daemonShutdownPromise = daemonsHandle.stop();
 
 		if (gracefulShutdownTimeoutMs <= 0) {

--- a/types/src/infra/config.ts
+++ b/types/src/infra/config.ts
@@ -1,8 +1,7 @@
 import type { Logger } from "@aikirun/lib/logger";
-import type { PathFromObject, TypeOfValueAtPath } from "@aikirun/lib/object";
 
-export interface ConfigProvider<Config extends object> {
-	get<Path extends PathFromObject<Config>>(path: Path): TypeOfValueAtPath<Config, Path>;
+export interface ConfigProvider<Config> {
+	readonly config: Config;
 	stop?(): void;
 }
 
@@ -10,6 +9,6 @@ export interface ConfigProviderContext {
 	logger: Logger;
 }
 
-export type CreateConfigProvider<Config extends object> = (
+export type CreateConfigProvider<Config> = (
 	context: ConfigProviderContext
 ) => ConfigProvider<Config> | Promise<ConfigProvider<Config>>;


### PR DESCRIPTION
## Problem

`ConfigProvider` is the contract an embedding application implements to tune the server's runtime configuration. On `main` it exposes a single typed dot-path read:

```typescript
interface ConfigProvider<Config extends object> {
  get<Path extends PathFromObject<Config>>(path: Path): TypeOfValueAtPath<Config, Path>;
  stop?(): void;
}
```

`PathFromObject` and `TypeOfValueAtPath` give per-key type safety but make the contract awkward on both sides. A custom provider can't return the conditional `TypeOfValueAtPath` type without casting back to it. Callers have to thread dot-path strings, and the path union is clumsy to index with.

## Solution

The contract returns the whole config snapshot. Consumers read the fields they need with ordinary typed property access.

```typescript
interface ConfigProvider<Config> {
  readonly config: Config;
  stop?(): void;
}
```

So `get("daemons.dueTimersConsumer")` becomes `config.daemons.dueTimersConsumer` — full inference, normal narrowing, no path strings or conditional types. The `Config extends object` constraint is gone; it existed only for the path types.

The per-tick daemon loop follows the same shift. It takes a selector into its config bundle, like `(config) => config.daemons.imminentScheduledRuns`, instead of a path string.

## Breaking changes

`ConfigProvider.get(path)` is replaced by `config` in `@aikirun/types`, so custom implementations and direct `.get(...)` callers break. The `staticConfigProvider` and `dynamicConfigProvider` exports are unchanged.