### PR TITLE
Flatten retry onto task and workflow definitions

### DIFF
--- a/docs/core-concepts/tasks.md
+++ b/docs/core-concepts/tasks.md
@@ -62,7 +62,7 @@ const orderWorkflowV1 = orderWorkflow.v("1.0.0", {
 
 ## Task Retry
 
-Configure automatic retries for failed tasks using the `options.retry` property:
+Configure automatic retries for failed tasks using the `retry` property:
 
 ```typescript
 const processPayment = task({
@@ -70,12 +70,10 @@ const processPayment = task({
 	handler(input: { paymentId: string; amount: number }) {
 		return paymentService.charge(input.paymentId, input.amount);
 	},
-	options: {
-		retry: {
-			type: "exponential",
-			maxAttempts: 3,
-			baseDelayMs: 1000,
-		},
+	retry: {
+		type: "exponential",
+		maxAttempts: 3,
+		baseDelayMs: 1000,
 	},
 });
 ```

--- a/docs/core-concepts/workflows.md
+++ b/docs/core-concepts/workflows.md
@@ -66,19 +66,17 @@ const userOnboardingV2 = userOnboardingWorkflow.v("2.0.0", {
 
 ## Workflow Retry
 
-Configure automatic retries for failed workflows using the `options.retry` property:
+Configure automatic retries for failed workflows using the `retry` property:
 
 ```typescript
 const orderWorkflowV1 = orderWorkflow.v("1.0.0", {
 	async handler(run, input: { orderId: string }) {
 		// Workflow logic...
 	},
-	options: {
-		retry: {
-			type: "exponential",
-			maxAttempts: 3,
-			baseDelayMs: 5000,
-		},
+	retry: {
+		type: "exponential",
+		maxAttempts: 3,
+		baseDelayMs: 5000,
 	},
 });
 ```

--- a/docs/getting-started/first-workflow.md
+++ b/docs/getting-started/first-workflow.md
@@ -24,12 +24,10 @@ const notifyRestaurant = task({
 		console.log(`Notifying restaurant about order ${input.orderId}`);
 		console.log(`Items: ${input.items.join(", ")}`);
 	},
-	options: {
-		retry: {
-			type: "exponential",
-			maxAttempts: 3,
-			baseDelayMs: 1000,
-		},
+	retry: {
+		type: "exponential",
+		maxAttempts: 3,
+		baseDelayMs: 1000,
 	},
 });
 

--- a/docs/guides/retry-strategies.md
+++ b/docs/guides/retry-strategies.md
@@ -9,9 +9,7 @@ Aiki provides automatic retry capabilities for both tasks and workflows. This gu
 No automatic retries. The task or workflow fails immediately on error.
 
 ```typescript
-options: {
-	retry: { type: "never" }
-}
+retry: { type: "never" }
 ```
 
 **Use when:**
@@ -24,12 +22,10 @@ options: {
 Retries with a constant delay between attempts.
 
 ```typescript
-options: {
-	retry: {
-		type: "fixed",
-		maxAttempts: 3,
-		delayMs: 1000, // 1 second between retries
-	}
+retry: {
+	type: "fixed",
+	maxAttempts: 3,
+	delayMs: 1000, // 1 second between retries
 }
 ```
 
@@ -43,14 +39,12 @@ options: {
 Retries with increasing delays (e.g., 1s, 2s, 4s, 8s...).
 
 ```typescript
-options: {
-	retry: {
-		type: "exponential",
-		maxAttempts: 5,
-		baseDelayMs: 1000,    // Start with 1 second
-		factor: 2,            // Double each time (default)
-		maxDelayMs: 30000,    // Cap at 30 seconds (optional)
-	}
+retry: {
+	type: "exponential",
+	maxAttempts: 5,
+	baseDelayMs: 1000,    // Start with 1 second
+	factor: 2,            // Double each time (default)
+	maxDelayMs: 30000,    // Cap at 30 seconds (optional)
 }
 ```
 
@@ -64,14 +58,12 @@ options: {
 Exponential backoff with randomization to prevent thundering herd problems.
 
 ```typescript
-options: {
-	retry: {
-		type: "jittered",
-		maxAttempts: 5,
-		baseDelayMs: 1000,
-		jitterFactor: 0.5,    // Add up to 50% random variation (default)
-		maxDelayMs: 30000,
-	}
+retry: {
+	type: "jittered",
+	maxAttempts: 5,
+	baseDelayMs: 1000,
+	jitterFactor: 0.5,    // Add up to 50% random variation (default)
+	maxDelayMs: 30000,
 }
 ```
 
@@ -94,12 +86,10 @@ const sendNotification = task({
 	handler(input) {
 		return notificationService.send(input);
 	},
-	options: {
-		retry: {
-			type: "exponential",
-			maxAttempts: 3,
-			baseDelayMs: 1000,
-		},
+	retry: {
+		type: "exponential",
+		maxAttempts: 3,
+		baseDelayMs: 1000,
 	},
 });
 ```
@@ -117,12 +107,10 @@ const orderWorkflowV1 = orderWorkflow.v("1.0.0", {
 	handler(run, input) {
 		// ...
 	},
-	options: {
-		retry: {
-			type: "exponential",
-			maxAttempts: 3,
-			baseDelayMs: 5000,
-		},
+	retry: {
+		type: "exponential",
+		maxAttempts: 3,
+		baseDelayMs: 5000,
 	},
 });
 ```
@@ -146,9 +134,7 @@ const chargeCard = task({
 			idempotencyKey: input.transactionId, // Prevents duplicate charges
 		});
 	},
-	options: {
-		retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 },
-	},
+	retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 },
 });
 ```
 

--- a/examples/src/workflows/retry-until-success.ts
+++ b/examples/src/workflows/retry-until-success.ts
@@ -16,9 +16,7 @@ const unreliableTask = task({
 		tasAttempts = 0;
 		return { ok: true };
 	},
-	options: {
-		retry: { type: "fixed", maxAttempts: 5, delayMs: 1_000 },
-	},
+	retry: { type: "fixed", maxAttempts: 5, delayMs: 1_000 },
 });
 
 let workflowAttempts = 0;
@@ -31,7 +29,5 @@ export const retryUntilSuccessV1 = workflow({ name: "retry-until-success" }).v("
 		}
 		await unreliableTask.start(run);
 	},
-	options: {
-		retry: { type: "exponential", maxAttempts: Number.MAX_SAFE_INTEGER, baseDelayMs: 500 },
-	},
+	retry: { type: "exponential", maxAttempts: Number.MAX_SAFE_INTEGER, baseDelayMs: 500 },
 });

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -149,7 +149,7 @@ describe("task", () => {
 					}
 					return "charged";
 				},
-				options: { retry },
+				retry,
 			});
 
 			const input = { cardId: "card-1" };
@@ -199,7 +199,7 @@ describe("task", () => {
 				handler: async () => {
 					throw new Error("down");
 				},
-				options: { retry },
+				retry,
 			});
 
 			const input = { cardId: "card-1" };

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -22,14 +22,7 @@ import {
 	WorkflowRunRevisionConflictError,
 	WorkflowRunSuspendedError,
 } from "@aikirun/types/workflow/run";
-import type {
-	TaskAddress,
-	TaskDefinitionOptions,
-	TaskId,
-	TaskInfo,
-	TaskName,
-	TaskStartOptions,
-} from "@aikirun/types/workflow/task";
+import type { TaskAddress, TaskId, TaskInfo, TaskName, TaskStartOptions } from "@aikirun/types/workflow/task";
 import { TaskFailedError } from "@aikirun/types/workflow/task";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -70,12 +63,10 @@ type UnknownWorkflowRunHandle = WorkflowRunHandle<unknown, unknown, unknown>;
  *   handler(input: { cardId: string; amount: number }) {
  *     return paymentService.charge(input.cardId, input.amount);
  *   },
- *   options: {
- *     retry: {
- *       type: "fixed",
- *       maxAttempts: 3,
- *       delayMs: 1_000,
- *     },
+ *   retry: {
+ *     type: "fixed",
+ *     maxAttempts: 3,
+ *     delayMs: 1_000,
  *   },
  * });
  *
@@ -92,7 +83,7 @@ export function task<Input extends Serializable = void, Output extends Serializa
 export interface TaskParams<Input, Output> {
 	name: string;
 	handler: (input: Input) => Promise<Output>;
-	options?: TaskDefinitionOptions;
+	retry?: RetryStrategy;
 	schema?: RequireAtLeastOneProp<{
 		input?: StandardSchemaV1<Input>;
 		output?: StandardSchemaV1<Output>;
@@ -112,14 +103,17 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		this.name = params.name as TaskName;
 	}
 
+	private definitionStartOptions(): TaskStartOptions {
+		return this.params.retry === undefined ? {} : { retry: this.params.retry };
+	}
+
 	public with(): TaskBuilder<Input, Output> {
-		const startOptions: TaskStartOptions = this.params.options ?? {};
-		const startOptionsOverrider = objectOverrider(startOptions);
+		const startOptionsOverrider = objectOverrider(this.definitionStartOptions());
 		return createTaskBuilder(this, startOptionsOverrider());
 	}
 
 	public async start(run: UnknownWorkflowRun, ...args: Input extends void ? [] : [Input]): Promise<Output> {
-		return this.startWithOptions(run, this.params.options ?? {}, ...args);
+		return this.startWithOptions(run, this.definitionStartOptions(), ...args);
 	}
 
 	public async startWithOptions(

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -18,7 +18,6 @@ import { SchemaValidationError } from "@aikirun/types/validator";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
 	ReplayManifest,
-	WorkflowDefinitionOptions,
 	WorkflowRunAddress,
 	WorkflowRunId,
 	WorkflowRunRecord,
@@ -42,7 +41,7 @@ import { type ChildWorkflowRunHandle, childWorkflowRunHandle } from "./run/handl
 export interface WorkflowVersionParams<Input, Output, Context, TEvents extends EventsDefinition> {
 	handler: (run: Readonly<WorkflowRun<Input, Context, TEvents>>, input: Input) => Promise<Output>;
 	events?: TEvents;
-	options?: WorkflowDefinitionOptions;
+	retry?: RetryStrategy;
 	schema?: RequireAtLeastOneProp<{
 		input?: StandardSchemaV1<Input>;
 		output?: StandardSchemaV1<Output>;
@@ -101,9 +100,12 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		};
 	}
 
+	private definitionStartOptions(): WorkflowStartOptions {
+		return this.params.retry === undefined ? {} : { retry: this.params.retry };
+	}
+
 	public with(): WorkflowBuilder<Input, Output, Context, TEvents> {
-		const startOptions: WorkflowStartOptions = this.params.options ?? {};
-		const startOptionsOverrider = objectOverrider(startOptions);
+		const startOptionsOverrider = objectOverrider(this.definitionStartOptions());
 		return createWorkflowBuilder(this, startOptionsOverrider());
 	}
 
@@ -111,7 +113,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		client: Client<Context>,
 		...args: Input extends void ? [] : [Input]
 	): Promise<WorkflowRunHandle<Input, Output, Context, TEvents>> {
-		return this.startWithOptions(client, this.params.options ?? {}, ...args);
+		return this.startWithOptions(client, this.definitionStartOptions(), ...args);
 	}
 
 	public async startWithOptions(
@@ -151,7 +153,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		parentRun: WorkflowRun<unknown, Context, EventsDefinition>,
 		...args: Input extends void ? [] : [Input]
 	): Promise<ChildWorkflowRunHandle<Input, Output, Context, TEvents>> {
-		return this.startAsChildWithOptions(parentRun, this.params.options ?? {}, ...args);
+		return this.startAsChildWithOptions(parentRun, this.definitionStartOptions(), ...args);
 	}
 
 	public async startAsChildWithOptions(
@@ -286,7 +288,8 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 
 		handle[INTERNAL].assertExecutionAllowed();
 
-		const retryStrategy = this.params.options?.retry ?? { type: "never" };
+		// TODO: test this - that persisted strategy takes precedence over defined strategy
+		const retryStrategy = run.options.retry ?? this.params.retry ?? { type: "never" };
 
 		logger.info("Starting workflow");
 		await handle[INTERNAL].transitionState({ status: "running" });

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -50,11 +50,8 @@ export interface WorkflowReferenceOptions {
 	conflictPolicy?: WorkflowRunConflictPolicy;
 }
 
-export interface WorkflowDefinitionOptions {
+export interface WorkflowStartOptions {
 	retry?: RetryStrategy;
-}
-
-export interface WorkflowStartOptions extends WorkflowDefinitionOptions {
 	trigger?: TriggerStrategy;
 	reference?: WorkflowReferenceOptions;
 	shard?: string;

--- a/types/src/workflow/task/task.ts
+++ b/types/src/workflow/task/task.ts
@@ -11,11 +11,9 @@ export type TaskAddress = string & { _brand: "task_address" };
 export const TASK_STATUSES = ["running", "awaiting_retry", "completed", "failed", "discarded"] as const;
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 
-export interface TaskDefinitionOptions {
+export interface TaskStartOptions {
 	retry?: RetryStrategy;
 }
-
-export interface TaskStartOptions extends TaskDefinitionOptions {}
 
 interface TaskStateBase {
 	status: TaskStatus;


### PR DESCRIPTION
## Problem

Definition-time `retry` was nested under an `options` wrapper — `TaskDefinitionOptions` / `WorkflowDefinitionOptions`, each a single-field interface holding only `retry`. The start-options types extended those wrappers and added the genuinely per-run fields (`trigger`, `reference`, `shard`), so `retry` was the only field the definition and start surfaces shared.

The workflow side also had a bug: a `retry` override passed at start via `with()` was persisted but never read at execution, so the workflow always self-retried using the definition default. Tasks already read retry from the start options and didn't have this gap.

## Solution

`retry` moves to the top level of the definition params; the `*DefinitionOptions` wrappers are removed and the start-options types declare `retry` directly.

```ts
// before
interface WorkflowStartOptions extends WorkflowDefinitionOptions { trigger?; reference?; shard? }
workflow.v("1.0.0", { handler, options: { retry } })

// after
interface WorkflowStartOptions { retry?; trigger?; reference?; shard? }
workflow.v("1.0.0", { handler, retry })
```

The wire format is unchanged — the SDK still packs `retry` into the start-options bag, and `with()` still merges a per-run override over the definition default. Workflow execution now resolves retry as `run.options.retry ?? params.retry ?? { type: "never" }`, so a start-time override takes effect (and `{ type: "never" }` at start disables the default).

The override-at-execution path has no automated coverage; the SDK has no workflow-execution test harness yet.

## Breaking changes

`task()` and `workflow.v()` take `retry` at the top level instead of under `options.retry`. `TaskDefinitionOptions` and `WorkflowDefinitionOptions` are removed.