### PR TITLE
Escape backslashes in workflow name prefix LIKE pattern

### DIFF
--- a/sdk/server/src/infra/db/pg/repository/workflow.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow.ts
@@ -146,7 +146,7 @@ export function createWorkflowRepository(db: PgDb) {
 
 			const namePrefixCondition =
 				namePrefix !== undefined
-					? like(workflow.name, `${namePrefix.replace(/%/g, "\\%").replace(/_/g, "\\_")}%`)
+					? like(workflow.name, `${namePrefix.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")}%`)
 					: undefined;
 
 			const items = await db


### PR DESCRIPTION
The namePrefix sanitizer escaped % and _ but not the escape character itself. A user-supplied backslash could pair with an inserted escape and re-arm a wildcard (\% became literal-backslash + live %), or a trailing backslash could swallow the appended % and turn the prefix search into an exact match. Escape backslashes first, then the wildcards.

Fixes the code scanning alert: Incomplete string escaping or encoding.