### PR TITLE
Inline the prototype pollution guard so CodeQL recognizes it

### DIFF
--- a/lib/src/object/overrider.ts
+++ b/lib/src/object/overrider.ts
@@ -1,23 +1,21 @@
 import type { NonArrayObject, PathFromObject, TypeOfValueAtPath } from "./types";
 
-const FORBIDDEN_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
 /**
  * Sets a value at a dot-notation path in an object.
  * Mutates the object in place.
+ *
+ * The guards against __proto__/constructor/prototype segments prevent prototype
+ * pollution.
  */
 function set(obj: Record<string, unknown>, path: string, value: unknown): void {
 	const keys = path.split(".");
-
-	for (const key of keys) {
-		if (FORBIDDEN_KEYS.has(key)) {
-			throw new Error(`Cannot set path "${path}": segment "${key}" is not allowed`);
-		}
-	}
 	let currentValue: Record<string, unknown> = obj;
 
 	for (let i = 0; i < keys.length - 1; i++) {
 		const key = keys[i] as string;
+		if (key === "__proto__" || key === "constructor" || key === "prototype") {
+			throw new Error(`Cannot set path "${path}": segment "${key}" is not allowed`);
+		}
 		let nextValue = currentValue[key];
 		if (nextValue === undefined || nextValue === null) {
 			nextValue = {};
@@ -27,6 +25,9 @@ function set(obj: Record<string, unknown>, path: string, value: unknown): void {
 	}
 
 	const lastKey = keys[keys.length - 1] as string;
+	if (lastKey === "__proto__" || lastKey === "constructor" || lastKey === "prototype") {
+		throw new Error(`Cannot set path "${path}": segment "${lastKey}" is not allowed`);
+	}
 	currentValue[lastKey] = value;
 }
 


### PR DESCRIPTION
The alert stayed open after the Set-based guard merged: CodeQL only recognizes the sanitizer as an equality check on the same variable that indexes the write, dominating it. Replace the pre-walk Set lookup with inline __proto__/constructor/prototype comparisons directly before each of the two property writes. Behavior is unchanged and the existing guard tests pass as-is; the payoff is that the scanner re-proves the guard on every scan and reopens the alert if it is ever removed.