### PR TITLE
Standalone compose file pinned to released images

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,64 @@
+# Standalone Aiki stack — pulls the published images at a pinned version, so it
+# runs from an empty directory with no clone. Put a .env with your DATABASE_URL
+# next to this file, then: docker compose up -d
+#
+# The image tags are stamped by `bun run bump`; pick the file from a release tag
+# so the pinned version matches published images.
+services:
+  migrate:
+    image: aikirun/cli:0.31.0
+    container_name: aiki-migrate
+    environment:
+      AIKI_MIGRATE_PACKAGES: ${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}
+      DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
+      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
+      DATABASE_SSL: ${DATABASE_SSL:-false}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        echo "migrating packages: $$AIKI_MIGRATE_PACKAGES" &&
+        for package in $$(echo "$$AIKI_MIGRATE_PACKAGES" | tr ',' ' ');
+        do aiki migrate apply --package "$$package" || exit 1;
+        done
+
+  server:
+    image: aikirun/server:0.31.0
+    container_name: aiki-server
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - "${AIKI_SERVER_PORT:-9850}:${AIKI_SERVER_PORT:-9850}"
+    environment:
+      AIKI_SERVER_HOST: ${AIKI_SERVER_HOST:-0.0.0.0}
+      AIKI_SERVER_PORT: ${AIKI_SERVER_PORT:-9850}
+      AIKI_SERVER_BASE_URL: ${AIKI_SERVER_BASE_URL:-http://localhost:9850}
+      AIKI_SERVER_AUTH_SECRET: ${AIKI_SERVER_AUTH_SECRET:-}
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:9851}
+      DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
+      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
+      DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
+      DATABASE_SSL: ${DATABASE_SSL:-false}
+      REDIS_HOST: ${REDIS_HOST:-}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      PRETTY_LOGS: ${PRETTY_LOGS:-true}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  dashboard:
+    image: aikirun/dashboard:0.31.0
+    container_name: aiki-dashboard
+    ports:
+      - "${AIKI_DASHBOARD_PORT:-9851}:9851"
+    environment:
+      AIKI_SERVER_UPSTREAM_URL: http://server:${AIKI_SERVER_PORT:-9850}
+    depends_on:
+      - server
+    restart: unless-stopped

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,9 +1,10 @@
 // Lockstep version bump for the whole workspace.
 //
-// Sets every workspace package to the same version, then regenerates the
-// lockfile. The lockfile refresh is important: `bun publish` reads workspace
-// versions from it when rewriting `workspace:*` into concrete cross-package
-// pins, so a stale lockfile would publish packages pinned to old sibling versions.
+// Sets every workspace package to the same version, pins the standalone
+// docker compose file's image tags to it, then regenerates the lockfile.
+// The lockfile refresh is important: `bun publish` reads workspace versions
+// from it when rewriting `workspace:*` into concrete cross-package pins,
+// so a stale lockfile would publish packages pinned to old sibling versions.
 //
 // Usage:  bun run bump 0.31.0
 import { $ } from "bun";
@@ -21,6 +22,14 @@ for (const dir of workspaces) {
 	await Bun.write(path, text.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`));
 	console.log(`  ${dir} → ${version}`);
 }
+
+const standaloneComposePath = "deploy/docker-compose.yml";
+const standaloneComposeText = await Bun.file(standaloneComposePath).text();
+await Bun.write(
+	standaloneComposePath,
+	standaloneComposeText.replace(/(aikirun\/(?:cli|server|dashboard)):[\w.-]+/g, `$1:${version}`)
+);
+console.log(`  ${standaloneComposePath} → ${version}`);
 
 await $`rm -f bun.lock`;
 await $`bun install`;


### PR DESCRIPTION
`deploy/docker-compose.yml` runs the standalone stack from an empty directory: it pulls aikirun/cli, aikirun/server, and aikirun/dashboard at a pinned version, with no build contexts — same migrate/gate/dashboard shape as the repo compose. `bump.ts` stamps its image tags along with the workspace versions, so a release tag's file always pins that release's images.

The installation guide is unchanged on purpose: the download-one-file flow only becomes true once the release pipeline publishes images, so the docs switch ships with it.