### PR TITLE
Skip own __proto__ keys when merging

### DIFF
--- a/lib/src/object/merge.test.ts
+++ b/lib/src/object/merge.test.ts
@@ -65,4 +65,13 @@ describe("merge", () => {
 		const result = merge(defaults, { b: { z: 30 } });
 		expect(result).toEqual({ a: { x: 1, y: 2 }, b: { z: 30 } });
 	});
+
+	test("ignores an own __proto__ key in JSON-sourced overrides", () => {
+		const defaults = { label: "default" };
+		const overrides = JSON.parse('{"label": "custom", "__proto__": {"injected": true}}') as Partial<typeof defaults>;
+		const result = merge(defaults, overrides);
+		expect(result).toEqual({ label: "custom" });
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+		expect((result as Record<string, unknown>).injected).toBeUndefined();
+	});
 });

--- a/lib/src/object/merge.ts
+++ b/lib/src/object/merge.ts
@@ -14,6 +14,9 @@ function mergeValues(defaults: unknown, overrides: unknown): unknown {
 
 	const result: Record<string, unknown> = { ...defaults };
 	for (const key of Object.keys(overrides)) {
+		if (key === "__proto__") {
+			continue;
+		}
 		const overrideValue = overrides[key];
 		if (overrideValue === undefined) {
 			continue;


### PR DESCRIPTION
merge builds a fresh result at each level and iterates own keys only, so it cannot write onto the shared Object.prototype. But JSON.parse can produce an own __proto__ key in overrides, and assigning it fires the inherited setter and replaces the merged result's prototype — missing keys would then resolve through the override-shaped prototype. Since merge is the config engine and dynamic config arrives at runtime, skip the key. constructor needs no guard here: writing it on the fresh result is an inert own-property shadow.

Test feeds JSON-parsed overrides with an own __proto__ key; it fails against the unguarded implementation.