### PR TITLE
Runtime teardown via a single abort signal

### DIFF
--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -21,18 +21,20 @@ if (import.meta.main) {
 
 	const aiki = server({
 		db,
-		cache,
 		logger,
-		iam:
-			config.auth && config.baseURL
-				? iam({
-						db,
-						cache,
-						secret: config.auth.secret,
-						baseURL: config.baseURL,
-						trustedOrigins: config.corsOrigins,
-					})
-				: undefined,
+		handler: {
+			cache,
+			iam:
+				config.auth && config.baseURL
+					? iam({
+							db,
+							cache,
+							secret: config.auth.secret,
+							baseURL: config.baseURL,
+							trustedOrigins: config.corsOrigins,
+						})
+					: undefined,
+		},
 		runtime: {
 			...(redis && {
 				publisher: redisPublisher(redis.client),

--- a/sdk/server/src/config/provider.ts
+++ b/sdk/server/src/config/provider.ts
@@ -24,10 +24,8 @@ export function dynamicConfigProvider(params: {
 	refreshIntervalMs: number;
 	refresh: (current: ServerConfig) => ServerConfig | Promise<ServerConfig>;
 }): CreateConfigProvider<ServerConfig> {
-	return async ({ logger }) => {
+	return async ({ logger, signal }) => {
 		let config = parseServerConfig({});
-		const abortController = new AbortController();
-		const { signal } = abortController;
 
 		const refreshConfig = async (): Promise<void> => {
 			const response = params.refresh(config);
@@ -66,9 +64,6 @@ export function dynamicConfigProvider(params: {
 		return {
 			get config() {
 				return config;
-			},
-			stop() {
-				abortController.abort();
 			},
 		};
 	};

--- a/sdk/server/src/daemons/due-timers-consumer.ts
+++ b/sdk/server/src/daemons/due-timers-consumer.ts
@@ -26,6 +26,7 @@ import { scheduleRowToDomain } from "../service/schedule";
 
 export interface DueTimersConsumerDeps {
 	repos: Repositories;
+	signal: AbortSignal;
 	timerPriorityQueue: TimerPriorityQueue;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunPublisher?: Publisher;
@@ -37,16 +38,12 @@ export interface DueTimersConsumerHandle {
 }
 
 export function spawnDueTimersConsumer(logger: Logger, deps: DueTimersConsumerDeps): DueTimersConsumerHandle {
-	const abortController = new AbortController();
-	const { signal } = abortController;
-
 	const timerSignalWaiter = deps.timerPriorityQueue.createSignalWaiter();
 
-	const promise = dueTimersConsumerLoop(logger, deps, timerSignalWaiter, signal);
+	const promise = dueTimersConsumerLoop(logger, deps, timerSignalWaiter, deps.signal);
 
 	return {
 		async stop() {
-			abortController.abort();
 			await timerSignalWaiter.close();
 			await promise;
 		},

--- a/sdk/server/src/daemons/index.ts
+++ b/sdk/server/src/daemons/index.ts
@@ -23,6 +23,7 @@ import type { ChildRunCanceller } from "../service/cancel-child-runs";
 
 export interface InitDaemonsDeps {
 	repos: Repositories;
+	signal: AbortSignal;
 	configProvider: ConfigProvider<ServerConfig>;
 	workflowRunPublisher?: Publisher;
 	timerPriorityQueue?: TimerPriorityQueue;
@@ -31,14 +32,13 @@ export interface InitDaemonsDeps {
 
 function initDaemon<Deps, DaemonOptions>(
 	logger: Logger,
+	signal: AbortSignal,
 	configProvider: ConfigProvider<ServerConfig>,
 	getDaemonConfig: (config: ServerConfig) => DaemonOptions & { intervalMs: number },
 	fn: (context: DaemonContext, deps: Deps, options: DaemonOptions) => Promise<void>,
 	deps: Deps
 ) {
 	const name = fn.name;
-	const abortController = new AbortController();
-	const { signal } = abortController;
 
 	const promise = (async () => {
 		while (!signal.aborted) {
@@ -69,20 +69,28 @@ function initDaemon<Deps, DaemonOptions>(
 		}
 	})();
 
-	return { abortController, promise };
+	return { promise };
 }
 
 export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
-	const { configProvider } = deps;
+	const { configProvider, signal } = deps;
 
 	const daemons = [
-		initDaemon(logger, configProvider, (config) => config.daemons.imminentScheduledRuns, processImminentScheduledRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
 		initDaemon(
 			logger,
+			signal,
+			configProvider,
+			(config) => config.daemons.imminentScheduledRuns,
+			processImminentScheduledRuns,
+			{
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
+		initDaemon(
+			logger,
+			signal,
 			configProvider,
 			(config) => config.daemons.imminentSleepElapsedRuns,
 			processImminentSleepElapsedRuns,
@@ -92,13 +100,21 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 				timerPriorityQueue: deps.timerPriorityQueue,
 			}
 		),
-		initDaemon(logger, configProvider, (config) => config.daemons.imminentRetryableRuns, processImminentRetryableRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
-		}),
 		initDaemon(
 			logger,
+			signal,
+			configProvider,
+			(config) => config.daemons.imminentRetryableRuns,
+			processImminentRetryableRuns,
+			{
+				repos: deps.repos,
+				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue: deps.timerPriorityQueue,
+			}
+		),
+		initDaemon(
+			logger,
+			signal,
 			configProvider,
 			(config) => config.daemons.imminentRetryableTaskRuns,
 			processImminentRetryableTaskRuns,
@@ -110,6 +126,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 		),
 		initDaemon(
 			logger,
+			signal,
 			configProvider,
 			(config) => config.daemons.imminentEventWaitTimedOutRuns,
 			processImminentEventWaitTimedOutRuns,
@@ -121,6 +138,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 		),
 		initDaemon(
 			logger,
+			signal,
 			configProvider,
 			(config) => config.daemons.imminentChildRunWaitTimedOutRuns,
 			processImminentChildRunWaitTimedOutRuns,
@@ -132,6 +150,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 		),
 		initDaemon(
 			logger,
+			signal,
 			configProvider,
 			(config) => config.daemons.imminentRecurringWorkflows,
 			processImminentRecurringWorkflows,
@@ -146,11 +165,11 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 
 	if (deps.workflowRunPublisher) {
 		daemons.push(
-			initDaemon(logger, configProvider, (config) => config.daemons.publishReadyRuns, publishReadyRuns, {
+			initDaemon(logger, signal, configProvider, (config) => config.daemons.publishReadyRuns, publishReadyRuns, {
 				repos: deps.repos,
 				workflowRunPublisher: deps.workflowRunPublisher,
 			}),
-			initDaemon(logger, configProvider, (config) => config.daemons.republishStaleRuns, republishStaleRuns, {
+			initDaemon(logger, signal, configProvider, (config) => config.daemons.republishStaleRuns, republishStaleRuns, {
 				repos: deps.repos,
 				workflowRunPublisher: deps.workflowRunPublisher,
 			})
@@ -161,6 +180,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 	if (deps.timerPriorityQueue) {
 		dueTimersConsumer = spawnDueTimersConsumer(logger, {
 			repos: deps.repos,
+			signal,
 			timerPriorityQueue: deps.timerPriorityQueue,
 			childRunCanceller: deps.childRunCanceller,
 			workflowRunPublisher: deps.workflowRunPublisher,
@@ -170,12 +190,7 @@ export function initDaemons(logger: Logger, deps: InitDaemonsDeps) {
 
 	return {
 		async stop() {
-			const daemonPromises: Promise<unknown>[] = [];
-			for (const { abortController, promise } of daemons) {
-				abortController.abort();
-				daemonPromises.push(promise);
-			}
-			await Promise.all(daemonPromises);
+			await Promise.all(daemons.map((daemon) => daemon.promise));
 			await dueTimersConsumer?.stop();
 		},
 	};

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -23,25 +23,32 @@ export function createRuntime(params: CreateRuntimeParams) {
 			const repos = await createRepos(params.db);
 			const childRunCanceller = createChildRunCanceller();
 
+			const abortController = new AbortController();
+			const { signal } = abortController;
+
 			const createConfigProvider = params.runtime?.config ?? staticConfigProvider();
 			const maybeConfigProvider = createConfigProvider({
 				logger: logger.child({ "aiki.component": "config-provider" }),
+				signal,
 			});
 			const configProvider = maybeConfigProvider instanceof Promise ? await maybeConfigProvider : maybeConfigProvider;
 
 			const daemonsHandle = initDaemons(logger, {
 				repos,
 				configProvider,
+				signal,
 				workflowRunPublisher: params.runtime?.publisher?.({
 					logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
+					signal,
 				}),
 				timerPriorityQueue: params.runtime?.timerPriorityQueue?.({
 					logger: logger.child({ "aiki.component": "timer-sorted-set" }),
+					signal,
 				}),
 				childRunCanceller,
 			});
 
-			return createRuntimeHandle({ logger, daemonsHandle, configProvider });
+			return createRuntimeHandle({ logger, daemonsHandle, configProvider, abortController });
 		},
 	};
 }
@@ -50,14 +57,23 @@ interface RuntimeHandleDeps {
 	logger: Logger;
 	daemonsHandle: { stop: () => Promise<void> };
 	configProvider: ConfigProvider<ServerConfig>;
+	abortController: AbortController;
 }
 
-function createRuntimeHandle({ configProvider, daemonsHandle, logger }: RuntimeHandleDeps): ServerRuntimeHandle {
+function createRuntimeHandle({
+	configProvider,
+	daemonsHandle,
+	logger,
+	abortController,
+}: RuntimeHandleDeps): ServerRuntimeHandle {
 	const id = ulid() as ServerRuntimeId;
 	let stopPromise: Promise<void> | undefined;
 
 	const _stop = async (): Promise<void> => {
 		const gracefulShutdownTimeoutMs = configProvider.config.gracefulShutdownTimeoutMs;
+
+		abortController.abort();
+
 		const daemonShutdownPromise = daemonsHandle.stop();
 
 		if (gracefulShutdownTimeoutMs <= 0) {
@@ -74,8 +90,6 @@ function createRuntimeHandle({ configProvider, daemonsHandle, logger }: RuntimeH
 				});
 			}
 		}
-
-		configProvider.stop?.();
 	};
 
 	return {

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -8,6 +8,11 @@ import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 
 import type { ServerConfig } from "./config";
 
+export interface ServerHandlerParams {
+	iam?: Iam;
+	cache?: CreateCache;
+}
+
 export interface ServerRuntimeParams {
 	publisher?: CreatePublisher;
 	timerPriorityQueue?: CreateTimerPriorityQueue;
@@ -16,9 +21,8 @@ export interface ServerRuntimeParams {
 
 export interface ServerParams {
 	db: CreateDatabase;
-	iam?: Iam;
-	cache?: CreateCache;
 	logger?: Logger;
+	handler?: ServerHandlerParams;
 	runtime?: ServerRuntimeParams;
 }
 
@@ -35,7 +39,7 @@ export interface Server {
 }
 
 export function server(params: ServerParams): Server {
-	const logger: Logger = params.logger ?? createConsoleLogger();
+	const logger = params.logger ?? createConsoleLogger();
 
 	let handler: Server["handler"] | undefined;
 	let createHandlerPromise: Promise<Server["handler"]> | undefined;
@@ -47,7 +51,7 @@ export function server(params: ServerParams): Server {
 				createHandlerPromise ??= (async () => {
 					const db = await params.db();
 					const { createHandler } = await import("./handler");
-					return createHandler({ db, logger, iam: params.iam, cache: params.cache });
+					return createHandler({ db, logger, iam: params.handler?.iam, cache: params.handler?.cache });
 				})();
 				handler = await createHandlerPromise;
 				return handler(request);

--- a/types/src/infra/config.ts
+++ b/types/src/infra/config.ts
@@ -2,11 +2,11 @@ import type { Logger } from "@aikirun/lib/logger";
 
 export interface ConfigProvider<Config> {
 	readonly config: Config;
-	stop?(): void;
 }
 
 export interface ConfigProviderContext {
 	logger: Logger;
+	signal: AbortSignal;
 }
 
 export type CreateConfigProvider<Config> = (

--- a/types/src/infra/queue/publisher.ts
+++ b/types/src/infra/queue/publisher.ts
@@ -27,6 +27,7 @@ export interface Publisher {
 
 export interface PublisherContext {
 	logger: Logger;
+	signal: AbortSignal;
 }
 
 export type CreatePublisher = (context: PublisherContext) => Publisher;

--- a/types/src/infra/timer.ts
+++ b/types/src/infra/timer.ts
@@ -39,6 +39,7 @@ export interface TimerPriorityQueue {
 
 export interface TimerPriorityQueueContext {
 	logger: Logger;
+	signal: AbortSignal;
 }
 
 export type CreateTimerPriorityQueue = (context: TimerPriorityQueueContext) => TimerPriorityQueue;


### PR DESCRIPTION
## Problem

The server splits into a handler (a request/response function, no shutdown) and a runtime (background work, started and stopped through a handle). Both take pluggable factories — config provider, publisher, and timer queue on the runtime side; IAM and cache on the handler side.

Teardown was ad-hoc. The config provider made its own `AbortController` and exposed a `stop()` the runtime called; the daemons and the due-timers consumer each made their own; everything else had none. The only contract-level hook was `ConfigProvider.stop?()`. And `ServerParams` listed `iam` and `cache` at the top level, with nothing marking which pluggables belong to which half.

## Solution

Teardown is now one `AbortSignal` carried in every runtime-side context. A pluggable cleans up when it aborts. `ConfigProvider.stop?()` is gone.

```ts
// before
interface ConfigProvider<Config> {
  readonly config: Config;
  stop?(): void;
}
interface ConfigProviderContext { logger: Logger; }

// after
interface ConfigProvider<Config> {
  readonly config: Config;
}
interface ConfigProviderContext { logger: Logger; signal: AbortSignal; }
```

The publisher and timer-queue contexts gain the same `signal`.

The runtime owns one `AbortController`. It threads the signal into those contexts and into the daemons and the due-timers consumer, and `runtime.stop()` aborts it once, then waits for the daemons to drain within the graceful timeout. The daemons and consumer no longer own controllers — their `stop()` just waits for the loop to finish.

So there's one teardown convention — the web-standard `AbortSignal` — instead of a method per contract. The SDK only aborts at the right moment; each implementation decides how it cleans up. This is a runtime concept by design: the handler is a function with no shutdown, so its pluggables get no signal — there's no moment to fire it.

`ServerParams` now splits by half, which lines up with the signal boundary — runtime-side contexts carry it, handler-side don't. `db` and `logger` stay shared at the top.

```ts
// before
interface ServerParams {
  db: CreateDatabase;
  iam?: Iam;
  cache?: CreateCache;
  logger?: Logger;
  runtime?: ServerRuntimeParams;
}

// after
interface ServerParams {
  db: CreateDatabase;
  logger?: Logger;
  handler?: { iam?: Iam; cache?: CreateCache };
  runtime?: ServerRuntimeParams;
}
```

## Breaking changes

- `ConfigProvider.stop?()` removed; the runtime no longer calls it. Cleanup moves to the context `signal`.
- `iam` / `cache` moved under `ServerParams.handler`.