### PR TITLE
Treat union-typed properties as atomic leaves in PathFromObject

### DIFF
--- a/lib/src/object/types.ts
+++ b/lib/src/object/types.ts
@@ -3,7 +3,7 @@ import type { Equal, ExpectTrue } from "../testing/expect/types";
 
 export type EmptyRecord = Record<PropertyKey, never>;
 
-export type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;
+export type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
 
 export type OptionalProp<T, K extends keyof T> = Omit<T, K> & { [Key in K]?: T[Key] };
 
@@ -55,6 +55,8 @@ declare const _requireAtLeastOnePropTypeTests: [
 
 type IsSubtype<SubT, SuperT> = SubT extends SuperT ? true : false;
 
+type IsUnion<T, Copy = T> = T extends unknown ? ([Copy] extends [T] ? false : true) : never;
+
 type And<T extends NonEmptyArray<boolean>> = T extends [infer First, ...infer Rest]
 	? false extends First
 		? false
@@ -72,9 +74,33 @@ type Or<T extends NonEmptyArray<boolean>> = T extends [infer First, ...infer Res
 	: never;
 
 // Thanks to @refined[https://github.com/refined] for this type
-export type PathFromObject<T, IncludeArrayKeys extends boolean = false> = T extends T
+export type PathFromObject<T, IncludeArrayKeys extends boolean = false> = T extends unknown
 	? PathFromObjectInternal<T, IncludeArrayKeys>
 	: never;
+declare const _pathFromObjectTypeTests: [
+	// biome-ignore lint/complexity/noBannedTypes: testing that empty object has no paths
+	ExpectTrue<Equal<PathFromObject<{}>, never>>,
+	ExpectTrue<Equal<PathFromObject<Record<string, never>>, string>>,
+	ExpectTrue<Equal<PathFromObject<{ a: never }>, "a">>,
+	ExpectTrue<
+		Equal<PathFromObject<{ a: string; b?: number; c: { d: boolean; e?: string[] } }>, "a" | "b" | "c" | "c.d" | "c.e">
+	>,
+	ExpectTrue<Equal<PathFromObject<{ union: "foo" | "bar" }>, "union">>,
+	ExpectTrue<
+		Equal<
+			PathFromObject<{ discriminatedUnion: { type: "foo"; foo: string } | { type: "bar"; bar: string } }>,
+			"discriminatedUnion"
+		>
+	>,
+	ExpectTrue<
+		Equal<
+			PathFromObject<{ discriminatedUnion?: { type: "foo"; foo: string } | { type: "bar"; bar: string } }>,
+			"discriminatedUnion"
+		>
+	>,
+	ExpectTrue<Equal<PathFromObject<{ either: { a: string } | { b: number } }>, "either">>,
+	ExpectTrue<Equal<PathFromObject<{ outer: { inner: { type: "a" } | { type: "b" } } }>, "outer" | "outer.inner">>,
+];
 
 type PathFromObjectInternal<T, IncludeArrayKeys extends boolean> =
 	And<[IsSubtype<T, object>, Or<[IncludeArrayKeys, NonArrayObject<T> extends never ? false : true]>]> extends true
@@ -83,6 +109,7 @@ type PathFromObjectInternal<T, IncludeArrayKeys extends boolean> =
 					[
 						IsSubtype<NonNullable<T[K]>, object>,
 						Or<[IncludeArrayKeys, NonArrayObject<NonNullable<T[K]>> extends never ? false : true]>,
+						IsUnion<NonNullable<T[K]>> extends true ? false : true,
 					]
 				> extends true
 					? K | `${K}.${PathFromObjectInternal<NonNullable<T[K]>, IncludeArrayKeys>}`


### PR DESCRIPTION
Descending into a union-typed property only exposes the members' shared discriminant, letting callers set the discriminant alone and build an invalid partial variant. Guard the descent with an IsUnion check so a union property is itself the deepest path.

Example — 
```ts
retry?: | { type: "fixed"; delayMs: number } 
        | { type: "exponential"; factor: number }

before:  "retry" | "retry.type"
           opt("retry.type", "exponential")  // compiles; yields { type: "exponential" }, missing factor
after:   "retry"
           opt("retry", { type: "exponential", factor: 2 })  // whole variant required
```

Adds type tests for optional, discriminant-less, and nested unions.