### PR TITLE
Synchronous server start and worker spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ const databaseUrl = process.env.DATABASE_URL ?? "postgresql://user:password@loca
 
 // Server and worker, both running in this process
 const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) });
-const runtimeHandle = await aikiServer.runtime.start();
+const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
-const workerHandle = await worker({ workflows: [trialV1] }).spawn(aikiClient);
+const workerHandle = worker({ workflows: [trialV1] }).spawn(aikiClient);
 
 // Start the workflow
 const handle = await trialV1.start(aikiClient, { userId: "user-123" });

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -43,7 +43,7 @@ if (import.meta.main) {
 		},
 	});
 
-	const runtimeHandle = await aiki.runtime.start();
+	const runtimeHandle = aiki.runtime.start();
 
 	const { createCorsResponse, withCorsHeaders } = createCorsHelpers(config.corsOrigins);
 

--- a/docs/architecture/server.md
+++ b/docs/architecture/server.md
@@ -60,7 +60,7 @@ const aikiServer = server({
   db: database({ provider: "pg", url: databaseUrl }),
 });
 
-const runtimeHandle = await aikiServer.runtime.start();
+const runtimeHandle = aikiServer.runtime.start();
 ```
 
 Optional pieces plug in the same way — `cache`, `iam` (multi-tenancy and auth), and the Redis-backed runtime adapters:

--- a/docs/core-concepts/workers.md
+++ b/docs/core-concepts/workers.md
@@ -21,7 +21,7 @@ const aikiWorker = worker({
   },
 });
 
-const handle = await aikiWorker.spawn(aikiClient);
+const handle = aikiWorker.spawn(aikiClient);
 ```
 
 Worker definitions are static and reusable. The `worker()` function creates a definition with a `workflows` array specifying which workflow versions it can execute. Call `spawn(client)` to begin execution; it returns a handle for controlling the running worker.
@@ -44,8 +44,8 @@ Workers scale naturally. You can add capacity in several ways:
 const worker1 = worker({ workflows: [orderWorkflowV1] });
 const worker2 = worker({ workflows: [orderWorkflowV1] });
 
-const handle1 = await worker1.spawn(aikiClient);
-const handle2 = await worker2.spawn(aikiClient);
+const handle1 = worker1.spawn(aikiClient);
+const handle2 = worker2.spawn(aikiClient);
 ```
 
 **Specialize workers** by registering different workflows on different workers. Each worker only handles the workflows it knows about.

--- a/docs/getting-started/first-workflow.md
+++ b/docs/getting-started/first-workflow.md
@@ -165,14 +165,14 @@ import { worker } from "@aikirun/worker";
 const databaseUrl = process.env.DATABASE_URL ?? "postgresql://user:password@localhost:5432/aiki";
 
 const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) });
-const runtimeHandle = await aikiServer.runtime.start();
+const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
 
 const aikiWorker = worker({
 	workflows: [restaurantOrderV1, courierDeliveryV1],
 });
-const workerHandle = await aikiWorker.spawn(aikiClient);
+const workerHandle = aikiWorker.spawn(aikiClient);
 
 // Graceful shutdown
 process.on("SIGINT", async () => {

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -46,10 +46,10 @@ const databaseUrl = process.env.DATABASE_URL ?? "postgresql://user:password@loca
 
 // Server and worker, both running in this process
 const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) });
-const runtimeHandle = await aikiServer.runtime.start();
+const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
-const workerHandle = await worker({ workflows: [trialV1] }).spawn(aikiClient);
+const workerHandle = worker({ workflows: [trialV1] }).spawn(aikiClient);
 
 // Start the workflow
 const handle = await trialV1.start(aikiClient, { userId: "user-123" });

--- a/examples/src/runner.ts
+++ b/examples/src/runner.ts
@@ -53,8 +53,8 @@ export async function runWithWorker(
 		config: { maxConcurrentWorkflowRuns: 10 },
 	});
 
-	const handleA = await workerA.spawn(aikiClient);
-	const handleB = await workerB.spawn(aikiClient);
+	const handleA = workerA.spawn(aikiClient);
+	const handleB = workerB.spawn(aikiClient);
 
 	const shutdown = async (exitCode: number) => {
 		await Promise.all([handleA.stop(), handleB.stop()]);
@@ -89,7 +89,7 @@ async function setup(): Promise<Setup> {
 			db: database(readDatabaseEnv()),
 			runtime: { publisher: queue.publisher, timerPriorityQueue },
 		});
-		const runtimeHandle = await aiki.runtime.start();
+		const runtimeHandle = aiki.runtime.start();
 
 		return {
 			client: client({ handler: aiki.handler }),

--- a/sdk/server/src/daemons/index.ts
+++ b/sdk/server/src/daemons/index.ts
@@ -75,74 +75,75 @@ function pollingDaemon(
 	};
 }
 
-export function spawnDaemons(logger: Logger, deps: SpawnDaemonsDeps) {
-	const { configProvider, signal } = deps;
+export async function spawnDaemons(logger: Logger, deps: SpawnDaemonsDeps): Promise<void> {
+	const { repos, signal, configProvider, workflowRunPublisher, timerPriorityQueue, childRunCanceller } = deps;
+
 	const { spawn: spawnPollingDaemon } = pollingDaemon(logger, signal, configProvider.scope("daemons"));
 
 	const daemonPromises: Promise<void>[] = [
 		spawnPollingDaemon((config) => config.imminentScheduledRuns, processImminentScheduledRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentSleepElapsedRuns, processImminentSleepElapsedRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentRetryableRuns, processImminentRetryableRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentRetryableTaskRuns, processImminentRetryableTaskRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentEventWaitTimedOutRuns, processImminentEventWaitTimedOutRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentChildRunWaitTimedOutRuns, processImminentChildRunWaitTimedOutRuns, {
-			repos: deps.repos,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 		spawnPollingDaemon((config) => config.imminentRecurringWorkflows, processImminentRecurringWorkflows, {
-			repos: deps.repos,
-			childRunCanceller: deps.childRunCanceller,
-			workflowRunPublisher: deps.workflowRunPublisher,
-			timerPriorityQueue: deps.timerPriorityQueue,
+			repos,
+			childRunCanceller,
+			workflowRunPublisher,
+			timerPriorityQueue,
 		}),
 	];
 
-	if (deps.workflowRunPublisher) {
+	if (workflowRunPublisher) {
 		daemonPromises.push(
 			spawnPollingDaemon((config) => config.publishReadyRuns, publishReadyRuns, {
-				repos: deps.repos,
-				workflowRunPublisher: deps.workflowRunPublisher,
+				repos,
+				workflowRunPublisher,
 			}),
 			spawnPollingDaemon((config) => config.republishStaleRuns, republishStaleRuns, {
-				repos: deps.repos,
-				workflowRunPublisher: deps.workflowRunPublisher,
+				repos,
+				workflowRunPublisher,
 			})
 		);
 	}
 
-	if (deps.timerPriorityQueue) {
+	if (timerPriorityQueue) {
 		daemonPromises.push(
 			spawnDueTimersConsumer(logger, {
-				repos: deps.repos,
+				repos,
 				signal,
-				timerPriorityQueue: deps.timerPriorityQueue,
-				childRunCanceller: deps.childRunCanceller,
-				workflowRunPublisher: deps.workflowRunPublisher,
+				timerPriorityQueue,
+				childRunCanceller,
+				workflowRunPublisher,
 				configProvider: configProvider.scope("daemons").scope("dueTimersConsumer"),
 			})
 		);
 	}
 
-	return Promise.allSettled(daemonPromises).then(() => {});
+	await Promise.allSettled(daemonPromises);
 }

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -1,102 +1,57 @@
-import { settleWithin } from "@aikirun/lib/async";
-import { asConfigProvider, type ConfigProvider } from "@aikirun/lib/config";
+import { asConfigProvider, type ConfigProvider, type CreateConfigProvider } from "@aikirun/lib/config";
 import type { Logger } from "@aikirun/lib/logger";
 import { merge } from "@aikirun/lib/object";
 import type { Database } from "@aikirun/types/infra/db";
-import { ulid } from "ulidx";
+import type { CreatePublisher } from "@aikirun/types/infra/queue/publisher";
+import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 
-import { defaultServerRuntimeConfig, type ServerRuntimeConfig } from "./config";
+import { defaultServerRuntimeConfig, type ServerRuntimeConfig, type ServerRuntimeConfigOverrides } from "./config";
 import { spawnDaemons } from "./daemons";
 import { createRepos } from "./infra/db/repo";
-import type { ServerRuntimeHandle, ServerRuntimeId, ServerRuntimeParams } from "./server";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
 
-export interface CreateRuntimeParams {
+export interface StartRuntimeParams {
 	db: Database;
 	logger: Logger;
-	runtime?: ServerRuntimeParams;
+	signal: AbortSignal;
+	publisher?: CreatePublisher;
+	timerPriorityQueue?: CreateTimerPriorityQueue;
+	config?: ServerRuntimeConfigOverrides | CreateConfigProvider<ServerRuntimeConfig>;
 }
 
-export function createRuntime(params: CreateRuntimeParams) {
-	return {
-		async start(): Promise<ServerRuntimeHandle> {
-			const { logger } = params;
-			const repos = await createRepos(params.db);
-			const childRunCanceller = createChildRunCanceller();
-
-			const abortController = new AbortController();
-			const { signal } = abortController;
-
-			const configParam = params.runtime?.config;
-			let configProvider: ConfigProvider<ServerRuntimeConfig>;
-			if (typeof configParam === "function") {
-				configProvider = configParam({ logger: logger.child({ "aiki.component": "config-provider" }), signal });
-			} else {
-				const config = merge(defaultServerRuntimeConfig, configParam);
-				configProvider = asConfigProvider(() => config);
-			}
-
-			const daemonsPromise = spawnDaemons(logger, {
-				repos,
-				configProvider,
-				signal,
-				workflowRunPublisher: params.runtime?.publisher?.({
-					logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
-					signal,
-				}),
-				timerPriorityQueue: params.runtime?.timerPriorityQueue?.({
-					logger: logger.child({ "aiki.component": "timer-sorted-set" }),
-					signal,
-				}),
-				childRunCanceller,
-			});
-
-			return createRuntimeHandle({ logger, daemonsPromise, configProvider, abortController });
-		},
-	};
-}
-
-interface RuntimeHandleDeps {
-	logger: Logger;
-	daemonsPromise: Promise<void>;
+export interface StartedRuntime {
 	configProvider: ConfigProvider<ServerRuntimeConfig>;
-	abortController: AbortController;
+	daemonsPromise: Promise<void>;
 }
 
-function createRuntimeHandle({
-	configProvider,
-	daemonsPromise,
-	logger,
-	abortController,
-}: RuntimeHandleDeps): ServerRuntimeHandle {
-	const id = ulid() as ServerRuntimeId;
-	let stopPromise: Promise<void> | undefined;
+export async function startRuntime(params: StartRuntimeParams): Promise<StartedRuntime> {
+	const { db, logger, signal, publisher, timerPriorityQueue, config: configParam } = params;
+	const childRunCanceller = createChildRunCanceller();
 
-	const _stop = async (): Promise<void> => {
-		const gracefulShutdownTimeoutMs = configProvider.config.gracefulShutdownTimeoutMs;
+	let configProvider: ConfigProvider<ServerRuntimeConfig>;
+	if (typeof configParam === "function") {
+		configProvider = configParam({ logger: logger.child({ "aiki.component": "config-provider" }), signal });
+	} else {
+		const config = merge(defaultServerRuntimeConfig, configParam);
+		configProvider = asConfigProvider(() => config);
+	}
 
-		abortController.abort();
+	const repos = await createRepos(db);
 
-		if (gracefulShutdownTimeoutMs <= 0) {
-			return;
-		}
+	const daemonsPromise = spawnDaemons(logger, {
+		repos,
+		configProvider,
+		signal,
+		workflowRunPublisher: publisher?.({
+			logger: logger.child({ "aiki.component": "workflow-run-publisher" }),
+			signal,
+		}),
+		timerPriorityQueue: timerPriorityQueue?.({
+			logger: logger.child({ "aiki.component": "timer-sorted-set" }),
+			signal,
+		}),
+		childRunCanceller,
+	});
 
-		const drained = await settleWithin(daemonsPromise, gracefulShutdownTimeoutMs);
-		if (!drained) {
-			logger.warn("Runtime did not shut down within graceful timeout", {
-				"aiki.runtimeId": id,
-				"aiki.gracefulShutdownTimeoutMs": gracefulShutdownTimeoutMs,
-			});
-		}
-	};
-
-	return {
-		id,
-		stop(): Promise<void> {
-			if (!stopPromise) {
-				stopPromise = _stop();
-			}
-			return stopPromise;
-		},
-	};
+	return { configProvider, daemonsPromise };
 }

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -1,3 +1,4 @@
+import { settleWithin } from "@aikirun/lib/async";
 import type { CreateConfigProvider } from "@aikirun/lib/config";
 import { createConsoleLogger, type Logger } from "@aikirun/lib/logger";
 import type { Iam } from "@aikirun/types/iam";
@@ -5,6 +6,7 @@ import type { CreateCache } from "@aikirun/types/infra/cache";
 import type { CreateDatabase } from "@aikirun/types/infra/db";
 import type { CreatePublisher } from "@aikirun/types/infra/queue";
 import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
+import { ulid } from "ulidx";
 
 import type { ServerRuntimeConfig, ServerRuntimeConfigOverrides } from "./config";
 
@@ -35,7 +37,7 @@ export interface ServerRuntimeHandle {
 
 export interface Server {
 	handler: (request: Request) => Promise<Response>;
-	runtime: { start: () => Promise<ServerRuntimeHandle> };
+	runtime: { start: () => ServerRuntimeHandle };
 }
 
 export function server(params: ServerParams): Server {
@@ -60,11 +62,72 @@ export function server(params: ServerParams): Server {
 			})();
 		},
 		runtime: {
-			async start(): Promise<ServerRuntimeHandle> {
-				const db = await params.db();
-				const { createRuntime } = await import("./runtime");
-				return createRuntime({ db, logger, runtime: params.runtime }).start();
+			start(): ServerRuntimeHandle {
+				return createRuntimeHandle({ db: params.db, logger, runtime: params.runtime });
 			},
+		},
+	};
+}
+
+function createRuntimeHandle(params: {
+	db: CreateDatabase;
+	logger: Logger;
+	runtime?: ServerRuntimeParams;
+}): ServerRuntimeHandle {
+	const { logger } = params;
+	const abortController = new AbortController();
+
+	const startRuntimePromise = (async () => {
+		try {
+			const db = await params.db();
+			const { startRuntime } = await import("./runtime");
+			return await startRuntime({
+				db,
+				logger,
+				signal: abortController.signal,
+				publisher: params.runtime?.publisher,
+				timerPriorityQueue: params.runtime?.timerPriorityQueue,
+				config: params.runtime?.config,
+			});
+		} catch (error) {
+			logger.error("Server runtime failed to start", { err: error });
+			return undefined;
+		}
+	})();
+
+	const id = ulid() as ServerRuntimeId;
+
+	let stopPromise: Promise<void> | undefined;
+
+	const _stop = async (): Promise<void> => {
+		abortController.abort();
+
+		const startedRuntime = await startRuntimePromise;
+		if (!startedRuntime) {
+			return;
+		}
+
+		const gracefulShutdownTimeoutMs = startedRuntime.configProvider.config.gracefulShutdownTimeoutMs;
+		if (gracefulShutdownTimeoutMs <= 0) {
+			return;
+		}
+
+		const drained = await settleWithin(startedRuntime.daemonsPromise, gracefulShutdownTimeoutMs);
+		if (!drained) {
+			logger.warn("Runtime did not shut down within graceful timeout", {
+				"aiki.runtimeId": id,
+				"aiki.gracefulShutdownTimeoutMs": gracefulShutdownTimeoutMs,
+			});
+		}
+	};
+
+	return {
+		id,
+		stop(): Promise<void> {
+			if (!stopPromise) {
+				stopPromise = _stop();
+			}
+			return stopPromise;
 		},
 	};
 }

--- a/sdk/worker/README.md
+++ b/sdk/worker/README.md
@@ -24,7 +24,7 @@ const aikiWorker = worker({
 	workflows: [orderWorkflowV1],
 });
 
-const handle = await aikiWorker.spawn(aikiClient);
+const handle = aikiWorker.spawn(aikiClient);
 
 // Graceful shutdown
 process.on("SIGTERM", async () => {

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -46,7 +46,7 @@ import { defaultWorkerConfig, type WorkerConfig, type WorkerConfigOverrides } fr
  *   config: { maxConcurrentWorkflowRuns: 10 },
  * });
  *
- * const handle = await myWorker.spawn(client);
+ * const handle = myWorker.spawn(client);
  *
  * process.on("SIGINT", async () => {
  *   await handle.stop();
@@ -81,7 +81,7 @@ export interface WorkerSpawnOptions {
 
 export interface Worker {
 	with(): WorkerBuilder;
-	spawn: <Context>(client: Client<Context>) => Promise<WorkerHandle>;
+	spawn: <Context>(client: Client<Context>) => WorkerHandle;
 }
 
 export interface WorkerHandle {
@@ -97,14 +97,11 @@ class WorkerImpl implements Worker {
 		return createWorkerBuilder(this, spawnOptionsOverrider());
 	}
 
-	public spawn<Context>(client: Client<Context>): Promise<WorkerHandle> {
+	public spawn<Context>(client: Client<Context>): WorkerHandle {
 		return this.spawnWithOptions(client, {});
 	}
 
-	public async spawnWithOptions<Context>(
-		client: Client<Context>,
-		spawnOptions: WorkerSpawnOptions
-	): Promise<WorkerHandle> {
+	public spawnWithOptions<Context>(client: Client<Context>, spawnOptions: WorkerSpawnOptions): WorkerHandle {
 		return new WorkerHandleImpl(client, this.params, spawnOptions);
 	}
 }


### PR DESCRIPTION
## Background

A server runtime is started with `runtime.start()`. It launches the daemons — the background pollers and the event-driven due-timers consumer that move workflow runs along. A worker is started with `worker.spawn(client)`, which returns a handle that can be used to stop it. Both returned promises.

The server is also mountable as a request handler. `server.handler` and the runtime are pulled in through separate dynamic imports, so a handler-only deployment — an edge function, say — never bundles the daemon and database code.

## Problem

Neither entry point does work that has to block the caller.

`start()` awaited three things: the database factory, a dynamic import of the runtime code, and repository construction. None of it needs to finish before the caller can hold a handle. The database factory builds a lazy `postgres` client — it opens a connection on the first query, not at construction. The import is the code-split above. Repository construction is synchronous once its module is loaded. So `await start()` waited on lazy setup and a couple of module loads, then handed back a handle.

`worker.spawn()` was `async` but never awaited anything. The worker's handle is built synchronously: the client is already connected, and the subscriber loop starts in the constructor. The promise carried no asynchronous work.

So both forced `await` ceremony for setup that doesn't need to be awaited.

## Solution

Both entry points return their handle synchronously.

```ts
// before
runtime: { start: () => Promise<ServerRuntimeHandle> }
spawn:   <Context>(client) => Promise<WorkerHandle>
// after
runtime: { start: () => ServerRuntimeHandle }
spawn:   <Context>(client) => WorkerHandle
```

`start()` builds the handle and kicks off the setup — the lazy DB client, the runtime import, repo construction, and the daemon launch — as a background boot the handle holds. The imports stay dynamic, so the code-split is intact; they just no longer sit on the calling path. `stop()` aborts the runtime signal, waits for the boot to finish, then drains the daemons within the graceful-shutdown timeout. If the boot fails, it is logged and `stop()` has nothing to drain.

`worker.spawn()` drops the `async` — the constructor already does everything synchronously.

One behavior change worth noting: boot errors. Before, `await start()` rejected if the database factory or an import threw. Now `start()` returns before the boot runs, so a boot failure is logged rather than surfaced at the call site, and `stop()` handles a runtime that never came up. The worker's "no workflows registered" guard is synchronous, so `spawn()` still throws it directly.

## Breaking changes

- `server.runtime.start()` returns `ServerRuntimeHandle`, not `Promise<ServerRuntimeHandle>`.
- `worker.spawn()` returns `WorkerHandle`, not `Promise<WorkerHandle>`.