### PR TITLE
Guard objectOverrider paths against prototype pollution

### DIFF
--- a/lib/src/object/overrider.test.ts
+++ b/lib/src/object/overrider.test.ts
@@ -79,4 +79,37 @@ describe("objectOverrider", () => {
 		expect(result.metadata?.label).toBe("important");
 		expect(result.metadata?.priority).toBeUndefined();
 	});
+
+	describe("prototype pollution guard", () => {
+		// PathFromObject rejects these paths at compile time; widening models a plain-JavaScript caller
+		const untypedBuilder = () =>
+			testObjectOverrider() as unknown as { with(path: string, value: unknown): { build(): TestObject } };
+
+		test("throws when a path segment is __proto__", () => {
+			expect(() => untypedBuilder().with("__proto__.injected", true).build()).toThrow(
+				'Cannot set path "__proto__.injected": segment "__proto__" is not allowed'
+			);
+		});
+
+		test("throws when a path segment is constructor", () => {
+			expect(() => untypedBuilder().with("constructor.prototype.injected", true).build()).toThrow(
+				'Cannot set path "constructor.prototype.injected": segment "constructor" is not allowed'
+			);
+		});
+
+		test("throws when a path segment is prototype", () => {
+			expect(() => untypedBuilder().with("metadata.prototype", true).build()).toThrow(
+				'Cannot set path "metadata.prototype": segment "prototype" is not allowed'
+			);
+		});
+
+		test("does not pollute Object.prototype when a hostile path is attempted", () => {
+			try {
+				untypedBuilder().with("__proto__.injected", true).build();
+			} catch {
+				// the guard throws; this test only asserts the absence of pollution
+			}
+			expect(({} as Record<string, unknown>).injected).toBeUndefined();
+		});
+	});
 });

--- a/lib/src/object/overrider.ts
+++ b/lib/src/object/overrider.ts
@@ -1,11 +1,19 @@
 import type { NonArrayObject, PathFromObject, TypeOfValueAtPath } from "./types";
 
+const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 /**
  * Sets a value at a dot-notation path in an object.
  * Mutates the object in place.
  */
 function set(obj: Record<string, unknown>, path: string, value: unknown): void {
 	const keys = path.split(".");
+
+	for (const key of keys) {
+		if (FORBIDDEN_KEYS.has(key)) {
+			throw new Error(`Cannot set path "${path}": segment "${key}" is not allowed`);
+		}
+	}
 	let currentValue: Record<string, unknown> = obj;
 
 	for (let i = 0; i < keys.length - 1; i++) {


### PR DESCRIPTION
The dot-path set() walked into any segment, so a path like __proto__.x or constructor.prototype.x would step out of the cloned object and assign onto the shared Object.prototype. Typed callers cannot produce such paths (PathFromObject excludes them), but the utility is generic and types vanish at runtime, so the guard belongs in set() itself: it now throws on __proto__, constructor, and prototype segments.

Tests cover all three segments and assert Object.prototype stays clean; verified they fail against the unguarded implementation.

Fixes the code scanning alert: Prototype-polluting function.