### PR TITLE
Release pipeline: versioned artifacts from the tag, in CI

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,21 @@
+name: Setup workspace
+description: Install bun and the workspace dependencies, with the install cache
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.4
+
+    - name: Cache bun install
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      run: bun install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,20 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.4
-
-      - name: Cache bun install
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup-workspace
 
       - name: Typecheck
         run: bun run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
             echo "no aikirun image pins found in deploy/docker-compose.yml" >&2
             exit 1
           fi
-          stale="$(echo "$pins" | grep -v ":$version\$" || true)"
+          escaped_version="$(printf '%s' "$version" | sed 's/[.]/\\./g')"
+          stale="$(echo "$pins" | grep -v ":$escaped_version\$" || true)"
           if [ -n "$stale" ]; then
             echo "deploy/docker-compose.yml pins not at $version — run bun run bump:" >&2
             echo "$stale" >&2
@@ -123,9 +124,11 @@ jobs:
         if: matrix.image == 'dashboard'
         run: docker run --rm -e AIKI_SERVER_UPSTREAM_URL=http://smoke:9850 aikirun/dashboard:smoke nginx -t
 
-      - name: Smoke test cli
+      - name: Smoke test cli package resolution
         if: matrix.image == 'cli'
-        run: docker run --rm aikirun/cli:smoke --help
+        run: |
+          docker run --rm -e DATABASE_PROVIDER=pg aikirun/cli:smoke migrate list --package server
+          docker run --rm -e DATABASE_PROVIDER=pg aikirun/cli:smoke migrate list --package iam
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -159,6 +162,7 @@ jobs:
 
       - name: Migrate the hosted database
         env:
+          DATABASE_PROVIDER: pg
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           bun cli/dist/index.js migrate apply --package server
@@ -252,8 +256,9 @@ jobs:
       # made it through.
       - name: Publish npm packages
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           for dir in types sdk/workflow sdk/client sdk/adapter/redis sdk/worker sdk/endpoint sdk/server sdk/iam cli; do
             name="$(jq -r .name "$dir/package.json")"
             if npm view "$name@$VERSION" version > /dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,264 @@
+name: Release
+
+# Cutting a release: bun run bump <version>, commit, bun run tag, push with
+# --follow-tags. The verify job re-checks everything in CI — tags can be
+# created without the tag script, so CI stays the authority.
+#
+# Steps run in a fixed order with npm publish last — it is the only
+# irreversible step, so nothing a user installs ships until everything before
+# it succeeded. deploy-cloud is the hosted deployment's slice of the pipeline;
+# it is the part that would move out if hosting ever gets its own repo.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # Everything here runs before any side effect: a failure aborts the release
+  # with nothing pushed, migrated, or published.
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tag matches the lockstep version
+        id: version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          package_version="$(jq -r .version types/package.json)"
+          if [ "$version" != "$package_version" ]; then
+            echo "tag $GITHUB_REF_NAME does not match workspace version $package_version — run bun run bump" >&2
+            exit 1
+          fi
+          for dir in $(jq -r '.workspaces[]' package.json); do
+            v="$(jq -r .version "$dir/package.json")"
+            if [ "$v" != "$version" ]; then
+              echo "$dir is at $v, expected $version — run bun run bump" >&2
+              exit 1
+            fi
+          done
+          pins="$(grep -oE 'aikirun/[a-z]+:[A-Za-z0-9_.-]+' deploy/docker-compose.yml || true)"
+          if [ -z "$pins" ]; then
+            echo "no aikirun image pins found in deploy/docker-compose.yml" >&2
+            exit 1
+          fi
+          stale="$(echo "$pins" | grep -v ":$version\$" || true)"
+          if [ -n "$stale" ]; then
+            echo "deploy/docker-compose.yml pins not at $version — run bun run bump:" >&2
+            echo "$stale" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/setup-workspace
+
+      - run: bun run check
+
+      - run: bun run lint
+
+      - run: bun test
+
+      - run: bun run build:packages
+
+      # prove the migration files are inside the packages before anything ships anywhere.
+      - name: Verify packed tarballs contain migration files
+        run: |
+          for dir in sdk/server sdk/iam; do
+            tarball="$(cd "$dir" && bun pm pack --quiet | tail -n 1)"
+            if ! tar -tzf "$dir/$tarball" | grep -q "dist/infra/db/pg/migration/.*\.sql"; then
+              echo "$dir tarball is missing migration files" >&2
+              exit 1
+            fi
+            rm "$dir/$tarball"
+          done
+
+  images:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        include:
+          - image: server
+            dockerfile: app/server/Dockerfile
+          - image: dashboard
+            dockerfile: app/dashboard/Dockerfile
+          - image: cli
+            dockerfile: cli/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build for smoke test
+        if: matrix.image != 'server'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          load: true
+          tags: aikirun/${{ matrix.image }}:smoke
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+
+      - name: Smoke test dashboard nginx config
+        if: matrix.image == 'dashboard'
+        run: docker run --rm -e AIKI_SERVER_UPSTREAM_URL=http://smoke:9850 aikirun/dashboard:smoke nginx -t
+
+      - name: Smoke test cli
+        if: matrix.image == 'cli'
+        run: docker run --rm aikirun/cli:smoke --help
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            aikirun/${{ matrix.image }}:${{ needs.verify.outputs.version }}
+            aikirun/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+
+  # The hosted deployment: migrate its database, roll its server to the new
+  # image, publish its dashboard. Secrets and vars live in the release
+  # environment.
+  deploy-cloud:
+    needs: [verify, images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-workspace
+
+      - run: bun run build:packages
+
+      - name: Migrate the hosted database
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          bun cli/dist/index.js migrate apply --package server
+          bun cli/dist/index.js migrate apply --package iam
+
+      - name: Redeploy the hosted server
+        id: redeploy
+        run: |
+          response="$(curl -fsS -G --data-urlencode "imgURL=docker.io/aikirun/server:$VERSION" "${{ secrets.RENDER_DEPLOY_HOOK_URL }}")"
+          deploy_id="$(echo "$response" | jq -r '.deploy.id')"
+          if [ -z "$deploy_id" ] || [ "$deploy_id" = "null" ]; then
+            echo "deploy hook did not return a deploy id: $response" >&2
+            exit 1
+          fi
+          echo "deploy_id=$deploy_id" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the deploy to go live
+        run: |
+          for attempt in $(seq 1 90); do
+            status="$(curl -fsS --max-time 10 \
+              -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+              "https://api.render.com/v1/services/${{ vars.RENDER_SERVICE_ID }}/deploys/${{ steps.redeploy.outputs.deploy_id }}" \
+              | jq -r '.status')"
+            case "$status" in
+              live)
+                echo "deploy live after $attempt checks"
+                exit 0
+                ;;
+              build_failed|update_failed|canceled|deactivated)
+                echo "deploy ended in status $status" >&2
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "deploy never went live" >&2
+          exit 1
+
+      - name: Confirm the release version is serving
+        run: |
+          for attempt in $(seq 1 12); do
+            deployed="$(curl -fsS --max-time 5 "${{ vars.AIKI_SERVER_BASE_URL }}/capabilities" | jq -r .version 2>/dev/null || true)"
+            if [ "$deployed" = "$VERSION" ]; then
+              echo "hosted server reports $VERSION"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "hosted server does not report version $VERSION" >&2
+          exit 1
+
+      - name: Deploy the hosted dashboard to Cloudflare Pages
+        env:
+          VITE_AIKI_SERVER_URL: ${{ vars.AIKI_SERVER_BASE_URL }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          bun run build:dashboard
+          bunx wrangler@4 pages deploy app/dashboard/dist --project-name "${{ vars.CLOUDFLARE_PAGES_PROJECT }}"
+
+  # The public artifacts: the GitHub release and npm. npm is the commit point.
+  publish:
+    needs: [verify, deploy-cloud]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-workspace
+
+      - run: bun run build:packages
+
+      # The standalone compose file is attached as an asset so
+      # releases/latest/download/docker-compose.yml always serves the newest
+      # release's pins. Safe to re-run: upload replaces the asset.
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" deploy/docker-compose.yml --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes deploy/docker-compose.yml
+          fi
+
+      # Already-published packages are skipped so a re-run after a partial
+      # publish heals the gap instead of failing on the first package that
+      # made it through.
+      - name: Publish npm packages
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for dir in types sdk/workflow sdk/client sdk/adapter/redis sdk/worker sdk/endpoint sdk/server sdk/iam cli; do
+            name="$(jq -r .name "$dir/package.json")"
+            if npm view "$name@$VERSION" version > /dev/null 2>&1; then
+              echo "$name@$VERSION already published; skipping"
+              continue
+            fi
+            (cd "$dir" && bun publish --access public)
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: release
@@ -105,8 +106,9 @@ jobs:
 
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for smoke test
         if: matrix.image != 'server'
@@ -138,8 +140,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            aikirun/${{ matrix.image }}:${{ needs.verify.outputs.version }}
-            aikirun/${{ matrix.image }}:latest
+            ghcr.io/aikirun/${{ matrix.image }}:${{ needs.verify.outputs.version }}
+            ghcr.io/aikirun/${{ matrix.image }}:latest
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,scope=${{ matrix.image }},mode=max
 
@@ -171,7 +173,7 @@ jobs:
       - name: Redeploy the hosted server
         id: redeploy
         run: |
-          response="$(curl -fsS -G --data-urlencode "imgURL=docker.io/aikirun/server:$VERSION" "${{ secrets.RENDER_DEPLOY_HOOK_URL }}")"
+          response="$(curl -fsS -G --data-urlencode "imgURL=ghcr.io/aikirun/server:$VERSION" "${{ secrets.RENDER_DEPLOY_HOOK_URL }}")"
           deploy_id="$(echo "$response" | jq -r '.deploy.id')"
           if [ -z "$deploy_id" ] || [ "$deploy_id" = "null" ]; then
             echo "deploy hook did not return a deploy id: $response" >&2

--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ Above, the client invokes `aikiServer.handler` directly — no network hop. If t
 
 ### Bundled standalone server + dashboard
 
-Prefer to run the server in its own process with a web dashboard? The repo ships a standalone server (`app/server`) and dashboard (`app/dashboard`) in a `docker-compose.yml`:
+Prefer to run the server in its own process with a web dashboard? Download the standalone compose file from the latest release — it pulls prebuilt images, so there is nothing to clone or build:
 
 ```bash
-git clone https://github.com/aikirun/aiki.git && cd aiki
+mkdir aiki && cd aiki
+curl -fsSL https://github.com/aikirun/aiki/releases/latest/download/docker-compose.yml -o docker-compose.yml
 
 # Create a .env with your DATABASE_URL, then:
 docker-compose up -d

--- a/app/server/src/config/schema.ts
+++ b/app/server/src/config/schema.ts
@@ -5,7 +5,7 @@ import { logLevels } from "../logger";
 
 const coerceBool = type("'true' | 'false' | '1' | '0'").pipe((v) => v === "true" || v === "1");
 
-const uniqueCommaSeparatedToItems = type("string > 0").pipe((v) =>
+const uniqueCommaSeparatedToItems = type("string").pipe((v) =>
 	Array.from(
 		new Set(
 			v
@@ -30,7 +30,7 @@ export const configSchema = type({
 	host: "string > 0 = '0.0.0.0'",
 	port: "string.integer.parse | number.integer > 0 = 9850",
 	"baseURL?": "string > 0",
-	corsOrigins: uniqueCommaSeparatedToItems,
+	corsOrigins: uniqueCommaSeparatedToItems.default(""),
 	"redis?": redisConfigSchema.or(type("undefined")),
 	db: databaseConfigSchema,
 	"auth?": authConfigSchema.or(type("undefined")),

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.4
+FROM oven/bun:1.3.4 AS builder
 
 WORKDIR /aiki
 
@@ -39,6 +39,37 @@ RUN bun run --cwd lib build \
 	&& bun run --cwd sdk/server build \
 	&& bun run --cwd sdk/iam build \
 	&& bun run --cwd cli build
+
+FROM oven/bun:1.3.4-alpine
+
+WORKDIR /aiki
+
+COPY package.json bun.lock ./
+COPY lib/package.json ./lib/
+COPY types/package.json ./types/
+COPY sdk/client/package.json ./sdk/client/
+COPY sdk/endpoint/package.json ./sdk/endpoint/
+COPY sdk/adapter/http/package.json ./sdk/adapter/http/
+COPY sdk/adapter/memory/package.json ./sdk/adapter/memory/
+COPY sdk/adapter/redis/package.json ./sdk/adapter/redis/
+COPY sdk/iam/package.json ./sdk/iam/
+COPY sdk/server/package.json ./sdk/server/
+COPY sdk/worker/package.json ./sdk/worker/
+COPY sdk/workflow/package.json ./sdk/workflow/
+COPY cli/package.json ./cli/
+COPY app/server/package.json ./app/server/
+COPY app/dashboard/package.json ./app/dashboard/
+COPY examples/package.json ./examples/
+COPY testing/package.json ./testing/
+
+# --ignore-scripts: the root prepare script runs husky, a devDependency absent
+# from a production install; no runtime dependency here needs install scripts
+RUN bun install --frozen-lockfile --production --ignore-scripts --filter '@aikirun/cli'
+
+COPY --from=builder /aiki/types/dist ./types/dist
+COPY --from=builder /aiki/sdk/server/dist ./sdk/server/dist
+COPY --from=builder /aiki/sdk/iam/dist ./sdk/iam/dist
+COPY --from=builder /aiki/cli/dist ./cli/dist
 
 RUN printf '#!/bin/sh\nexec bun /aiki/cli/dist/index.js "$@"\n' > /usr/local/bin/aiki \
 	&& chmod +x /usr/local/bin/aiki

--- a/cli/src/commands/migrate-apply.ts
+++ b/cli/src/commands/migrate-apply.ts
@@ -1,10 +1,9 @@
-import path from "node:path";
 import type { Logger } from "@aikirun/lib/logger";
 import { createConsoleLogger } from "@aikirun/lib/logger";
 
 import { loadDatabaseConfig, type PgDatabaseConfig } from "../lib/db-config";
 import { loadEnv } from "../lib/env";
-import { resolvePackageRoot, type SupportedPackage } from "../lib/resolve-package";
+import { resolveMigrationsFolder, type SupportedPackage } from "../lib/resolve-package";
 
 interface MigrateApplyOptions {
 	pkg: SupportedPackage;
@@ -15,8 +14,7 @@ export async function migrateApply(options: MigrateApplyOptions): Promise<void> 
 	loadEnv(options.envFile);
 	const dbConfig = loadDatabaseConfig();
 
-	const packageRoot = resolvePackageRoot(options.pkg);
-	const migrationsFolder = path.join(packageRoot, "dist", "infra", "db", dbConfig.provider, "migration");
+	const migrationsFolder = resolveMigrationsFolder(options.pkg, dbConfig.provider);
 	const migrationsTable = `__drizzle_migrations__${options.pkg}`;
 	const logger = createConsoleLogger();
 

--- a/cli/src/commands/migrate-list.ts
+++ b/cli/src/commands/migrate-list.ts
@@ -1,0 +1,49 @@
+// biome-ignore-all lint/suspicious/noConsole: this prints command output, not logs
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadDatabaseProvider } from "../lib/db-config";
+import { loadEnv } from "../lib/env";
+import { resolveMigrationsFolder, type SupportedPackage } from "../lib/resolve-package";
+
+interface MigrateListOptions {
+	pkg: SupportedPackage;
+	envFile?: string;
+}
+
+interface JournalEntry {
+	tag: string;
+}
+
+interface Journal {
+	entries: JournalEntry[];
+}
+
+// Lists the migrations a package ships, reading only the migration journal —
+// no database connection.
+export async function migrateList(options: MigrateListOptions): Promise<void> {
+	loadEnv(options.envFile);
+	const provider = loadDatabaseProvider();
+
+	const migrationsFolder = resolveMigrationsFolder(options.pkg, provider);
+	const journalPath = path.join(migrationsFolder, "meta", "_journal.json");
+
+	let journalText: string;
+	try {
+		journalText = await fs.promises.readFile(journalPath, "utf8");
+	} catch {
+		throw new Error(
+			`no migration journal at ${journalPath} — the @aikirun/${options.pkg} build shipped without its ${provider} migrations`
+		);
+	}
+
+	const journal = JSON.parse(journalText) as Journal;
+	if (!Array.isArray(journal.entries)) {
+		throw new Error(`malformed migration journal at ${journalPath}`);
+	}
+
+	console.log(`@aikirun/${options.pkg} (${provider}): ${journal.entries.length} migration(s)`);
+	for (const entry of journal.entries) {
+		console.log(`  ${entry.tag}`);
+	}
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,10 +2,11 @@ import { cac } from "cac";
 
 import { migrateApply } from "./commands/migrate-apply";
 import { migrateGenerate } from "./commands/migrate-generate";
+import { migrateList } from "./commands/migrate-list";
 import { isSupportedPackage, SUPPORTED_PACKAGES, type SupportedPackage } from "./lib/resolve-package";
 import pkg from "../package.json" with { type: "json" };
 
-const MIGRATE_SUBCOMMANDS = ["apply", "generate"] as const;
+const MIGRATE_SUBCOMMANDS = ["apply", "generate", "list"] as const;
 type MigrateSubcommand = (typeof MIGRATE_SUBCOMMANDS)[number];
 
 function isMigrateSubcommand(value: string): value is MigrateSubcommand {
@@ -36,7 +37,7 @@ function requirePackage(value: string | undefined): SupportedPackage {
 const cli = cac("aiki");
 
 cli
-	.command("migrate [subcommand]", "Database migration commands (apply | generate)")
+	.command("migrate [subcommand]", "Database migration commands (apply | generate | list)")
 	.option(`--package <name>`, `Target package: ${SUPPORTED_PACKAGES.join(" | ")} (required)`)
 	.option("--custom", "Generate a custom SQL stub (only valid with `generate`)")
 	.option("--env-file <path>", "Path to env file")
@@ -60,6 +61,9 @@ cli
 				return;
 			case "generate":
 				await migrateGenerate({ pkg: targetPackage, custom: options.custom, envFile: options.envFile });
+				return;
+			case "list":
+				await migrateList({ pkg: targetPackage, envFile: options.envFile });
 				return;
 			default:
 				subcommand satisfies never;

--- a/cli/src/lib/resolve-package.ts
+++ b/cli/src/lib/resolve-package.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
+import type { DatabaseProvider } from "@aikirun/types/infra/db";
 
 const require = createRequire(import.meta.url);
 
@@ -23,4 +24,8 @@ export function resolvePackageRoot(pkg: SupportedPackage): string {
 	} catch {
 		throw new Error(`@aikirun/${pkg} is not installed. Install it as a dependency of your project.`);
 	}
+}
+
+export function resolveMigrationsFolder(pkg: SupportedPackage, provider: DatabaseProvider): string {
+	return path.join(resolvePackageRoot(pkg), "dist", "infra", "db", provider, "migration");
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       AIKI_SERVER_PORT: ${AIKI_SERVER_PORT:-9850}
       AIKI_SERVER_BASE_URL: ${AIKI_SERVER_BASE_URL:-http://localhost:9850}
       AIKI_SERVER_AUTH_SECRET: ${AIKI_SERVER_AUTH_SECRET:-}
-      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:9851}
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,7 +6,7 @@
 # so the pinned version matches published images.
 services:
   migrate:
-    image: aikirun/cli:0.31.0
+    image: ghcr.io/aikirun/cli:0.31.0
     container_name: aiki-migrate
     environment:
       AIKI_MIGRATE_PACKAGES: ${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}
@@ -25,7 +25,7 @@ services:
         done
 
   server:
-    image: aikirun/server:0.31.0
+    image: ghcr.io/aikirun/server:0.31.0
     container_name: aiki-server
     depends_on:
       migrate:
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   dashboard:
-    image: aikirun/dashboard:0.31.0
+    image: ghcr.io/aikirun/dashboard:0.31.0
     container_name: aiki-dashboard
     ports:
       - "${AIKI_DASHBOARD_PORT:-9851}:9851"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       AIKI_SERVER_PORT: ${AIKI_SERVER_PORT:-9850}
       AIKI_SERVER_BASE_URL: ${AIKI_SERVER_BASE_URL:-http://localhost:9850}
       AIKI_SERVER_AUTH_SECRET: ${AIKI_SERVER_AUTH_SECRET:-}
-      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:9851}
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: cli/Dockerfile
-    image: aikirun/cli
+    image: ghcr.io/aikirun/cli
     container_name: aiki-migrate
     environment:
       AIKI_MIGRATE_PACKAGES: ${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}
@@ -27,7 +27,7 @@ services:
       dockerfile: app/server/Dockerfile
       args:
         AIKI_SERVER_PORT: ${AIKI_SERVER_PORT:-9850}
-    image: aikirun/server
+    image: ghcr.io/aikirun/server
     container_name: aiki-server
     depends_on:
       migrate:
@@ -58,7 +58,7 @@ services:
     build:
       context: .
       dockerfile: app/dashboard/Dockerfile
-    image: aikirun/dashboard
+    image: ghcr.io/aikirun/dashboard
     container_name: aiki-dashboard
     ports:
       - "${AIKI_DASHBOARD_PORT:-9851}:9851"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -114,7 +114,7 @@ Deploy `app/dashboard/dist/` to any static file host, and add the dashboard's or
 The image needs no build-time configuration: nginx inside it serves the dashboard and proxies its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read at container start. Browser traffic stays on one origin, so no CORS setup is needed. Pick the version matching your server from the [releases](https://github.com/aikirun/aiki/releases):
 
 ```bash
-docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 aikirun/dashboard:<version>
+docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 ghcr.io/aikirun/dashboard:<version>
 ```
 
 ## Environment Variable Reference

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,12 +45,14 @@ Start them in that order: migrate must finish before the server starts. You only
 
 ### With Docker Compose
 
+Download the standalone compose file from the latest release into an empty directory — it pulls that release's published images, so there is nothing to clone or build:
+
 ```bash
-git clone https://github.com/aikirun/aiki.git
-cd aiki
+mkdir aiki && cd aiki
+curl -fsSL https://github.com/aikirun/aiki/releases/latest/download/docker-compose.yml -o docker-compose.yml
 ```
 
-Create a `.env` in the clone's root with your database URL:
+Create a `.env` next to it with your database URL:
 
 ```bash
 DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
@@ -73,10 +75,10 @@ const aikiClient = client({ url: "http://localhost:9850" });
 
 ### From source
 
-The same stack runs without Docker (this path needs Bun):
+The same stack runs without Docker (this path needs Bun). Clone at a release tag so you run released code:
 
 ```bash
-git clone https://github.com/aikirun/aiki.git
+git clone --branch v0.31.0 https://github.com/aikirun/aiki.git
 cd aiki
 bun install
 cp app/server/.env.example app/server/.env
@@ -109,11 +111,10 @@ Deploy `app/dashboard/dist/` to any static file host, and add the dashboard's or
 
 ### As a Docker image
 
-The image needs no build-time configuration: nginx inside it serves the dashboard and proxies its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read at container start. Browser traffic stays on one origin, so no CORS setup is needed. From a clone of [aikirun/aiki](https://github.com/aikirun/aiki):
+The image needs no build-time configuration: nginx inside it serves the dashboard and proxies its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read at container start. Browser traffic stays on one origin, so no CORS setup is needed. Pick the version matching your server from the [releases](https://github.com/aikirun/aiki/releases):
 
 ```bash
-docker build -f app/dashboard/Dockerfile -t aikirun/dashboard .
-docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 aikirun/dashboard
+docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 aikirun/dashboard:<version>
 ```
 
 ## Environment Variable Reference
@@ -132,7 +133,7 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `AIKI_SERVER_PORT` | No | `9850` | Server port |
 | `AIKI_SERVER_BASE_URL` | If IAM is on | — | Public URL of the server; required only when `AIKI_SERVER_AUTH_SECRET` is also set |
 | `AIKI_SERVER_AUTH_SECRET` | If IAM is on | — | Authentication secret; setting this (with `AIKI_SERVER_BASE_URL`) activates the IAM package |
-| `CORS_ORIGINS` | No | — | Comma-separated allowed origins for cross-origin requests |
+| `CORS_ORIGINS` | If the dashboard is cross-origin | — | Comma-separated allowed origins, e.g. a static-host dashboard's; unneeded behind the dashboard image's proxy |
 | `REDIS_HOST` | No | — | Enables Redis-backed work distribution and timer dispatch |
 | `REDIS_PORT` | No | `6379` | Redis port |
 | `REDIS_PASSWORD` | No | — | Redis password |

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"server:watch": "bun run --cwd app/server start:watch",
 		"dashboard": "bun run --cwd app/dashboard dev",
 		"bump": "bun scripts/bump.ts",
+		"tag": "bun scripts/tag.ts",
 		"clean": "rm -rf lib/dist types/dist app/server/dist app/dashboard/dist cli/dist sdk/*/dist sdk/adapter/*/dist sdk/iam/dist",
 		"build:lib": "bun run --cwd lib build",
 		"build:types": "bun run --cwd types build",
@@ -45,13 +46,12 @@
 		"build:cli": "bun run --cwd cli build",
 		"build:server": "bun run --cwd app/server build",
 		"build:dashboard": "bun run --cwd app/dashboard build",
-		"build:all": "bun run build:lib && bun run build:types && bun run build:sdk && bun run build:cli && bun run build:server && bun run build:dashboard",
+		"build:packages": "bun run build:lib && bun run build:types && bun run build:sdk && bun run build:cli",
+		"build:all": "bun run build:packages && bun run build:server && bun run build:dashboard",
 		"docker:build": "docker compose build",
 		"docker:up": "docker compose up -d",
 		"docker:down": "docker compose down",
 		"docker:logs": "docker compose logs -f",
-		"release": "bun run build:lib && bun run build:types && bun run build:sdk && bun run build:cli && bun run release:publish && git tag v$(bun -e \"console.log(require('./types/package.json').version)\") && git push && git push --tags",
-		"release:publish": "for pkg in types sdk/workflow sdk/client sdk/adapter/redis sdk/worker sdk/endpoint sdk/server sdk/iam cli; do (cd $pkg && bun publish --access public) || exit 1; done",
 		"prepare": "husky"
 	},
 	"lint-staged": {

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,7 +1,8 @@
 // Lockstep version bump for the whole workspace.
 //
 // Sets every workspace package to the same version, pins the standalone
-// docker compose file's image tags to it, then regenerates the lockfile.
+// docker compose file's image tags to it, updates the version in the
+// docs, then regenerates the lockfile.
 // The lockfile refresh is important: `bun publish` reads workspace versions
 // from it when rewriting `workspace:*` into concrete cross-package pins,
 // so a stale lockfile would publish packages pinned to old sibling versions.
@@ -25,11 +26,15 @@ for (const dir of workspaces) {
 
 const standaloneComposePath = "deploy/docker-compose.yml";
 const standaloneComposeText = await Bun.file(standaloneComposePath).text();
-await Bun.write(
-	standaloneComposePath,
-	standaloneComposeText.replace(/(aikirun\/(?:cli|server|dashboard)):[\w.-]+/g, `$1:${version}`)
-);
+await Bun.write(standaloneComposePath, standaloneComposeText.replace(/(aikirun\/[a-z]+):[\w.-]+/g, `$1:${version}`));
 console.log(`  ${standaloneComposePath} → ${version}`);
+
+const pinnedDocs = await $`grep -rl --include="*.md" -e "--branch v" docs README.md`.nothrow().quiet();
+for (const path of pinnedDocs.text().trim().split("\n").filter(Boolean)) {
+	const text = await Bun.file(path).text();
+	await Bun.write(path, text.replace(/--branch v[\w.-]+/g, `--branch v${version}`));
+	console.log(`  ${path} → ${version}`);
+}
 
 await $`rm -f bun.lock`;
 await $`bun install`;

--- a/scripts/tag.ts
+++ b/scripts/tag.ts
@@ -1,0 +1,59 @@
+// Creates the release tag after verifying the checkout is releasable: clean
+// tree, on main, every workspace package at the same version, the standalone
+// compose file's image pins stamped to it, and the tag not already taken.
+// CI's verify job repeats these checks — tags can be created without this
+// script, so CI stays the authority.
+//
+// Usage:  bun run tag   (then: git push --follow-tags)
+import { $ } from "bun";
+
+const status = (await $`git status --porcelain`.text()).trim();
+if (status !== "") {
+	console.error("working tree is not clean — commit or stash first");
+	process.exit(1);
+}
+
+const branch = (await $`git branch --show-current`.text()).trim();
+if (branch !== "main") {
+	console.error(`on branch ${branch} — releases are tagged from main`);
+	process.exit(1);
+}
+
+const { version } = (await Bun.file("types/package.json").json()) as { version: string };
+
+const { workspaces } = (await Bun.file("package.json").json()) as { workspaces: string[] };
+const mismatchedPackages: string[] = [];
+for (const dir of workspaces) {
+	const workspacePackage = (await Bun.file(`${dir}/package.json`).json()) as { version?: string };
+	if (workspacePackage.version !== version) {
+		mismatchedPackages.push(`${dir} is at ${workspacePackage.version}`);
+	}
+}
+if (mismatchedPackages.length > 0) {
+	console.error(`workspace versions are not all ${version} — run bun run bump`);
+	for (const mismatch of mismatchedPackages) {
+		console.error(`  ${mismatch}`);
+	}
+	process.exit(1);
+}
+
+const composeText = await Bun.file("deploy/docker-compose.yml").text();
+const pins = composeText.match(/aikirun\/[a-z]+:[\w.-]+/g) ?? [];
+const stalePins = pins.filter((pin) => !pin.endsWith(`:${version}`));
+if (pins.length === 0 || stalePins.length > 0) {
+	console.error(`deploy/docker-compose.yml pins are not at ${version} — run bun run bump`);
+	for (const pin of stalePins) {
+		console.error(`  ${pin}`);
+	}
+	process.exit(1);
+}
+
+const tag = `v${version}`;
+const existing = await $`git rev-parse --quiet --verify refs/tags/${tag}`.nothrow().quiet();
+if (existing.exitCode === 0) {
+	console.error(`tag ${tag} already exists`);
+	process.exit(1);
+}
+
+await $`git tag ${tag}`;
+console.log(`created ${tag} — push with: git push --follow-tags`);

--- a/sdk/server/src/capabilities.ts
+++ b/sdk/server/src/capabilities.ts
@@ -1,4 +1,5 @@
 export interface Capabilities {
+	version: string;
 	iam: {
 		dashboard: boolean;
 	};

--- a/sdk/server/src/handler.ts
+++ b/sdk/server/src/handler.ts
@@ -19,6 +19,7 @@ import { createWorkflowService } from "./service/workflow";
 import { createWorkflowRunService } from "./service/workflow-run";
 import { createWorkflowRunOutboxService } from "./service/workflow-run-outbox";
 import { createWorkflowRunStateMachineService } from "./service/workflow-run-state-machine";
+import packageJson from "../package.json";
 
 export interface CreateHandlerParams {
 	db: Database;
@@ -98,6 +99,7 @@ export async function createHandler(params: CreateHandlerParams) {
 				return new Response("Method Not Allowed", { status: 405 });
 			}
 			return Response.json({
+				version: packageJson.version,
 				iam: { dashboard: dashboardIam !== undefined },
 			} satisfies Capabilities);
 		}


### PR DESCRIPTION
## Problem

Releasing Aiki today is a local script: build, publish npm from the laptop, then tag and push. The server, dashboard, and cli images exist only as Dockerfiles users build from a clone, and the standalone compose file from #60 pins image versions no registry serves. Meanwhile Aiki's hosted deployment (server on Render, dashboard on Cloudflare Pages) deploys from `main`, so a user on a released SDK can talk to a server running unreleased code. And the script has no guardrails: npm publish runs before anything checks the release as a whole.

## Solution

Pushing a `v*` tag now runs a Release workflow that publishes everything at that version. The steps are ordered so npm publish comes last: nothing a user can install ships until everything else succeeded. Four jobs:

- **verify** — all the side-effect-free checks, first. The tag matches the lockstep version, every workspace package agrees, the compose file's image pins match. Then check, lint, tests, builds, and a pack-and-inspect of the server and iam tarballs to prove the migration scripts ship inside them. A failure here means nothing was pushed, migrated, or published.
- **images** — builds and pushes the three images for amd64 and arm64, tagged with the version and `latest`. Some are smoke-tested locally before pushing (the dashboard's nginx config renders and validates, the cli resolves its packages and lists its bundled migrations), so a broken image dies on the CI runner, not on container start.
- **deploy-cloud** — the hosted deployment's slice, in a protected `release` environment so production secrets exist only on tag runs. It migrates the hosted database, triggers Render's deploy hook with the exact image version, waits until that specific deploy is live, then confirms the public URL reports the new version. Finally it builds and uploads the dashboard to Cloudflare Pages.
- **publish** — creates the GitHub release with the standalone compose file attached, so `releases/latest/download/docker-compose.yml` always serves the newest release's pins — the docs curl that URL, so they carry no version number. Then npm publish, skipping packages already published at this version, so a re-run heals a partial publish instead of failing.

A mid-run failure can leave images public before npm publishes. That is the safe direction — a newer server serves older SDKs — and a re-run overwrites by tag.

**Cutting a release** is now: `bun run bump <version>` → commit → `bun run tag` → `git push --follow-tags`. The tag script refuses on a dirty tree, a branch other than main, mixed workspace versions, stale compose pins, or an existing tag. CI re-checks all of it, since tags can be created without the script. `bump` also stamps the compose pins and the docs' `--branch` clone commands, so pinned instructions can't go stale.

**Changes the pipeline forced:**

- The cli image is two-stage: built output plus a production install on alpine — 300MB, down from 780MB.
- `aiki migrate list` enumerates a package's bundled migrations. It is the cli image's smoke target — proving in-image package resolution and that the migration files shipped.
- `/capabilities` now includes the server's version. That is what makes the deploy check meaningful.
- `CORS_ORIGINS` is optional. The schema required it, forcing even the proxied (same-origin) dashboard setup to invent a value just to boot. It now defaults to no allowed origins; only a cross-origin dashboard sets it. Both compose files drop their localhost default.
- The bun setup, cache, and install steps are one shared composite action used by the PR and release workflows.
- The docs describe the released world: download-one-file compose flow, tag-pinned clones, `docker run` for the dashboard image. These become true when the first tag runs — merge and first release should be close together.

## Breaking changes

- The `release` and `release:publish` scripts are removed; releases are cut by tag push.
- The compose files no longer default `CORS_ORIGINS` to `http://localhost:9851`; a cross-origin dashboard must set it explicitly.