### PR TITLE
Polish run & schedule metadata rows and runs-list back nav

### DIFF
--- a/app/dashboard/src/components/run-detail/ExecutionTab.tsx
+++ b/app/dashboard/src/components/run-detail/ExecutionTab.tsx
@@ -231,10 +231,13 @@ const TaskCard = memo(function TaskCard({ task, scrollTo }: { task: TaskInfo; sc
 						)}
 					</div>
 					<div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 1 }}>
-						<span style={{ fontFamily: "var(--mono)", fontSize: 9.5, color: "var(--t3)" }}>{shortId(task.id)}</span>
+						<span style={{ fontFamily: "var(--mono)", fontSize: 9.5, color: "var(--t3)" }}>ID: {shortId(task.id)}</span>
 						<CopyButton text={task.id} />
+						<span style={{ fontSize: 9.5, color: "var(--t1)", fontWeight: 700, marginLeft: -2, marginRight: 2 }}>
+							•
+						</span>
 						<span style={{ fontFamily: "var(--mono)", fontSize: 9.5, color: "var(--t3)" }}>
-							· {shortId(task.inputHash)}
+							HASH: {shortId(task.inputHash)}
 						</span>
 						<CopyButton text={task.inputHash} />
 					</div>

--- a/app/dashboard/src/components/runs/RunRow.tsx
+++ b/app/dashboard/src/components/runs/RunRow.tsx
@@ -68,29 +68,36 @@ export function RunRow({ run }: RunRowProps) {
 
 				{/* Line 2: short ID + copy, reference ID + copy, task counts */}
 				<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-					<div style={{ display: "flex", alignItems: "center", gap: 2 }}>
-						<span style={{ fontFamily: "monospace", fontSize: 10, color: "var(--t3)" }}>{run.id.slice(-6)}</span>
+					<div style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
+						<span style={{ fontFamily: "monospace", fontSize: 10, color: "var(--t3)", whiteSpace: "nowrap" }}>
+							ID: {run.id.slice(-6)}
+						</span>
 						<CopyButton text={run.id} />
 					</div>
 
 					{run.referenceId ? (
-						<div style={{ display: "flex", alignItems: "center", gap: 2, minWidth: 0 }}>
-							<span
-								style={{
-									fontFamily: "monospace",
-									fontSize: 10,
-									color: "var(--t2)",
-									overflow: "hidden",
-									textOverflow: "ellipsis",
-									whiteSpace: "nowrap",
-									maxWidth: 120,
-								}}
-								title={run.referenceId}
-							>
-								{run.referenceId}
+						<>
+							<span style={{ color: "var(--t1)", fontSize: 10, fontWeight: 700, marginLeft: -2, marginRight: 2 }}>
+								•
 							</span>
-							<CopyButton text={run.referenceId} />
-						</div>
+							<div style={{ display: "flex", alignItems: "center", gap: 2, minWidth: 0 }}>
+								<span
+									style={{
+										fontFamily: "monospace",
+										fontSize: 10,
+										color: "var(--t3)",
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+										maxWidth: 120,
+									}}
+									title={run.referenceId}
+								>
+									REF: {run.referenceId}
+								</span>
+								<CopyButton text={run.referenceId} />
+							</div>
+						</>
 					) : null}
 
 					{run.taskCounts && <TaskSummaryBar taskCounts={run.taskCounts} />}

--- a/app/dashboard/src/hooks/useElementWidth.ts
+++ b/app/dashboard/src/hooks/useElementWidth.ts
@@ -1,0 +1,27 @@
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+/**
+ * Measures an element's own width via ResizeObserver, so responsive decisions can be based on the
+ * actual rendered width rather than the viewport (which is a poor proxy when a sidebar eats space).
+ * Starts at Infinity so content shows until the first measurement lands.
+ */
+export function useElementWidth<T extends HTMLElement>(): [RefObject<T>, number] {
+	const ref = useRef<T>(null);
+	const [width, setWidth] = useState(Number.POSITIVE_INFINITY);
+
+	useEffect(() => {
+		const element = ref.current;
+		if (!element) {
+			return;
+		}
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				setWidth(entry.contentRect.width);
+			}
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, []);
+
+	return [ref, width];
+}

--- a/app/dashboard/src/pages/RunDetail.tsx
+++ b/app/dashboard/src/pages/RunDetail.tsx
@@ -102,6 +102,7 @@ function Meta({ label, children }: MetaProps) {
 export function RunDetail() {
 	const { id } = useParams<{ id: string }>();
 	const [searchParams, setSearchParams] = useSearchParams();
+	const runsListSearch = sessionStorage.getItem("runsListSearch") ?? "";
 	const queryClient = useQueryClient();
 	const [actionLoading, setActionLoading] = useState<string | null>(null);
 	const [actionError, setActionError] = useState<string | null>(null);
@@ -222,7 +223,7 @@ export function RunDetail() {
 			{/* Nav bar */}
 			<div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 14 }}>
 				<Link
-					to="/"
+					to={{ pathname: "/", search: runsListSearch }}
 					style={{
 						background: "var(--s2)",
 						border: "1px solid var(--b0)",

--- a/app/dashboard/src/pages/RunsList.tsx
+++ b/app/dashboard/src/pages/RunsList.tsx
@@ -1,5 +1,5 @@
 import type { WorkflowRunStatus } from "@aikirun/types/workflow/run";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { useWorkflowRuns } from "../api/hooks";
@@ -24,6 +24,11 @@ export function RunsList() {
 	});
 
 	const page = Number(searchParams.get("page") ?? "0");
+
+	// Remember the current filtered URL so the run-detail "← Runs" link can return here with filters intact.
+	useEffect(() => {
+		sessionStorage.setItem("runsListSearch", searchParams.toString());
+	}, [searchParams]);
 
 	// Debounced values for API
 	const debouncedId = useDebounce(idFilter, 500);

--- a/app/dashboard/src/pages/SchedulesList.tsx
+++ b/app/dashboard/src/pages/SchedulesList.tsx
@@ -10,6 +10,7 @@ import { CopyButton } from "../components/common/CopyButton";
 import { WorkflowSearchInput } from "../components/runs/WorkflowSearchInput";
 import { SCHEDULE_STATUS_CONFIG } from "../constants/schedule-status";
 import { useDebounce } from "../hooks/useDebounce";
+import { useElementWidth } from "../hooks/useElementWidth";
 
 const ALL_SCHEDULE_STATUSES: ScheduleStatus[] = ["active", "paused", "deleted"];
 const PAGE_SIZE = 25;
@@ -452,6 +453,9 @@ function ScheduleRow({
 	onAction: (action: "pause" | "resume" | "delete", id: string) => void;
 }) {
 	const [open, setOpen] = useState(false);
+	const [rowRef, rowWidth] = useElementWidth<HTMLDivElement>();
+	const showRef = rowWidth >= 480;
+	const showOverlap = rowWidth >= 380;
 	const spec = schedule.spec;
 	const isCron = spec.type === "cron";
 	const specLabel = spec.type === "cron" ? spec.expression : `every ${fmtMs(spec.everyMs)}`;
@@ -462,7 +466,7 @@ function ScheduleRow({
 	};
 
 	return (
-		<div className="anim-in" style={{ animationDelay: `${idx * 30}ms` }}>
+		<div ref={rowRef} className="anim-in" style={{ animationDelay: `${idx * 30}ms` }}>
 			{/* Collapsed row */}
 			<button
 				type="button"
@@ -520,38 +524,39 @@ function ScheduleRow({
 							</span>
 						</div>
 
-						{/* Line 2: short ID, ref, run count, overlap */}
+						{/* Line 2: short ID, ref, overlap */}
 						<div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 10.5, color: "var(--t3)" }}>
-							<span style={{ display: "flex", alignItems: "center", gap: 2 }}>
-								<span style={{ fontFamily: "monospace", fontSize: 10 }}>{shortId(schedule.id)}</span>
+							<span style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
+								<span style={{ fontFamily: "monospace", fontSize: 10, whiteSpace: "nowrap" }}>
+									ID: {shortId(schedule.id)}
+								</span>
 								<CopyButton text={schedule.id} />
 							</span>
-							{schedule.options?.reference?.id && (
-								<span style={{ display: "flex", alignItems: "center", gap: 2 }}>
-									<span style={{ fontFamily: "monospace", fontSize: 10, color: "var(--t2)" }}>
-										ref:{schedule.options.reference.id}
+							{showRef && schedule.options?.reference?.id && (
+								<>
+									<span style={{ fontSize: 10, color: "var(--t1)", fontWeight: 700, marginLeft: -2, marginRight: 2 }}>
+										•
 									</span>
-									<CopyButton text={schedule.options.reference.id} />
-								</span>
+									<span style={{ display: "flex", alignItems: "center", gap: 2, minWidth: 0 }}>
+										<span
+											style={{
+												fontFamily: "monospace",
+												fontSize: 10,
+												color: "var(--t3)",
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+												whiteSpace: "nowrap",
+												maxWidth: 120,
+											}}
+											title={schedule.options.reference.id}
+										>
+											REF: {schedule.options.reference.id}
+										</span>
+										<CopyButton text={schedule.options.reference.id} />
+									</span>
+								</>
 							)}
-							<button
-								type="button"
-								onClick={viewRuns}
-								style={{
-									color: "var(--accent-sky)",
-									cursor: "pointer",
-									borderBottom: "1px dashed #38BDF8",
-									paddingBottom: 1,
-									background: "none",
-									border: "none",
-									padding: 0,
-									font: "inherit",
-									fontSize: "inherit",
-								}}
-							>
-								{runCount.toLocaleString()} runs →
-							</button>
-							{schedule.spec.overlapPolicy && (
+							{showOverlap && schedule.spec.overlapPolicy && (
 								<span
 									style={{
 										fontFamily: "monospace",
@@ -562,24 +567,54 @@ function ScheduleRow({
 										borderRadius: 3,
 									}}
 								>
-									{schedule.spec.overlapPolicy}
+									OVERLAP: {schedule.spec.overlapPolicy}
 								</span>
 							)}
 						</div>
 					</div>
 
-					{/* Right side: next run + last occurrence */}
-					<div style={{ textAlign: "right", flexShrink: 0 }}>
-						{schedule.status === "active" && schedule.nextRunAt > 0 && (
-							<div style={{ fontSize: 11, fontFamily: "monospace", color: "var(--accent-sky)", fontWeight: 500 }}>
-								next {timeUntil(schedule.nextRunAt)}
-							</div>
-						)}
-						{schedule.lastOccurrence && (
-							<div style={{ fontSize: 10, color: "var(--t3)", marginTop: 2 }}>
-								last {timeAgo(schedule.lastOccurrence)} ago
-							</div>
-						)}
+					{/* Right side: next/last occurrence + runs link */}
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "flex-end",
+							justifyContent: "space-between",
+							alignSelf: "stretch",
+							flexShrink: 0,
+							gap: 8,
+						}}
+					>
+						<div style={{ textAlign: "right" }}>
+							{schedule.status === "active" && schedule.nextRunAt > 0 && (
+								<div style={{ fontSize: 11, fontFamily: "monospace", color: "var(--accent-sky)", fontWeight: 500 }}>
+									next {timeUntil(schedule.nextRunAt)}
+								</div>
+							)}
+							{schedule.lastOccurrence && (
+								<div style={{ fontSize: 10, color: "var(--t3)", marginTop: 2 }}>
+									last {timeAgo(schedule.lastOccurrence)} ago
+								</div>
+							)}
+						</div>
+						<button
+							type="button"
+							onClick={viewRuns}
+							style={{
+								color: "var(--accent-sky)",
+								cursor: "pointer",
+								borderBottom: "1px dashed #38BDF8",
+								paddingBottom: 1,
+								background: "none",
+								border: "none",
+								padding: 0,
+								font: "inherit",
+								fontSize: 11,
+								whiteSpace: "nowrap",
+							}}
+						>
+							{runCount.toLocaleString()} runs →
+						</button>
 					</div>
 				</div>
 			</button>
@@ -599,6 +634,9 @@ function ScheduleRow({
 					{/* Metadata row */}
 					<div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginBottom: 12 }}>
 						<Meta label="ID" value={schedule.id} copyable />
+						{schedule.options?.reference?.id && (
+							<Meta label="Reference" value={schedule.options.reference.id} copyable />
+						)}
 						<Meta label="Type" value={schedule.spec.type} />
 						{schedule.spec.type === "cron" && <Meta label="Expression" value={schedule.spec.expression} />}
 						{schedule.spec.type === "cron" && schedule.spec.timezone && (


### PR DESCRIPTION
- Label the ID/HASH/REF fields and separate them with a bullet; match REF styling to ID and keep IDs on a single line on both lists
- Schedule row: move the runs link to the bottom-right corner, shed REF then OVERLAP as the row narrows (measured width), and surface the Reference in the expanded detail card
- Returning from a run detail goes back to the runs list with its filters intact (browser-back still cycles the detail tabs)
- Add a useElementWidth hook for width-based responsive rendering