### PR TITLE
Resolve redirect param against origin to close open-redirect bypass

### DIFF
--- a/app/dashboard/src/auth/redirect.test.ts
+++ b/app/dashboard/src/auth/redirect.test.ts
@@ -1,0 +1,39 @@
+import { getSafeRedirect } from "./redirect";
+import { describe, expect, test } from "bun:test";
+
+const origin = "https://dashboard.example.com";
+
+describe("getSafeRedirect", () => {
+	test("returns a same-origin path", () => {
+		expect(getSafeRedirect("?redirect=%2Finvitations%2Fabc", origin)).toBe("/invitations/abc");
+	});
+
+	test("preserves query and hash on the redirect path", () => {
+		expect(getSafeRedirect("?redirect=%2Fruns%3Ftab%3Devents%23latest", origin)).toBe("/runs?tab=events#latest");
+	});
+
+	test("returns null when the param is absent", () => {
+		expect(getSafeRedirect("", origin)).toBeNull();
+		expect(getSafeRedirect("?other=value", origin)).toBeNull();
+	});
+
+	test("rejects absolute URLs", () => {
+		expect(getSafeRedirect("?redirect=https%3A%2F%2Fevil.example.net%2Fphish", origin)).toBeNull();
+	});
+
+	test("rejects same-origin absolute URLs (only paths are allowed)", () => {
+		expect(getSafeRedirect(`?redirect=${encodeURIComponent(`${origin}/runs`)}`, origin)).toBeNull();
+	});
+
+	test("rejects protocol-relative URLs", () => {
+		expect(getSafeRedirect("?redirect=%2F%2Fevil.example.net%2Fphish", origin)).toBeNull();
+	});
+
+	test("rejects backslash protocol-relative URLs", () => {
+		expect(getSafeRedirect("?redirect=%2F%5Cevil.example.net", origin)).toBeNull();
+	});
+
+	test("rejects javascript: URLs", () => {
+		expect(getSafeRedirect("?redirect=javascript%3Aalert(1)", origin)).toBeNull();
+	});
+});

--- a/app/dashboard/src/auth/redirect.ts
+++ b/app/dashboard/src/auth/redirect.ts
@@ -1,0 +1,20 @@
+/**
+ * Extracts the `redirect` query param and returns it only when it resolves to a
+ * same-origin path, preventing open-redirect phishing.
+ */
+export function getSafeRedirect(search: string, origin: string = window.location.origin): string | null {
+	const redirectParam = new URLSearchParams(search).get("redirect");
+	if (!redirectParam?.startsWith("/")) {
+		return null;
+	}
+
+	try {
+		const resolved = new URL(redirectParam, origin);
+		if (resolved.origin !== origin) {
+			return null;
+		}
+		return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+	} catch {
+		return null;
+	}
+}

--- a/app/dashboard/src/pages/auth/SignIn.tsx
+++ b/app/dashboard/src/pages/auth/SignIn.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../auth/AuthProvider";
 import { authClient } from "../../auth/client";
+import { getSafeRedirect } from "../../auth/redirect";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { FormInput } from "../../components/auth/FormInput";
 
@@ -11,9 +12,7 @@ export function SignIn() {
 	const location = useLocation();
 	const { refetchSession } = useAuth();
 
-	// Extract and validate the redirect param — only allow same-origin paths to prevent open redirect
-	const redirectParam = new URLSearchParams(location.search).get("redirect");
-	const safeRedirect = redirectParam?.startsWith("/") ? redirectParam : null;
+	const safeRedirect = getSafeRedirect(location.search);
 
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");

--- a/app/dashboard/src/pages/auth/SignUp.tsx
+++ b/app/dashboard/src/pages/auth/SignUp.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 
 import { createNamespace } from "../../api/client";
 import { authClient } from "../../auth/client";
+import { getSafeRedirect } from "../../auth/redirect";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { FormInput } from "../../components/auth/FormInput";
 
@@ -19,9 +20,7 @@ function generatePersonalSlug(email: string): string {
 
 export function SignUp() {
 	const location = useLocation();
-	// Extract and validate the redirect param — only allow same-origin paths to prevent open redirect
-	const redirectParam = new URLSearchParams(location.search).get("redirect");
-	const safeRedirect = redirectParam?.startsWith("/") ? redirectParam : null;
+	const safeRedirect = getSafeRedirect(location.search);
 
 	const [name, setName] = useState("");
 	const [email, setEmail] = useState("");

--- a/app/dashboard/tsconfig.json
+++ b/app/dashboard/tsconfig.json
@@ -26,7 +26,7 @@
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedSideEffectImports": true,
-		"types": ["vite/client"]
+		"types": ["vite/client", "bun-types"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
The sign-in/sign-up redirect guard only checked startsWith("/"), which protocol-relative URLs pass: //evil.com and /\evil.com (backslashes are normalized to slashes) both start with / yet navigate off-origin when assigned to window.location. A crafted sign-up link could send a user to a phishing page right after they typed their password.

Both pages now share getSafeRedirect, which resolves the param with new URL(param, origin) — the same algorithm the browser applies at navigation — accepts it only when the resolved origin matches, and returns the re-serialized path. Tests cover accept and bypass cases; the bypass tests fail against the old startsWith check. bun-types added to the dashboard tsconfig for its first test file.

Fixes the code scanning alert: Client-side URL redirect.