### PR TITLE
Stop the fake client from masking test failures

### DIFF
--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -2,7 +2,7 @@ import {
 	cronScheduleActivateRequestFactory,
 	intervalScheduleActivateRequestFactory,
 } from "@aikirun/testing/api/schedule";
-import { fakeClient } from "@aikirun/testing/client";
+import { withFakeClient } from "@aikirun/testing/client";
 import { cronScheduleFactory, intervalScheduleFactory } from "@aikirun/testing/schedule";
 import type { ScheduleId } from "@aikirun/types/schedule";
 
@@ -27,115 +27,115 @@ const cronScheduleActivateRequest = cronScheduleActivateRequestFactory.params({
 
 describe("schedule", () => {
 	describe("activate", () => {
-		test("maps the interval to everyMs and carries the overlap policy", async () => {
-			using client = fakeClient();
-			client.api.schedule.activateV1.once(
-				intervalScheduleActivateRequest.build({
-					spec: { type: "interval", overlapPolicy: "cancel_previous", everyMs: 5_000 },
-				}),
-				{ schedule: intervalScheduleFactory.build() }
-			);
+		test("maps the interval to everyMs and carries the overlap policy", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						spec: { type: "interval", overlapPolicy: "cancel_previous", everyMs: 5_000 },
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
 
-			await schedule({ type: "interval", every: { seconds: 5 }, overlapPolicy: "cancel_previous" }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
-		});
+				await schedule({ type: "interval", every: { seconds: 5 }, overlapPolicy: "cancel_previous" }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
+			}));
 
-		test("passes a cron spec through unchanged", async () => {
-			using client = fakeClient();
-			client.api.schedule.activateV1.once(
-				cronScheduleActivateRequest.build({
-					spec: { type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" },
-				}),
-				{ schedule: cronScheduleFactory.build() }
-			);
+		test("passes a cron spec through unchanged", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					cronScheduleActivateRequest.build({
+						spec: { type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" },
+					}),
+					{ schedule: cronScheduleFactory.build() }
+				);
 
-			await schedule({ type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
-		});
+				await schedule({ type: "cron", expression: "0 * * * *", timezone: "UTC", overlapPolicy: "skip" }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
+			}));
 
-		test("returns a handle carrying the activated schedule id", async () => {
-			using client = fakeClient();
-			const activatedSchedule = intervalScheduleFactory.build();
+		test("returns a handle carrying the activated schedule id", () =>
+			withFakeClient(async (client) => {
+				const activatedSchedule = intervalScheduleFactory.build();
 
-			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+				client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
 
-			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
+				const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
 
-			expect(handle.id).toBe(activatedSchedule.id as ScheduleId);
-		});
+				expect(handle.id).toBe(activatedSchedule.id as ScheduleId);
+			}));
 	});
 
 	describe("with builder", () => {
-		test("opt sets the options sent to activate", async () => {
-			using client = fakeClient();
-			client.api.schedule.activateV1.once(
-				intervalScheduleActivateRequest.build({
-					options: { reference: { id: "ref-1" } },
-				}),
-				{ schedule: intervalScheduleFactory.build() }
-			);
+		test("opt sets the options sent to activate", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						options: { reference: { id: "ref-1" } },
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
 
-			await schedule({ type: "interval", every: { seconds: 1 } })
-				.with()
-				.opt("reference.id", "ref-1")
-				.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
-		});
+				await schedule({ type: "interval", every: { seconds: 1 } })
+					.with()
+					.opt("reference.id", "ref-1")
+					.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
+			}));
 	});
 
 	describe("handle operations", () => {
-		test("pause calls pauseV1 with the schedule id", async () => {
-			using client = fakeClient();
-			const activatedSchedule = intervalScheduleFactory.build();
+		test("pause calls pauseV1 with the schedule id", () =>
+			withFakeClient(async (client) => {
+				const activatedSchedule = intervalScheduleFactory.build();
 
-			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
-			client.api.schedule.pauseV1.once({ id: activatedSchedule.id });
+				client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+				client.api.schedule.pauseV1.once({ id: activatedSchedule.id });
 
-			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
-			await handle.pause();
-		});
+				const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
+				await handle.pause();
+			}));
 
-		test("resume calls resumeV1 with the schedule id", async () => {
-			using client = fakeClient();
-			const activatedSchedule = intervalScheduleFactory.build();
+		test("resume calls resumeV1 with the schedule id", () =>
+			withFakeClient(async (client) => {
+				const activatedSchedule = intervalScheduleFactory.build();
 
-			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
-			client.api.schedule.resumeV1.once({ id: activatedSchedule.id });
+				client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+				client.api.schedule.resumeV1.once({ id: activatedSchedule.id });
 
-			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
-			await handle.resume();
-		});
+				const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
+				await handle.resume();
+			}));
 
-		test("delete calls deleteV1 with the schedule id", async () => {
-			using client = fakeClient();
-			const activatedSchedule = intervalScheduleFactory.build();
+		test("delete calls deleteV1 with the schedule id", () =>
+			withFakeClient(async (client) => {
+				const activatedSchedule = intervalScheduleFactory.build();
 
-			client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
-			client.api.schedule.deleteV1.once({ id: activatedSchedule.id });
+				client.api.schedule.activateV1.once(expect.anything(), { schedule: activatedSchedule });
+				client.api.schedule.deleteV1.once({ id: activatedSchedule.id });
 
-			const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
-				client,
-				syncInventoryWorkflow,
-				{ warehouseId: "wh-1" }
-			);
-			await handle.delete();
-		});
+				const handle = await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					syncInventoryWorkflow,
+					{ warehouseId: "wh-1" }
+				);
+				await handle.delete();
+			}));
 	});
 });

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -1,7 +1,7 @@
 import { getTaskAddress } from "@aikirun/lib/address";
 import { asConfigProvider } from "@aikirun/lib/config";
 import { hashInput } from "@aikirun/lib/crypto";
-import { fakeClient } from "@aikirun/testing/client";
+import { withFakeClient } from "@aikirun/testing/client";
 import { baseWorkflowRunRecordFactory, runningWorkflowRunRecordFactory } from "@aikirun/testing/workflow/run";
 import {
 	completedTaskInfoFactory,
@@ -87,32 +87,87 @@ const stateByStatus: { [Status in WorkflowRunStatus]: Extract<WorkflowRunState, 
 describe("task", () => {
 	describe("start", () => {
 		for (const status of ["queued", "running"] as const) {
-			test(`creates the task, then completes it with the handler output when the run is ${status}`, async () => {
-				using client = fakeClient();
-				const runRecord = { ...baseWorkflowRunRecordFactory.build(), state: stateByStatus[status] };
-				const run = createTestWorkflowRun(client, runRecord);
+			test(`creates the task, then completes it with the handler output when the run is ${status}`, () =>
+				withFakeClient(async (client) => {
+					const runRecord = { ...baseWorkflowRunRecordFactory.build(), state: stateByStatus[status] };
+					const run = createTestWorkflowRun(client, runRecord);
 
-				const sendEmail = task({
-					name: "send-email",
-					handler: async (to: string): Promise<string> => `Sent to ${to}`,
+					const sendEmail = task({
+						name: "send-email",
+						handler: async (to: string): Promise<string> => `Sent to ${to}`,
+					});
+
+					const input = "info@aiki.run";
+					const output = "Sent to info@aiki.run";
+
+					const runningTaskInfo = runningTaskInfoFactory.build({ name: sendEmail.name, state: { input } });
+					const completedTaskInfo = completedTaskInfoFactory.build({
+						id: runningTaskInfo.id,
+						name: sendEmail.name,
+						state: { output },
+					});
+
+					client.api.workflowRun.transitionTaskStateV1
+						.once(
+							{
+								type: "create",
+								taskName: sendEmail.name,
+								options: {},
+								taskState: runningTaskInfo.state,
+								id: runRecord.id,
+								expectedWorkflowRunRevision: runRecord.revision,
+							},
+							{ taskInfo: runningTaskInfo }
+						)
+						.once(
+							{
+								taskId: runningTaskInfo.id,
+								taskState: completedTaskInfo.state,
+								id: runRecord.id,
+								expectedWorkflowRunRevision: runRecord.revision,
+							},
+							{ taskInfo: completedTaskInfo }
+						);
+
+					expect(await sendEmail.start(run, input)).toBe(output);
+				}));
+		}
+
+		test("retries in-memory when the delay is within the spin threshold, recording no extra transition", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+				const run = createTestWorkflowRun(client, runRecord, { spinThresholdMs: 10 });
+
+				const retry = { type: "fixed", maxAttempts: 2, delayMs: 1 } as const;
+				let handlerCalls = 0;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						if (handlerCalls === 1) {
+							throw new Error("transient");
+						}
+						return "charged";
+					},
+					retry,
 				});
 
-				const input = "info@aiki.run";
-				const output = "Sent to info@aiki.run";
+				const input = { cardId: "card-1" };
+				const output = "charged";
 
-				const runningTaskInfo = runningTaskInfoFactory.build({ name: sendEmail.name, state: { input } });
+				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
 				const completedTaskInfo = completedTaskInfoFactory.build({
 					id: runningTaskInfo.id,
-					name: sendEmail.name,
-					state: { output },
+					name: chargeCard.name,
+					state: { attempts: 2, output },
 				});
 
 				client.api.workflowRun.transitionTaskStateV1
 					.once(
 						{
 							type: "create",
-							taskName: sendEmail.name,
-							options: {},
+							taskName: chargeCard.name,
+							options: { retry },
 							taskState: runningTaskInfo.state,
 							id: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
@@ -129,369 +184,311 @@ describe("task", () => {
 						{ taskInfo: completedTaskInfo }
 					);
 
+				expect(await chargeCard.start(run, input)).toBe(output);
+				expect(handlerCalls).toBe(2);
+			}));
+
+		test("persists awaiting_retry and suspends when the delay exceeds the spin threshold", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+				const run = createTestWorkflowRun(client, runRecord, { spinThresholdMs: 0 });
+
+				const retry = { type: "fixed", maxAttempts: 2, delayMs: 1_000 } as const;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						throw new Error("down");
+					},
+					retry,
+				});
+
+				const input = { cardId: "card-1" };
+				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
+
+				client.api.workflowRun.transitionTaskStateV1
+					.once(
+						{
+							type: "create",
+							taskName: chargeCard.name,
+							options: { retry },
+							taskState: runningTaskInfo.state,
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: runningTaskInfo }
+					)
+					.once(
+						{
+							taskId: runningTaskInfo.id,
+							taskState: {
+								status: "awaiting_retry",
+								attempts: 1,
+								error: expect.objectContaining({ message: "down" }),
+								nextAttemptInMs: 1_000,
+							},
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: runningTaskInfo }
+					);
+
+				let error: unknown;
+				try {
+					await chargeCard.start(run, input);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(WorkflowRunSuspendedError);
+			}));
+
+		test("fails the task and throws TaskFailedError when there is no retry budget", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+				const run = createTestWorkflowRun(client, runRecord);
+
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						throw new Error("declined");
+					},
+				});
+
+				const input = { cardId: "card-1" };
+				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
+
+				client.api.workflowRun.transitionTaskStateV1
+					.once(
+						{
+							type: "create",
+							taskName: chargeCard.name,
+							options: {},
+							taskState: runningTaskInfo.state,
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: runningTaskInfo }
+					)
+					.once(
+						{
+							taskId: runningTaskInfo.id,
+							taskState: {
+								status: "failed",
+								attempts: 1,
+								error: expect.objectContaining({ message: "declined" }),
+							},
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: runningTaskInfo }
+					);
+
+				let error: unknown;
+				try {
+					await chargeCard.start(run, input);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(TaskFailedError);
+			}));
+
+		test("replays a completed task from history without touching the client", () =>
+			withFakeClient(async (client) => {
+				let handlerCalls = 0;
+				const sendEmail = task<{ to: string }, string>({
+					name: "send-email",
+					handler: async () => {
+						handlerCalls++;
+						return "freshly-sent";
+					},
+				});
+
+				const input = { to: "info@aiki.run" };
+				const output = "previously-sent";
+
+				const inputHash = await hashInput(input);
+				const address = getTaskAddress(sendEmail.name, inputHash);
+				const recordedTask = completedTaskInfoFactory.build({ name: sendEmail.name, state: { output } });
+				const runRecord = runningWorkflowRunRecordFactory.build({
+					taskQueues: { [address]: { tasks: [recordedTask] } },
+				});
+				const run = createTestWorkflowRun(client, runRecord);
+
 				expect(await sendEmail.start(run, input)).toBe(output);
-			});
-		}
+				expect(handlerCalls).toBe(0);
+			}));
 
-		test("retries in-memory when the delay is within the spin threshold, recording no extra transition", async () => {
-			using client = fakeClient();
-			const runRecord = runningWorkflowRunRecordFactory.build();
-			const run = createTestWorkflowRun(client, runRecord, { spinThresholdMs: 10 });
+		test("fails the run and throws WorkflowRunFailedError when the input schema rejects", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+				const run = createTestWorkflowRun(client, runRecord);
 
-			const retry = { type: "fixed", maxAttempts: 2, delayMs: 1 } as const;
-			let handlerCalls = 0;
-			const chargeCard = task<{ cardId: string }, string>({
-				name: "charge-card",
-				handler: async () => {
-					handlerCalls++;
-					if (handlerCalls === 1) {
-						throw new Error("transient");
-					}
-					return "charged";
-				},
-				retry,
-			});
-
-			const input = { cardId: "card-1" };
-			const output = "charged";
-
-			const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
-			const completedTaskInfo = completedTaskInfoFactory.build({
-				id: runningTaskInfo.id,
-				name: chargeCard.name,
-				state: { attempts: 2, output },
-			});
-
-			client.api.workflowRun.transitionTaskStateV1
-				.once(
-					{
-						type: "create",
-						taskName: chargeCard.name,
-						options: { retry },
-						taskState: runningTaskInfo.state,
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
+				const alwaysInvalid: StandardSchemaV1<string> = {
+					"~standard": {
+						version: 1,
+						vendor: "test",
+						validate: () => ({ issues: [{ message: "invalid input" }] }),
 					},
-					{ taskInfo: runningTaskInfo }
-				)
-				.once(
+				};
+				const validateInput = task<string, string>({
+					name: "validate-input",
+					handler: async (value) => value,
+					schema: { input: alwaysInvalid },
+				});
+
+				client.api.workflowRun.transitionStateV1.once(
 					{
-						taskId: runningTaskInfo.id,
-						taskState: completedTaskInfo.state,
+						type: "optimistic",
 						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
+						state: expect.objectContaining({ status: "failed", cause: "self" }),
+						expectedRevision: runRecord.revision,
 					},
-					{ taskInfo: completedTaskInfo }
+					{ revision: runRecord.revision, state: runRecord.state, attempts: runRecord.attempts }
 				);
 
-			expect(await chargeCard.start(run, input)).toBe(output);
-			expect(handlerCalls).toBe(2);
-		});
+				let error: unknown;
+				try {
+					await validateInput.start(run, "anything");
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(WorkflowRunFailedError);
+			}));
 
-		test("persists awaiting_retry and suspends when the delay exceeds the spin threshold", async () => {
-			using client = fakeClient();
-			const runRecord = runningWorkflowRunRecordFactory.build();
-			const run = createTestWorkflowRun(client, runRecord, { spinThresholdMs: 0 });
-
-			const retry = { type: "fixed", maxAttempts: 2, delayMs: 1_000 } as const;
-			const chargeCard = task<{ cardId: string }, string>({
-				name: "charge-card",
-				handler: async () => {
-					throw new Error("down");
-				},
-				retry,
-			});
-
-			const input = { cardId: "card-1" };
-			const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
-
-			client.api.workflowRun.transitionTaskStateV1
-				.once(
-					{
-						type: "create",
-						taskName: chargeCard.name,
-						options: { retry },
-						taskState: runningTaskInfo.state,
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
+		test("replays a failed task from history as TaskFailedError without touching the client", () =>
+			withFakeClient(async (client) => {
+				let handlerCalls = 0;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						return "charged";
 					},
-					{ taskInfo: runningTaskInfo }
-				)
-				.once(
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getTaskAddress(chargeCard.name, inputHash);
+				const failedTask = failedTaskInfoFactory.build({ name: chargeCard.name });
+				const runRecord = runningWorkflowRunRecordFactory.build({
+					taskQueues: { [address]: { tasks: [failedTask] } },
+				});
+				const run = createTestWorkflowRun(client, runRecord);
+
+				let error: unknown;
+				try {
+					await chargeCard.start(run, input);
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(TaskFailedError);
+				expect(handlerCalls).toBe(0);
+			}));
+
+		test("fails the run with NonDeterminismError when the replay history diverges", () =>
+			withFakeClient(async (client) => {
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => "charged",
+				});
+
+				const runRecord = runningWorkflowRunRecordFactory.build({
+					taskQueues: { "other-task:other-hash": { tasks: [completedTaskInfoFactory.build()] } },
+				});
+				const run = createTestWorkflowRun(client, runRecord);
+
+				client.api.workflowRun.transitionStateV1.once(
 					{
-						taskId: runningTaskInfo.id,
-						taskState: {
-							status: "awaiting_retry",
-							attempts: 1,
-							error: expect.objectContaining({ message: "down" }),
-							nextAttemptInMs: 1_000,
-						},
+						type: "optimistic",
 						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
+						state: expect.objectContaining({ status: "failed", cause: "self" }),
+						expectedRevision: runRecord.revision,
 					},
-					{ taskInfo: runningTaskInfo }
+					{ revision: runRecord.revision, state: runRecord.state, attempts: runRecord.attempts }
 				);
 
-			let error: unknown;
-			try {
-				await chargeCard.start(run, input);
-			} catch (caught) {
-				error = caught;
-			}
-			expect(error).toBeInstanceOf(WorkflowRunSuspendedError);
-		});
-
-		test("fails the task and throws TaskFailedError when there is no retry budget", async () => {
-			using client = fakeClient();
-			const runRecord = runningWorkflowRunRecordFactory.build();
-			const run = createTestWorkflowRun(client, runRecord);
-
-			const chargeCard = task<{ cardId: string }, string>({
-				name: "charge-card",
-				handler: async () => {
-					throw new Error("declined");
-				},
-			});
-
-			const input = { cardId: "card-1" };
-			const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name, state: { input } });
-
-			client.api.workflowRun.transitionTaskStateV1
-				.once(
-					{
-						type: "create",
-						taskName: chargeCard.name,
-						options: {},
-						taskState: runningTaskInfo.state,
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
-					},
-					{ taskInfo: runningTaskInfo }
-				)
-				.once(
-					{
-						taskId: runningTaskInfo.id,
-						taskState: {
-							status: "failed",
-							attempts: 1,
-							error: expect.objectContaining({ message: "declined" }),
-						},
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
-					},
-					{ taskInfo: runningTaskInfo }
-				);
-
-			let error: unknown;
-			try {
-				await chargeCard.start(run, input);
-			} catch (caught) {
-				error = caught;
-			}
-			expect(error).toBeInstanceOf(TaskFailedError);
-		});
-
-		test("replays a completed task from history without touching the client", async () => {
-			using client = fakeClient();
-
-			let handlerCalls = 0;
-			const sendEmail = task<{ to: string }, string>({
-				name: "send-email",
-				handler: async () => {
-					handlerCalls++;
-					return "freshly-sent";
-				},
-			});
-
-			const input = { to: "info@aiki.run" };
-			const output = "previously-sent";
-
-			const inputHash = await hashInput(input);
-			const address = getTaskAddress(sendEmail.name, inputHash);
-			const recordedTask = completedTaskInfoFactory.build({ name: sendEmail.name, state: { output } });
-			const runRecord = runningWorkflowRunRecordFactory.build({
-				taskQueues: { [address]: { tasks: [recordedTask] } },
-			});
-			const run = createTestWorkflowRun(client, runRecord);
-
-			expect(await sendEmail.start(run, input)).toBe(output);
-			expect(handlerCalls).toBe(0);
-		});
-
-		test("fails the run and throws WorkflowRunFailedError when the input schema rejects", async () => {
-			using client = fakeClient();
-			const runRecord = runningWorkflowRunRecordFactory.build();
-			const run = createTestWorkflowRun(client, runRecord);
-
-			const alwaysInvalid: StandardSchemaV1<string> = {
-				"~standard": {
-					version: 1,
-					vendor: "test",
-					validate: () => ({ issues: [{ message: "invalid input" }] }),
-				},
-			};
-			const validateInput = task<string, string>({
-				name: "validate-input",
-				handler: async (value) => value,
-				schema: { input: alwaysInvalid },
-			});
-
-			client.api.workflowRun.transitionStateV1.once(
-				{
-					type: "optimistic",
-					id: runRecord.id,
-					state: expect.objectContaining({ status: "failed", cause: "self" }),
-					expectedRevision: runRecord.revision,
-				},
-				{ revision: runRecord.revision, state: runRecord.state, attempts: runRecord.attempts }
-			);
-
-			let error: unknown;
-			try {
-				await validateInput.start(run, "anything");
-			} catch (caught) {
-				error = caught;
-			}
-			expect(error).toBeInstanceOf(WorkflowRunFailedError);
-		});
-
-		test("replays a failed task from history as TaskFailedError without touching the client", async () => {
-			using client = fakeClient();
-
-			let handlerCalls = 0;
-			const chargeCard = task<{ cardId: string }, string>({
-				name: "charge-card",
-				handler: async () => {
-					handlerCalls++;
-					return "charged";
-				},
-			});
-
-			const input = { cardId: "card-1" };
-			const inputHash = await hashInput(input);
-			const address = getTaskAddress(chargeCard.name, inputHash);
-			const failedTask = failedTaskInfoFactory.build({ name: chargeCard.name });
-			const runRecord = runningWorkflowRunRecordFactory.build({
-				taskQueues: { [address]: { tasks: [failedTask] } },
-			});
-			const run = createTestWorkflowRun(client, runRecord);
-
-			let error: unknown;
-			try {
-				await chargeCard.start(run, input);
-			} catch (caught) {
-				error = caught;
-			}
-			expect(error).toBeInstanceOf(TaskFailedError);
-			expect(handlerCalls).toBe(0);
-		});
-
-		test("fails the run with NonDeterminismError when the replay history diverges", async () => {
-			using client = fakeClient();
-
-			const chargeCard = task<{ cardId: string }, string>({
-				name: "charge-card",
-				handler: async () => "charged",
-			});
-
-			const runRecord = runningWorkflowRunRecordFactory.build({
-				taskQueues: { "other-task:other-hash": { tasks: [completedTaskInfoFactory.build()] } },
-			});
-			const run = createTestWorkflowRun(client, runRecord);
-
-			client.api.workflowRun.transitionStateV1.once(
-				{
-					type: "optimistic",
-					id: runRecord.id,
-					state: expect.objectContaining({ status: "failed", cause: "self" }),
-					expectedRevision: runRecord.revision,
-				},
-				{ revision: runRecord.revision, state: runRecord.state, attempts: runRecord.attempts }
-			);
-
-			let error: unknown;
-			try {
-				await chargeCard.start(run, { cardId: "card-1" });
-			} catch (caught) {
-				error = caught;
-			}
-			expect(error).toBeInstanceOf(NonDeterminismError);
-		});
+				let error: unknown;
+				try {
+					await chargeCard.start(run, { cardId: "card-1" });
+				} catch (caught) {
+					error = caught;
+				}
+				expect(error).toBeInstanceOf(NonDeterminismError);
+			}));
 
 		for (const status of WORKFLOW_RUN_STATUSES) {
 			if (status === "queued" || status === "running") {
 				continue;
 			}
 
-			test(`throws WorkflowRunNotExecutableError when the run is ${status}`, async () => {
-				using client = fakeClient();
-				const runRecord = { ...baseWorkflowRunRecordFactory.build(), state: stateByStatus[status] };
-				const run = createTestWorkflowRun(client, runRecord);
+			test(`throws WorkflowRunNotExecutableError when the run is ${status}`, () =>
+				withFakeClient(async (client) => {
+					const runRecord = { ...baseWorkflowRunRecordFactory.build(), state: stateByStatus[status] };
+					const run = createTestWorkflowRun(client, runRecord);
 
-				let handlerCalls = 0;
-				const sendEmail = task<{ to: string }, string>({
-					name: "send-email",
-					handler: async () => {
-						handlerCalls++;
-						return "sent";
-					},
-				});
+					let handlerCalls = 0;
+					const sendEmail = task<{ to: string }, string>({
+						name: "send-email",
+						handler: async () => {
+							handlerCalls++;
+							return "sent";
+						},
+					});
 
-				let error: unknown;
-				try {
-					await sendEmail.start(run, { to: "info@aiki.run" });
-				} catch (caught) {
-					error = caught;
-				}
-				expect(error).toBeInstanceOf(WorkflowRunNotExecutableError);
-				expect(handlerCalls).toBe(0);
-			});
+					let error: unknown;
+					try {
+						await sendEmail.start(run, { to: "info@aiki.run" });
+					} catch (caught) {
+						error = caught;
+					}
+					expect(error).toBeInstanceOf(WorkflowRunNotExecutableError);
+					expect(handlerCalls).toBe(0);
+				}));
 		}
 
-		test("applies builder options to the create transition call", async () => {
-			using client = fakeClient();
-			const runRecord = runningWorkflowRunRecordFactory.build();
-			const run = createTestWorkflowRun(client, runRecord);
+		test("applies builder options to the create transition call", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+				const run = createTestWorkflowRun(client, runRecord);
 
-			const sendEmail = task<{ to: string }, string>({
-				name: "send-email",
-				handler: async () => "sent",
-			});
+				const sendEmail = task<{ to: string }, string>({
+					name: "send-email",
+					handler: async () => "sent",
+				});
 
-			const input = { to: "info@aiki.run" };
-			const output = "sent";
-			const retry = { type: "fixed", maxAttempts: 3, delayMs: 1 } as const;
+				const input = { to: "info@aiki.run" };
+				const output = "sent";
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 1 } as const;
 
-			const runningTaskInfo = runningTaskInfoFactory.build({ name: sendEmail.name, state: { input } });
-			const completedTaskInfo = completedTaskInfoFactory.build({
-				id: runningTaskInfo.id,
-				name: sendEmail.name,
-				state: { output },
-			});
+				const runningTaskInfo = runningTaskInfoFactory.build({ name: sendEmail.name, state: { input } });
+				const completedTaskInfo = completedTaskInfoFactory.build({
+					id: runningTaskInfo.id,
+					name: sendEmail.name,
+					state: { output },
+				});
 
-			client.api.workflowRun.transitionTaskStateV1
-				.once(
-					{
-						type: "create",
-						taskName: sendEmail.name,
-						options: { retry },
-						taskState: runningTaskInfo.state,
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
-					},
-					{ taskInfo: runningTaskInfo }
-				)
-				.once(
-					{
-						taskId: runningTaskInfo.id,
-						taskState: completedTaskInfo.state,
-						id: runRecord.id,
-						expectedWorkflowRunRevision: runRecord.revision,
-					},
-					{ taskInfo: completedTaskInfo }
-				);
+				client.api.workflowRun.transitionTaskStateV1
+					.once(
+						{
+							type: "create",
+							taskName: sendEmail.name,
+							options: { retry },
+							taskState: runningTaskInfo.state,
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: runningTaskInfo }
+					)
+					.once(
+						{
+							taskId: runningTaskInfo.id,
+							taskState: completedTaskInfo.state,
+							id: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: completedTaskInfo }
+					);
 
-			expect(await sendEmail.with().opt("retry", retry).start(run, input)).toBe(output);
-		});
+				expect(await sendEmail.with().opt("retry", retry).start(run, input)).toBe(output);
+			}));
 	});
 });

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -29,11 +29,10 @@ type MockApi<T> = {
 	[K in keyof T]: T[K] extends (...args: infer Args) => infer Return ? MockEndpoint<Args, Return> : MockApi<T[K]>;
 };
 
-export interface FakeClient<Context = null> extends Client<Context>, Disposable {
+export interface FakeClient<Context = null> extends Client<Context> {
 	api: MockApi<ApiClient>;
 	/**
-	 * Throws if any call queued via `once` was never made. Runs automatically on scope exit
-	 * when the client is declared with `using` (via `[Symbol.dispose]`).
+	 * Throws if any call queued via `once` was never made.
 	 */
 	verify(): void;
 }
@@ -52,16 +51,9 @@ interface RegisteredEndpoint {
  * A `Client` whose every API endpoint is an auto-created mock augmented with `once`.
  * Queue the calls a test expects; any call with no queued expectation throws.
  *
- * Declare it with `using` so `verify()` runs automatically on scope exit:
- *
- * @example
- * test("activates a schedule", async () => {
- *   using client = fakeClient();
- *   client.api.schedule.activateV1.once({ spec: mySpec }, { schedule: intervalScheduleFactory.build() });
- *   await schedule(myParams).activate(client, myWorkflow, input);
- * });
+ * Use it through {@link withFakeClient}, which calls `verify()` for you on success:
  */
-export function fakeClient<Context = null>(): FakeClient<Context> {
+function fakeClient<Context = null>(): FakeClient<Context> {
 	const endpoints: RegisteredEndpoint[] = [];
 
 	const createEndpoint = (endpointName: string): unknown => {
@@ -143,6 +135,26 @@ export function fakeClient<Context = null>(): FakeClient<Context> {
 		logger: createConsoleLogger({ level: "DEBUG" }),
 		[INTERNAL]: {},
 		verify,
-		[Symbol.dispose]: verify,
 	};
+}
+
+/**
+ * Runs `fn` with a fresh fake client, then asserts every queued call was made.
+ *
+ * `verify()` runs only after `fn` resolves, so a failure inside `fn` propagates with its own
+ * error — never masked by a verification error.
+ *
+ * @example
+ * test("activates a schedule", () =>
+ *   withFakeClient(async (client) => {
+ *     client.api.schedule.activateV1.once(request, response);
+ *     await schedule(params).activate(client, workflow, input);
+ *   }));
+ */
+export async function withFakeClient<Context = null>(
+	fn: (client: Omit<FakeClient<Context>, "verify">) => Promise<void> | void
+): Promise<void> {
+	const client = fakeClient<Context>();
+	await fn(client);
+	client.verify();
 }


### PR DESCRIPTION
The SDK's unit tests use a **fake client** — a stand-in for `Client` whose API endpoints are mocks. A test queues the calls it expects with `.once(request, response)`, and `verify()` asserts they were all made.

The client was declared with `using`, so `verify()` ran on scope exit. That masks failures: when a test body throws — often the useful error, like a `toEqual` diff from a call sent with the wrong arguments — `verify()` still runs on the way out, finds the queued calls the body never reached, and throws too. JavaScript folds the two into a `SuppressedError` that surfaces the verify error and buries the real one ("An error was suppressed during disposal"). A disposer can't work around it: `[Symbol.dispose]` never receives the in-flight error.

`withFakeClient(fn)` replaces the pattern — it runs `fn`, then verifies only after `fn` resolves. A throw in `fn` propagates with its own error and skips verification.

```ts
test("activates a schedule", () =>
  withFakeClient(async (client) => {
    client.api.schedule.activateV1.once(request, response);
    await schedule(params).activate(client, workflow, input);
  }));
```

## Breaking changes

`fakeClient()` is no longer exported from `@aikirun/testing`; tests go through `withFakeClient(fn)` instead of `using client = fakeClient()`.