### PR TITLE
Drop the Options suffix from reference identity types

### DIFF
--- a/sdk/server/src/contract/schema/schedule.ts
+++ b/sdk/server/src/contract/schema/schedule.ts
@@ -21,13 +21,13 @@ export const scheduleSpecSchema = cronScheduleSpecSchema.or(intervalScheduleSpec
 
 export const scheduleStatusSchema = type("'active' | 'paused' | 'deleted'");
 
-export const scheduleReferenceOptionsSchema = type({
+export const scheduleReferenceSchema = type({
 	id: "string > 0",
 	"conflictPolicy?": "'error' | 'return_existing'",
 });
 
 export const scheduleActivateOptionsSchema = type({
-	"reference?": scheduleReferenceOptionsSchema.or("undefined"),
+	"reference?": scheduleReferenceSchema.or("undefined"),
 });
 
 export const scheduleWorkflowFilterSchema = type({

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -13,13 +13,13 @@ export const workflowRunStatusSchema = type(
 
 export const terminalWorkflowRunStatusSchema = type("'cancelled' | 'failed' | 'completed'");
 
-const workflowReferenceOptionsSchema = type({
+const workflowReferenceSchema = type({
 	id: "string > 0",
 	"conflictPolicy?": "'error' | 'return_existing' | undefined",
 });
 
 export const workflowOptionsSchema = type({
-	"reference?": workflowReferenceOptionsSchema,
+	"reference?": workflowReferenceSchema,
 	"trigger?": triggerStrategySchema,
 	"shard?": "string | undefined",
 	"retry?": retryStrategySchema,

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -21,7 +21,7 @@ import type {
 	ChildWorkflowRunInfo,
 	ChildWorkflowRunQueue,
 	ChildWorkflowRunWaitQueue,
-	EventReferenceOptions,
+	EventReference,
 	EventWaitQueue,
 	SleepQueue,
 	TerminalWorkflowRunState,
@@ -245,7 +245,7 @@ export const createWorkflowRunService = ({
 		runId: WorkflowRunId,
 		eventName: string,
 		data: unknown,
-		reference: EventReferenceOptions | undefined
+		reference: EventReference | undefined
 	): Promise<void> {
 		return repos.transaction(async (txRepos) => {
 			// TODO: should we use getByIdWithState instead?

--- a/sdk/workflow/src/index.ts
+++ b/sdk/workflow/src/index.ts
@@ -11,7 +11,7 @@ export type { Schedule, ScheduleActivateOptions, ScheduleSpec, ScheduleStatus } 
 export { SchemaValidationError } from "@aikirun/types/validator";
 export type {
 	EventName,
-	EventReferenceOptions,
+	EventReference,
 	EventSendOptions,
 	EventWait,
 	EventWaitOptions,

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -30,13 +30,13 @@ export type ScheduleSpec = CronScheduleSpec | IntervalScheduleSpec;
 export const SCHEDULE_CONFLICT_POLICIES = ["error", "return_existing"] as const;
 export type ScheduleConflictPolicy = (typeof SCHEDULE_CONFLICT_POLICIES)[number];
 
-export interface ScheduleReferenceOptions {
+export interface ScheduleReference {
 	id: string;
 	conflictPolicy?: ScheduleConflictPolicy;
 }
 
 export interface ScheduleActivateOptions {
-	reference?: ScheduleReferenceOptions;
+	reference?: ScheduleReference;
 }
 
 export interface Schedule {

--- a/types/src/workflow/run/event.ts
+++ b/types/src/workflow/run/event.ts
@@ -13,7 +13,7 @@ export interface EventWaitReceived<Data> extends EventWaitBase {
 	status: "received";
 	data?: Data;
 	receivedAt: number;
-	reference?: EventReferenceOptions;
+	reference?: EventReference;
 }
 
 export interface EventWaitTimeout extends EventWaitBase {
@@ -36,9 +36,9 @@ export type EventWaitResult<Data, Timed extends boolean> = Timed extends false
 	: { timeout: false; data: Data } | { timeout: true };
 
 export interface EventSendOptions {
-	reference?: EventReferenceOptions;
+	reference?: EventReference;
 }
 
-export interface EventReferenceOptions {
+export interface EventReference {
 	id: string;
 }

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -45,7 +45,7 @@ export function isTerminalWorkflowRunStatus(status: WorkflowRunStatus): status i
 export const WORKFLOW_RUN_CONFLICT_POLICIES = ["error", "return_existing"] as const;
 export type WorkflowRunConflictPolicy = (typeof WORKFLOW_RUN_CONFLICT_POLICIES)[number];
 
-export interface WorkflowReferenceOptions {
+export interface WorkflowReference {
 	id: string;
 	conflictPolicy?: WorkflowRunConflictPolicy;
 }
@@ -53,7 +53,7 @@ export interface WorkflowReferenceOptions {
 export interface WorkflowStartOptions {
 	retry?: RetryStrategy;
 	trigger?: TriggerStrategy;
-	reference?: WorkflowReferenceOptions;
+	reference?: WorkflowReference;
 	shard?: string;
 }
 


### PR DESCRIPTION
Rename the three types, and the two arktype schemas that back them, to drop the `Options` suffix so that types becomes: `WorkflowReference`, `ScheduleReference`, `EventReference`. This is a rename only, no change to shape or behavior.

## Breaking changes

Public exported types are renamed. `WorkflowReference` and `ScheduleReference` come from `@aikirun/types`; `EventReference` is also re-exported from the workflow SDK. Consumers importing the old `*ReferenceOptions` names must update to the new ones.