### PR TITLE
Reference-first schedule identity

### DIFF
--- a/examples/src/scenarios/scheduled-notify.ts
+++ b/examples/src/scenarios/scheduled-notify.ts
@@ -11,7 +11,10 @@ const everyFiveSeconds = schedule({
 });
 
 await runWithWorker([notify], async (client) => {
-	const scheduleHandle = await everyFiveSeconds.activate(client, notify, "This is a reminder");
+	const scheduleHandle = await everyFiveSeconds
+		.with()
+		.opt("reference.id", "my-correlation-id")
+		.activate(client, notify, "This is a reminder");
 	await delay(20_000);
 	await scheduleHandle.pause();
 });

--- a/lib/src/db/migrate/commands/apply.ts
+++ b/lib/src/db/migrate/commands/apply.ts
@@ -13,7 +13,6 @@ export async function migrateApply(params: MigrateApplyParams): Promise<void> {
 	switch (dbConfig.provider) {
 		case "pg":
 			await applyPg(dbConfig, params.migrationsDir, params.migrationsTable);
-			console.log("migrations applied");
 			return;
 		case "sqlite":
 		case "mysql":

--- a/sdk/server/src/contract/schema/schedule.ts
+++ b/sdk/server/src/contract/schema/schedule.ts
@@ -23,7 +23,7 @@ export const scheduleStatusSchema = type("'active' | 'paused' | 'deleted'");
 
 export const scheduleReferenceOptionsSchema = type({
 	id: "string > 0",
-	"conflictPolicy?": "'upsert' | 'error'",
+	"conflictPolicy?": "'error' | 'return_existing'",
 });
 
 export const scheduleActivateOptionsSchema = type({

--- a/sdk/server/src/errors.ts
+++ b/sdk/server/src/errors.ts
@@ -54,12 +54,18 @@ export class InvalidTaskStateTransitionError extends Error {
 }
 
 export class ScheduleConflictError extends Error {
-	public readonly referenceId: string;
+	public readonly definitionHash: string;
+	public readonly referenceId?: string;
 
-	constructor(referenceId: string) {
-		super(`Schedule already exists with reference: ${referenceId}`);
+	constructor(params: { definitionHash: string; referenceId?: string }) {
+		super(
+			`Conflicting schedule already exists (definitionHash ${params.definitionHash}${
+				params.referenceId ? `, referenceId ${params.referenceId}` : ""
+			})`
+		);
 		this.name = "ScheduleConflictError";
-		this.referenceId = referenceId;
+		this.definitionHash = params.definitionHash;
+		this.referenceId = params.referenceId;
 	}
 }
 

--- a/sdk/server/src/infra/db/pg/migration/0004_fluffy_mad_thinker.sql
+++ b/sdk/server/src/infra/db/pg/migration/0004_fluffy_mad_thinker.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "schedule" ALTER COLUMN "conflict_policy" SET DATA TYPE text;--> statement-breakpoint
+UPDATE "schedule" SET "conflict_policy" = 'error' WHERE "conflict_policy" = 'upsert';--> statement-breakpoint
+DROP TYPE "public"."schedule_conflict_policy";--> statement-breakpoint
+CREATE TYPE "public"."schedule_conflict_policy" AS ENUM('error', 'return_existing');--> statement-breakpoint
+ALTER TABLE "schedule" ALTER COLUMN "conflict_policy" SET DATA TYPE "public"."schedule_conflict_policy" USING "conflict_policy"::"public"."schedule_conflict_policy";

--- a/sdk/server/src/infra/db/pg/migration/meta/0004_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0004_snapshot.json
@@ -1,0 +1,1798 @@
+{
+	"id": "340817a7-1132-450e-bd7d-8939535a030f",
+	"prevId": "613385b6-aeeb-434d-850c-57090dc73466",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_awake_at_id": {
+					"name": "idx_workflow_run_status_awake_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "awake_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_workflow_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_rank_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_workflow_claimed_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_claimed_rank_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_rank_id": {
+					"name": "idx_workflow_run_outbox_status_rank_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_published_id": {
+					"name": "idx_workflow_run_outbox_status_published_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "published_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_claimed_id": {
+					"name": "idx_workflow_run_outbox_status_claimed_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "deleted"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1780357962446,
 			"tag": "0003_useful_saracen",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1783463524943,
+			"tag": "0004_fluffy_mad_thinker",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -1,9 +1,10 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import { and, count, eq, getTableColumns, inArray, lte, sql } from "drizzle-orm";
+import { and, count, eq, getTableColumns, inArray, isNull, lte, sql } from "drizzle-orm";
 
 import { timerStreamCursorFilter } from "./lib/timer-stream";
+import { ScheduleConflictError } from "../../../../errors";
 import type { TimerStreamCursor } from "../../../../lib/timer-stream";
 import type { DaemonContext } from "../../../../middleware/context";
 import type { PgDb } from "../provider";
@@ -32,19 +33,38 @@ type ScheduleRowUpdate = Partial<
 
 export const createScheduleRepository = (db: PgDb) => ({
 	async create(input: ScheduleRowInsert): Promise<ScheduleRow> {
-		const result = await db.insert(schedule).values(input).returning();
-		const created = result[0];
+		const [created] = await db.insert(schedule).values(input).onConflictDoNothing().returning();
 		if (!created) {
-			throw new Error("Failed to create schedule - no row returned");
+			throw new ScheduleConflictError({
+				definitionHash: input.definitionHash,
+				referenceId: input.referenceId ?? undefined,
+			});
 		}
 		return created;
 	},
 
-	async update(namespaceId: NamespaceId, id: string, updates: ScheduleRowUpdate): Promise<ScheduleRow | null> {
+	async update(
+		namespaceId: NamespaceId,
+		filter: { id: string; referenceId?: string | null },
+		updates: ScheduleRowUpdate
+	): Promise<ScheduleRow | null> {
+		const conditions = [eq(schedule.namespaceId, namespaceId)];
+
+		if (filter.id) {
+			conditions.push(eq(schedule.id, filter.id));
+		}
+		if (filter.referenceId !== undefined) {
+			if (filter.referenceId === null) {
+				conditions.push(isNull(schedule.referenceId));
+			} else {
+				conditions.push(eq(schedule.referenceId, filter.referenceId));
+			}
+		}
+
 		const result = await db
 			.update(schedule)
 			.set(updates)
-			.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.id, id)))
+			.where(and(...conditions))
 			.returning();
 		return result[0] ?? null;
 	},
@@ -71,20 +91,27 @@ export const createScheduleRepository = (db: PgDb) => ({
 			.where(sql`${schedule.id} = v.id`);
 	},
 
-	async getByReferenceId(namespaceId: NamespaceId, referenceId: string): Promise<ScheduleRow | null> {
-		const result = await db
-			.select()
-			.from(schedule)
-			.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.referenceId, referenceId)))
-			.limit(1);
-		return result[0] ?? null;
-	},
+	async get(
+		namespaceId: NamespaceId,
+		filter: { definitionHash?: string; referenceId?: string | null }
+	): Promise<ScheduleRow | null> {
+		const conditions = [eq(schedule.namespaceId, namespaceId)];
 
-	async getByDefinitionHash(namespaceId: NamespaceId, definitionHash: string): Promise<ScheduleRow | null> {
+		if (filter.definitionHash) {
+			conditions.push(eq(schedule.definitionHash, filter.definitionHash));
+		}
+		if (filter.referenceId !== undefined) {
+			if (filter.referenceId === null) {
+				conditions.push(isNull(schedule.referenceId));
+			} else {
+				conditions.push(eq(schedule.referenceId, filter.referenceId));
+			}
+		}
+
 		const result = await db
 			.select()
 			.from(schedule)
-			.where(and(eq(schedule.namespaceId, namespaceId), eq(schedule.definitionHash, definitionHash)))
+			.where(and(...conditions))
 			.limit(1);
 		return result[0] ?? null;
 	},

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -117,7 +117,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 			nextRunAt: TimestampMs | null;
 		}>
 	): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, id, updates);
+		const schedule = await repos.schedule.update(namespaceId, { id }, updates);
 		if (!schedule) {
 			throw new NotFoundError(`Schedule not found: ${id}`);
 		}
@@ -144,7 +144,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 			})
 		);
 		const referenceId = options?.reference?.id;
-		const conflictPolicy = options?.reference?.conflictPolicy ?? "upsert";
+		const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
 		const workflowRunInputHash = await hashInput(input);
 
 		return repos.transaction(async (txRepos) => {
@@ -156,60 +156,90 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 			});
 
 			const workflowInfo = { workflowName, workflowVersionId };
+			const now = Date.now();
+			const nextRunAt = getNextOccurrence(spec, now) as TimestampMs;
 
-			const existingSchedule = referenceId
-				? await txRepos.schedule.getByReferenceId(namespaceId, referenceId)
-				: await txRepos.schedule.getByDefinitionHash(namespaceId, definitionHash);
+			if (!referenceId) {
+				const existingScheduleByDefinition = await txRepos.schedule.get(namespaceId, { definitionHash });
 
-			if (existingSchedule) {
-				if (existingSchedule.definitionHash === definitionHash && existingSchedule.status === "active") {
-					return { schedule: scheduleRowToDomain(existingSchedule, workflowInfo) };
-				}
+				const schedule = existingScheduleByDefinition
+					? existingScheduleByDefinition.status === "active"
+						? existingScheduleByDefinition
+						: await reactivateSchedule(txRepos.schedule, {
+								namespaceId,
+								scheduleId: existingScheduleByDefinition.id as ScheduleId,
+								nextRunAt,
+							})
+					: await createSchedule(txRepos.schedule, {
+							namespaceId,
+							workflowId: workflowRow.id,
+							spec,
+							workflowRunInput: input,
+							workflowRunInputHash,
+							definitionHash,
+							referenceId: undefined,
+							conflictPolicy: options?.reference?.conflictPolicy,
+							nextRunAt,
+						});
 
-				if (referenceId && existingSchedule.definitionHash !== definitionHash && conflictPolicy === "error") {
-					throw new ScheduleConflictError(referenceId);
-				}
-
-				const now = Date.now();
-				const updatedRow = await txRepos.schedule.update(namespaceId, existingSchedule.id, {
-					workflowId: workflowRow.id,
-					status: "active",
-					type: spec.type,
-					cronExpression: spec.type === "cron" ? spec.expression : undefined,
-					intervalMs: spec.type === "interval" ? spec.everyMs : undefined,
-					overlapPolicy: spec.overlapPolicy,
-					workflowRunInput: input,
-					workflowRunInputHash,
-					definitionHash,
-					nextRunAt: getNextOccurrence(spec, now) as TimestampMs,
-				});
-				if (!updatedRow) {
-					throw new NotFoundError(`Schedule not found: ${existingSchedule.id}`);
-				}
-				return { schedule: scheduleRowToDomain(updatedRow, workflowInfo) };
+				return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 			}
 
-			const id = ulid() as ScheduleId;
-			const now = Date.now();
-			const nextRunAt = getNextOccurrence(spec, now);
+			const existingScheduleByReference = await txRepos.schedule.get(namespaceId, { referenceId });
+			if (existingScheduleByReference) {
+				if (existingScheduleByReference.definitionHash !== definitionHash) {
+					if (conflictPolicy === "error") {
+						throw new ScheduleConflictError({ definitionHash, referenceId });
+					}
+					conflictPolicy satisfies "return_existing";
+					return { schedule: scheduleRowToDomain(existingScheduleByReference, workflowInfo) };
+				}
 
-			const createdRow = await txRepos.schedule.create({
-				id,
+				const schedule =
+					existingScheduleByReference.status === "active"
+						? existingScheduleByReference
+						: await reactivateSchedule(txRepos.schedule, {
+								namespaceId,
+								scheduleId: existingScheduleByReference.id as ScheduleId,
+								nextRunAt,
+							});
+
+				return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
+			}
+
+			// Reference id is free, but the definition may already exist.
+			const existingNonReferencedSchedule = await txRepos.schedule.get(namespaceId, {
+				definitionHash,
+				referenceId: null,
+			});
+			if (existingNonReferencedSchedule) {
+				const schedule = await txRepos.schedule.update(
+					namespaceId,
+					{ id: existingNonReferencedSchedule.id, referenceId: null },
+					{
+						referenceId,
+						conflictPolicy: options?.reference?.conflictPolicy ?? null,
+						status: "active",
+						nextRunAt,
+					}
+				);
+				if (schedule) {
+					return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
+				}
+			}
+
+			const schedule = await createSchedule(txRepos.schedule, {
 				namespaceId,
 				workflowId: workflowRow.id,
-				status: "active",
-				type: spec.type,
-				cronExpression: spec.type === "cron" ? spec.expression : null,
-				intervalMs: spec.type === "interval" ? spec.everyMs : null,
-				overlapPolicy: spec.overlapPolicy ?? null,
+				spec,
 				workflowRunInput: input,
 				workflowRunInputHash,
 				definitionHash,
 				referenceId,
-				conflictPolicy: options?.reference?.conflictPolicy ?? null,
-				nextRunAt: nextRunAt as TimestampMs,
+				conflictPolicy: options?.reference?.conflictPolicy,
+				nextRunAt,
 			});
-			return { schedule: scheduleRowToDomain(createdRow, workflowInfo) };
+			return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 		});
 	},
 
@@ -274,21 +304,21 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 	},
 
 	async pauseSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, id, { status: "paused" });
+		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "paused" });
 		if (!schedule) {
 			throw new NotFoundError(`Schedule not found: ${id}`);
 		}
 	},
 
 	async resumeSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, id, { status: "active" });
+		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "active" });
 		if (!schedule) {
 			throw new NotFoundError(`Schedule not found: ${id}`);
 		}
 	},
 
 	async deleteSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, id, { status: "deleted" });
+		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "deleted" });
 		if (!schedule) {
 			throw new NotFoundError(`Schedule not found: ${id}`);
 		}
@@ -296,6 +326,57 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 });
 
 export type ScheduleService = ReturnType<typeof createScheduleService>;
+
+async function reactivateSchedule(
+	repo: Repositories["schedule"],
+	params: { namespaceId: NamespaceId; scheduleId: ScheduleId; nextRunAt: TimestampMs }
+): Promise<ScheduleRow> {
+	const updatedRow = await repo.update(
+		params.namespaceId,
+		{ id: params.scheduleId },
+		{
+			status: "active",
+			nextRunAt: params.nextRunAt,
+		}
+	);
+	if (!updatedRow) {
+		throw new NotFoundError(`Schedule not found: ${params.scheduleId}`);
+	}
+	return updatedRow;
+}
+
+async function createSchedule(
+	repo: Repositories["schedule"],
+	params: {
+		namespaceId: NamespaceId;
+		workflowId: string;
+		spec: ScheduleSpec;
+		workflowRunInput: unknown;
+		workflowRunInputHash: string;
+		definitionHash: string;
+		referenceId: string | undefined;
+		conflictPolicy: ScheduleConflictPolicy | undefined | null;
+		nextRunAt: TimestampMs;
+	}
+): Promise<ScheduleRow> {
+	const { spec } = params;
+	return repo.create({
+		id: ulid(),
+		namespaceId: params.namespaceId,
+		workflowId: params.workflowId,
+		status: "active",
+		type: spec.type,
+		cronExpression: spec.type === "cron" ? spec.expression : null,
+		intervalMs: spec.type === "interval" ? spec.everyMs : null,
+		overlapPolicy: spec.overlapPolicy ?? null,
+		workflowRunInput: params.workflowRunInput,
+		workflowRunInputHash: params.workflowRunInputHash,
+		definitionHash: params.definitionHash,
+		referenceId: params.referenceId,
+		conflictPolicy: params.conflictPolicy,
+		nextRunAt: params.nextRunAt,
+	});
+}
 
 export function scheduleRowToDomain(
 	schedule: ScheduleRow,

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -555,6 +555,7 @@ async function createWorkflowRunInTx(
 				if (conflictPolicy === "error") {
 					throw new WorkflowRunConflictError(name, versionId, referenceId);
 				}
+				conflictPolicy satisfies "return_existing";
 			}
 
 			context.logger.info("Returning existing run from reference ID", { runId: existingRun.id, referenceId });

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -27,7 +27,7 @@ export interface IntervalScheduleSpec extends ScheduleSpecBase {
 
 export type ScheduleSpec = CronScheduleSpec | IntervalScheduleSpec;
 
-export const SCHEDULE_CONFLICT_POLICIES = ["upsert", "error"] as const;
+export const SCHEDULE_CONFLICT_POLICIES = ["error", "return_existing"] as const;
 export type ScheduleConflictPolicy = (typeof SCHEDULE_CONFLICT_POLICIES)[number];
 
 export interface ScheduleReferenceOptions {


### PR DESCRIPTION
## Background

A schedule is identified by two things: its **definition hash** — a hash of the workflow name, version, spec, and input — and an optional **reference id**, a stable key the caller supplies to name the schedule. The `schedule` table has a unique index on each, per namespace. A schedule with no reference id is **anonymous**: its definition hash alone identifies it.

Schedule activation is the idempotent "create-or-return" entry point. Re-activating the same schedule should return the existing one, not create a duplicate.

## Problem

The old flow had three issues that collided:

1. It looked up the existing schedule **reference-first** — by reference id when one was given, otherwise by definition hash — but the definition-hash unique index was enforced unconditionally. So activating a definition that already existed anonymously, this time *with* a reference id, found nothing by reference, fell through to an insert, and violated the definition-hash index. A raw Postgres error surfaced instead of a clean result.

2. When it found an existing schedule by reference but whose definition differed, it **rewrote the definition in place**. That erased what the schedule used to be, and it's conceptually wrong: a schedule *is* its definition, so changing the spec is a different schedule, not an edit.

3. `conflictPolicy` was `upsert | error`, baking that redefine behavior into the API.

## Solution

Commit to one identity model and make lookup, uniqueness, and conflict handling agree.

- The **definition is immutable**. Re-activation only flips a paused schedule back to active; it never rewrites the definition.
- When a **reference id is given, it is the identity**. When it isn't, the **definition hash is the idempotency key**.

Activation resolves like this:

- **No reference id** — look up by definition hash. Found → reactivate if paused, otherwise return as-is. Missing → create.
- **Reference id given** — look up by reference id.
  - Found, same definition → idempotent (reactivate if paused).
  - Found, different definition → a conflict, never a redefine. `error` throws; `return_existing` hands back the existing schedule untouched.
  - Not found → the definition may already exist anonymously, so **adopt** it: attach the reference id to that row (a rename, not a redefine). With no anonymous schedule to adopt, create.

This is how workflow-run activation already resolves a reference bound to a different payload, so `conflictPolicy` changes from `upsert | error` to `error | return_existing`.

Two concurrency points, since two activations can target the same definition at once:

- **Adopt is a compare-and-swap.** Attaching the reference id updates the row only while its reference id is still null. If a concurrent activation adopted it first, the update matches no row, and we fall through to create.
- **Create leans on the unique indexes, not a pre-check.** The insert uses `ON CONFLICT DO NOTHING`; an empty result means the definition or reference already exists — including when two activations race — and becomes a `ScheduleConflictError`. That error carries the definition hash and, when present, the reference id, and maps to a 409.

## Breaking changes

- The `conflict_policy` enum changes: `upsert` is removed, `return_existing` is added, and the schedule reference option's `conflictPolicy` type changes to match. A migration recreates the enum type (Postgres can't drop an enum value) and first moves any existing `upsert` rows to `error`, so the cast to the new type can't hit a value that no longer exists.