### PR TITLE
`aikirun/cli` image and automatic docker-compose migrations

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -24,10 +24,13 @@ RUN bun install --frozen-lockfile
 
 COPY lib/ ./lib/
 COPY types/ ./types/
+COPY sdk/adapter/memory/ ./sdk/adapter/memory/
 COPY sdk/iam/ ./sdk/iam/
 COPY sdk/server/ ./sdk/server/
 COPY cli/ ./cli/
 COPY tsconfig.json ./
+
+RUN bunx tsc --noEmit
 
 # Building @aikirun/server and @aikirun/iam places their migration files in
 # dist/, where `aiki migrate apply` resolves them from the workspace packages

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,44 @@
+FROM oven/bun:1.3.4
+
+WORKDIR /aiki
+
+COPY package.json bun.lock ./
+COPY lib/package.json ./lib/
+COPY types/package.json ./types/
+COPY sdk/client/package.json ./sdk/client/
+COPY sdk/endpoint/package.json ./sdk/endpoint/
+COPY sdk/adapter/http/package.json ./sdk/adapter/http/
+COPY sdk/adapter/memory/package.json ./sdk/adapter/memory/
+COPY sdk/adapter/redis/package.json ./sdk/adapter/redis/
+COPY sdk/iam/package.json ./sdk/iam/
+COPY sdk/server/package.json ./sdk/server/
+COPY sdk/worker/package.json ./sdk/worker/
+COPY sdk/workflow/package.json ./sdk/workflow/
+COPY cli/package.json ./cli/
+COPY app/server/package.json ./app/server/
+COPY app/dashboard/package.json ./app/dashboard/
+COPY examples/package.json ./examples/
+COPY testing/package.json ./testing/
+
+RUN bun install --frozen-lockfile
+
+COPY lib/ ./lib/
+COPY types/ ./types/
+COPY sdk/iam/ ./sdk/iam/
+COPY sdk/server/ ./sdk/server/
+COPY cli/ ./cli/
+COPY tsconfig.json ./
+
+# Building @aikirun/server and @aikirun/iam places their migration files in
+# dist/, where `aiki migrate apply` resolves them from the workspace packages
+RUN bun run --cwd lib build \
+	&& bun run --cwd types build \
+	&& bun run --cwd sdk/server build \
+	&& bun run --cwd sdk/iam build \
+	&& bun run --cwd cli build
+
+RUN printf '#!/bin/sh\nexec bun /aiki/cli/dist/index.js "$@"\n' > /usr/local/bin/aiki \
+	&& chmod +x /usr/local/bin/aiki
+
+ENTRYPOINT ["aiki"]
+CMD ["--help"]

--- a/cli/src/commands/migrate-apply.ts
+++ b/cli/src/commands/migrate-apply.ts
@@ -22,7 +22,7 @@ export async function migrateApply(options: MigrateApplyOptions): Promise<void> 
 
 	switch (dbConfig.provider) {
 		case "pg":
-			await applyPg(dbConfig, migrationsFolder, migrationsTable, logger);
+			await applyPg(options.pkg, dbConfig, migrationsFolder, migrationsTable, logger);
 			break;
 		case "sqlite":
 		case "mysql":
@@ -33,6 +33,7 @@ export async function migrateApply(options: MigrateApplyOptions): Promise<void> 
 }
 
 async function applyPg(
+	pkg: SupportedPackage,
 	config: PgDatabaseConfig,
 	migrationsFolder: string,
 	migrationsTable: string,
@@ -84,7 +85,7 @@ async function applyPg(
 			});
 		}
 
-		logger.info("Migrations applied");
+		logger.info(`${pkg} migrations applied`);
 	} finally {
 		await client.end();
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: aikirun/cli
     container_name: aiki-migrate
     environment:
-      AIKI_SERVER_AUTH_SECRET: ${AIKI_SERVER_AUTH_SECRET:-}
+      AIKI_MIGRATE_PACKAGES: ${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}
@@ -16,11 +16,10 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - >-
-        aiki migrate apply --package server &&
-        if [ -n "$$AIKI_SERVER_AUTH_SECRET" ];
-        then aiki migrate apply --package iam;
-        else echo "AIKI_SERVER_AUTH_SECRET not set; skipping iam migrations";
-        fi
+        echo "migrating packages: $$AIKI_MIGRATE_PACKAGES" &&
+        for package in $$(echo "$$AIKI_MIGRATE_PACKAGES" | tr ',' ' ');
+        do aiki migrate apply --package "$$package" || exit 1;
+        done
 
   server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,27 @@
 services:
+  migrate:
+    build:
+      context: .
+      dockerfile: cli/Dockerfile
+    image: aikirun/cli
+    container_name: aiki-migrate
+    environment:
+      AIKI_SERVER_AUTH_SECRET: ${AIKI_SERVER_AUTH_SECRET:-}
+      DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
+      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
+      DATABASE_SSL: ${DATABASE_SSL:-false}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        aiki migrate apply --package server &&
+        if [ -n "$$AIKI_SERVER_AUTH_SECRET" ];
+        then aiki migrate apply --package iam;
+        else echo "AIKI_SERVER_AUTH_SECRET not set; skipping iam migrations";
+        fi
+
   server:
     build:
       context: .
@@ -7,6 +30,9 @@ services:
         AIKI_SERVER_PORT: ${AIKI_SERVER_PORT:-9850}
     image: aikirun/server
     container_name: aiki-server
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
     ports:
       - "${AIKI_SERVER_PORT:-9850}:${AIKI_SERVER_PORT:-9850}"
     environment:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,22 +1,24 @@
 # Installation
 
-Aiki's server is a library: you install the SDK packages into your project, apply the schema migration to your database, and choose where the server runs — in the same process as your app, in a process of its own, or as the bundled standalone server with a web dashboard.
+How you install Aiki depends on what you're doing:
 
-The install and migration steps are the same for every topology.
+- **Building workflows** — add the SDK to your TypeScript project and run the server embedded in your app, or point your app at a hosted Aiki server. Follow [Add Aiki to your project](#add-aiki-to-your-project).
+- **Hosting Aiki** — stand up the standalone server and web dashboard as infrastructure, with no SDK install. You need a PostgreSQL database, plus either Docker for the ready-made stack or Bun to run from source. Follow [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
 
-## Prerequisites
+## Add Aiki to your project
 
-- Node.js 18+ or Bun 1.0+
-- PostgreSQL 14+ (SQLite and MySQL coming soon)
+You need Node.js 18+ or Bun 1.0+, and a PostgreSQL 14+ database (SQLite and MySQL coming soon).
 
-## Install the SDK packages
+### Install the SDK packages
 
 ```bash
 npm install @aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server
 npm install --save-dev @aikirun/cli
 ```
 
-## Apply the schema migration
+### Apply the schema migration
+
+If your server will be the standalone stack from [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard), skip this step — that stack applies migrations itself when it starts.
 
 ```bash
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
@@ -25,26 +27,22 @@ DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
 
 Re-run this command when upgrading Aiki to apply new migrations.
 
-## Choose where the server runs
-
-Both shapes below run the same server, and workflow code is identical either way.
-
-### Embedded in your process
+### Run the server
 
 Mount `aikiServer.handler` in any HTTP framework — in the same process as your app, or in a process dedicated to Aiki. The [Quick Start](./quick-start.md) walks through this end-to-end, including worker and client.
 
-### Bundled standalone server + dashboard
+Workflow code is identical against an embedded or standalone server, so you can also skip embedding entirely and point your client at a server hosted per [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
 
-The repo ships a prebuilt server (`app/server`) and a web dashboard (`app/dashboard`), bundled in `docker-compose.yml`.
+## Run the standalone server and dashboard
 
-#### Run with Docker Compose
+The prebuilt server and dashboard ship as a ready-made stack, run from a clone of [aikirun/aiki](https://github.com/aikirun/aiki). With Docker, one command applies the migrations, starts the server, and serves the dashboard (a from-source variant without Docker follows below):
 
 ```bash
 git clone https://github.com/aikirun/aiki.git
 cd aiki
 ```
 
-Create a `.env` in the repo root with your database URL:
+Create a `.env` in the clone's root with your database URL:
 
 ```bash
 DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
@@ -57,17 +55,17 @@ docker-compose up -d
 - Server: http://localhost:9850
 - Dashboard: http://localhost:9851
 
-Point the client at the server's URL:
+Migrations are applied before the server starts. Re-running is safe; already-applied migrations are skipped.
+
+Applications connect by pointing their client at the server's URL:
 
 ```typescript
 const aikiClient = client({ url: "http://localhost:9850" });
 ```
 
-#### Run with Bun (no Docker)
+Prefer no Docker? The same stack runs from source (this path needs Bun):
 
 ```bash
-git clone https://github.com/aikirun/aiki.git
-cd aiki
 bun install
 cp app/server/.env.example app/server/.env
 # Edit app/server/.env with your DATABASE_URL
@@ -76,9 +74,36 @@ bun run server     # Terminal 1
 bun run dashboard  # Terminal 2
 ```
 
+## Run the dashboard on its own
+
+If you ran the standalone stack above, the dashboard is already up — skip this section. Run the dashboard separately when your server is embedded in your app or hosted elsewhere. It is a single-page app that calls the server from the browser, and there are two ways to serve it.
+
+### On a static host
+
+The right fit when the server is embedded in your app or hosted on its own. The server's URL is baked in at build time, so the dashboard is built per deployment (the build needs Bun) — from the release tag matching your installed `@aikirun/*` version:
+
+```bash
+git clone --branch v0.31.0 https://github.com/aikirun/aiki.git
+cd aiki
+bun install
+bun run build:types
+VITE_AIKI_SERVER_URL=https://aiki.example.com bun run build:dashboard
+```
+
+Deploy `app/dashboard/dist/` to any static file host, and add the dashboard's origin to the server's `CORS_ORIGINS`. A build that forgot `VITE_AIKI_SERVER_URL` fails loudly in the browser: the dashboard reaches no server, and its error screen names the variable.
+
+### As a Docker image
+
+The image needs no build-time configuration: nginx inside it serves the dashboard and proxies its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read at container start. Browser traffic stays on one origin, so no CORS setup is needed. From a clone of [aikirun/aiki](https://github.com/aikirun/aiki):
+
+```bash
+docker build -f app/dashboard/Dockerfile -t aikirun/dashboard .
+docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 aikirun/dashboard
+```
+
 ## Environment Variable Reference
 
-These apply to the bundled `app/server` and `app/dashboard`. If you embed the server in your own app, you control configuration directly via the `server({...})` factory and don't need these.
+These apply to the standalone server and the dashboard. If you embed the server in your own app, you control configuration directly via the `server({...})` factory and don't need these.
 
 ### Server
 
@@ -105,12 +130,9 @@ These apply to the bundled `app/server` and `app/dashboard`. If you embed the se
 |----------|----------|---------|-------------|
 | `AIKI_SERVER_UPSTREAM_URL` | If using the docker image | — | Server address the dashboard docker image proxies to; read at container start |
 | `AIKI_DASHBOARD_PORT` | No | `9851` | Port for the dashboard |
-| `VITE_AIKI_SERVER_URL` | If on a static host | — | Build-time server URL for a dashboard served outside the docker image (see below) |
+| `VITE_AIKI_SERVER_URL` | If on a static host | — | Build-time server URL for a dashboard served outside the docker image |
 
-The dashboard runs in one of two modes:
-
-- **Dashboard docker image.** nginx inside the image serves the dashboard and forwards its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read when the container starts. The bundled `docker-compose.yml` sets it for you; set it yourself when running the image directly. No build-time configuration is needed.
-- **Static host.** You build the dashboard and serve the files yourself, so the browser calls the server directly. Build with `VITE_AIKI_SERVER_URL` set to the server's URL, and add the dashboard's origin to the server's `CORS_ORIGINS`.
+Which variable applies depends on the deployment mode — see [Run the dashboard on its own](#run-the-dashboard-on-its-own). The bundled `docker-compose.yml` sets `AIKI_SERVER_UPSTREAM_URL` for you.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ npm install --save-dev @aikirun/cli
 
 ### Apply the schema migration
 
-If your server will be the standalone stack from [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard), skip this step — that stack applies migrations itself when it starts.
+If your server will be the standalone stack from [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard), skip this step — the Docker Compose path applies migrations itself on `up`, and the from-source instructions include their own migrate step.
 
 ```bash
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
@@ -35,7 +35,15 @@ Workflow code is identical against an embedded or standalone server, so you can 
 
 ## Run the standalone server and dashboard
 
-The prebuilt server and dashboard ship as a ready-made stack, run from a clone of [aikirun/aiki](https://github.com/aikirun/aiki). With Docker, one command applies the migrations, starts the server, and serves the dashboard (a from-source variant without Docker follows below):
+The stack is three containers:
+
+- **Migrate** — runs `aiki migrate apply --package server` and exits. Also runs `aiki migrate apply --package iam` if the server will run with auth (`AIKI_SERVER_AUTH_SECRET`). Needs `DATABASE_URL`.
+- **Server** — the Aiki server. Needs `DATABASE_URL`.
+- **Dashboard** — the web UI; proxies browser calls to the server set in `AIKI_SERVER_UPSTREAM_URL`.
+
+Start them in that order: migrate must finish before the server starts. You only need the migrate step on a fresh database or when an upgrade ships new migrations, but it is safe to run every time — already-applied migrations are skipped. Docker Compose is the easy path; one command does all of this.
+
+### With Docker Compose
 
 ```bash
 git clone https://github.com/aikirun/aiki.git
@@ -55,7 +63,7 @@ docker-compose up -d
 - Server: http://localhost:9850
 - Dashboard: http://localhost:9851
 
-Migrations are applied before the server starts. Re-running is safe; already-applied migrations are skipped.
+The migrate step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker-compose up -d`.
 
 Applications connect by pointing their client at the server's URL:
 
@@ -63,16 +71,23 @@ Applications connect by pointing their client at the server's URL:
 const aikiClient = client({ url: "http://localhost:9850" });
 ```
 
-Prefer no Docker? The same stack runs from source (this path needs Bun):
+### From source
+
+The same stack runs without Docker (this path needs Bun):
 
 ```bash
+git clone https://github.com/aikirun/aiki.git
+cd aiki
 bun install
 cp app/server/.env.example app/server/.env
 # Edit app/server/.env with your DATABASE_URL
 
-bun run server     # Terminal 1
-bun run dashboard  # Terminal 2
+bun run db:migrate:server   # the migrate step
+bun run server              # Terminal 1
+bun run dashboard           # Terminal 2
 ```
+
+Run `bun run db:migrate:iam` too when the server will run with auth. One piece differs from its container form: the dashboard here is a dev server, and the browser calls the Aiki server directly on `localhost:9850` — no proxy and no `AIKI_SERVER_UPSTREAM_URL` (the `.env.example` already allows the dashboard's origin through `CORS_ORIGINS`).
 
 ## Run the dashboard on its own
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -17,8 +17,8 @@ DATABASE_SSL=false
 ##########################################
 #    AIKI_EXAMPLE_MODE=remote
 ##########################################
-
 # AIKI_SERVER_URL=http://localhost:9850
+
 # Optional — only set it if the remote server requires API key auth
 # AIKI_API_KEY=yourApiKey
 


### PR DESCRIPTION
## Problem

Aiki's database migrations are applied by the `aiki` CLI: `aiki migrate apply --package <server|iam>`. It finds each package's migration files inside the installed `@aikirun/server` and `@aikirun/iam` packages. Migration is deliberately a separate step — the server never migrates itself. The iam package is the auth layer: the server only turns it on when `AIKI_SERVER_AUTH_SECRET` is set, and it has its own migrations, tracked separately from the server's.

Two gaps. The docker-compose stack (standalone server + dashboard) had no migration step — before `docker-compose up`, you had to apply migrations from a Node project with the SDK installed, a developer toolchain the hosting flow otherwise doesn't need. And there was no container form of the CLI, which the release pipeline needs to publish as `aikirun/cli`.

## Solution

**The `aikirun/cli` image.** A new Dockerfile builds the CLI image from the repo: install the workspace, then build the server, iam, and cli packages — building them is what puts the migration files where the CLI looks for them. Installing from npm instead wouldn't work: in the release pipeline, images are built and pushed before npm publish, so the version being released doesn't exist on npm yet. The image's entrypoint is `aiki`, so `docker run aikirun/cli migrate apply --package server` works like the command line.

**Compose migrates itself.** A migrate service runs first and exits; the server only starts after it succeeds. Which packages it applies comes from one variable, `AIKI_MIGRATE_PACKAGES` — a comma-separated list the container loops over. The default is computed by Compose on the host: `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set — the same condition under which the server turns iam on, so the database always matches what the server will run. Only the derived list reaches the migrate container, never the secret's value. The list can also be set explicitly, for example to create the iam tables before turning auth on. Re-running is safe — already-applied migrations are skipped — so enabling auth later is just setting the secret and running `up` again.

**The installation guide is reorganized around two audiences.** It now routes readers up front: developers adding Aiki to a project (Node/Bun, SDK packages, `npx aiki migrate apply`) versus operators hosting Aiki (a database plus Docker or Bun — no SDK, no npm). The manual migration step lives in the developer flow only. The hosting section first states what the stack is — three containers, and migrate must finish before the server starts — so it can be mapped onto any orchestrator, then presents Compose as the easy path and running from source as the alternative. The dashboard gets its own section (static host or Docker image) for people whose server is embedded or hosted elsewhere.

## Test plan

Use a scratch Postgres — `docker compose up` now applies migrations to whatever `DATABASE_URL` points at:

- `DATABASE_URL=... docker compose up -d --build`: migrate logs "migrating packages: server" and exits, then the server starts and `curl localhost:9850/health` answers.
- Same with `AIKI_SERVER_AUTH_SECRET` set: the log shows `server,iam` and the iam tables (`user`, `session`, `organization`, …) appear.
- `AIKI_MIGRATE_PACKAGES=server,bogus docker compose up migrate`: the CLI names the bad package and exits non-zero; the server does not start.

## Breaking changes

- `docker compose up` now applies database migrations automatically before starting the server.
