### PR TITLE
Retry and shard for scheduled runs

### DIFF
--- a/app/dashboard/src/pages/SchedulesList.tsx
+++ b/app/dashboard/src/pages/SchedulesList.tsx
@@ -1,4 +1,4 @@
-import type { Schedule, ScheduleStatus } from "@aikirun/types/schedule";
+import type { Schedule, ScheduledWorkflowStartOptions, ScheduleStatus } from "@aikirun/types/schedule";
 import { useQueryClient } from "@tanstack/react-query";
 import type { CSSProperties } from "react";
 import { useMemo, useState } from "react";
@@ -137,6 +137,30 @@ function fmtMs(ms: number): string {
 	if (ms < 60000) return `${Math.round(ms / 1000)}s`;
 	if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
 	return `${Math.round(ms / 3600000)}h`;
+}
+
+function fmtDelay(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	const seconds = ms / 1000;
+	return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`;
+}
+
+function retrySummary(retry: NonNullable<ScheduledWorkflowStartOptions["retry"]>): string {
+	switch (retry.type) {
+		case "never":
+			return "never";
+		case "fixed":
+			return `fixed · ${retry.maxAttempts}× · ${fmtDelay(retry.delayMs)}`;
+		case "exponential":
+		case "jittered": {
+			const parts = [retry.type, `${retry.maxAttempts}×`, `${fmtDelay(retry.baseDelayMs)} base`];
+			if (retry.factor !== undefined) parts.push(`×${retry.factor}`);
+			if (retry.maxDelayMs !== undefined) parts.push(`≤ ${fmtDelay(retry.maxDelayMs)}`);
+			return parts.join(" · ");
+		}
+		default:
+			return retry satisfies never;
+	}
 }
 
 function fmtDate(ts: number): string {
@@ -644,6 +668,10 @@ function ScheduleRow({
 						)}
 						{schedule.spec.type === "interval" && <Meta label="Interval" value={fmtMs(schedule.spec.everyMs)} />}
 						{schedule.spec.overlapPolicy && <Meta label="Overlap" value={schedule.spec.overlapPolicy} />}
+						{schedule.workflowRunOptions?.retry && (
+							<Meta label="Retry" value={retrySummary(schedule.workflowRunOptions.retry)} />
+						)}
+						{schedule.workflowRunOptions?.shard && <Meta label="Shard" value={schedule.workflowRunOptions.shard} />}
 						<Meta label="Total Runs" value={runCount.toLocaleString()} />
 						<Meta label="Created" value={fmtDate(schedule.createdAt)} />
 					</div>

--- a/examples/src/scenarios/scheduled-notify.ts
+++ b/examples/src/scenarios/scheduled-notify.ts
@@ -13,7 +13,9 @@ const everyFiveSeconds = schedule({
 await runWithWorker([notify], async (client) => {
 	const scheduleHandle = await everyFiveSeconds
 		.with()
-		.opt("reference.id", "my-correlation-id")
+		.opt("reference.id", "my-correlation-xxx")
+		.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
+		.opt("workflowRun.shard", "eu")
 		.activate(client, notify, "This is a reminder");
 	await delay(20_000);
 	await scheduleHandle.pause();

--- a/sdk/server/src/contract/procedure/schedule.ts
+++ b/sdk/server/src/contract/procedure/schedule.ts
@@ -19,6 +19,7 @@ import { type } from "arktype";
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
 import {
 	scheduleActivateOptionsSchema,
+	scheduledWorkflowStartOptionsSchema,
 	scheduleSchema,
 	scheduleSpecSchema,
 	scheduleStatusSchema,
@@ -33,6 +34,7 @@ const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateR
 			"workflowRunInput?": "unknown",
 			spec: scheduleSpecSchema,
 			"options?": scheduleActivateOptionsSchema.or("undefined"),
+			"workflowRunOptions?": scheduledWorkflowStartOptionsSchema.or("undefined"),
 		})
 	)
 	.output(

--- a/sdk/server/src/contract/schema/schedule.ts
+++ b/sdk/server/src/contract/schema/schedule.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 
 import { workflowSourceSchema } from "./workflow";
+import { workflowOptionsSchema } from "./workflow-run";
 
 export const overlapPolicySchema = type("'allow' | 'skip' | 'cancel_previous'");
 
@@ -30,6 +31,8 @@ export const scheduleActivateOptionsSchema = type({
 	"reference?": scheduleReferenceSchema.or("undefined"),
 });
 
+export const scheduledWorkflowStartOptionsSchema = workflowOptionsSchema.pick("retry", "shard");
+
 export const scheduleWorkflowFilterSchema = type({
 	name: "string > 0",
 	"versionId?": "string > 0 | undefined",
@@ -44,6 +47,7 @@ export const scheduleSchema = type({
 	spec: scheduleSpecSchema,
 	status: scheduleStatusSchema,
 	"options?": scheduleActivateOptionsSchema.or("undefined"),
+	"workflowRunOptions?": scheduledWorkflowStartOptionsSchema.or("undefined"),
 	createdAt: "number > 0",
 	updatedAt: "number > 0",
 	"lastOccurrence?": "number > 0 | undefined",

--- a/sdk/server/src/daemons/imminent-recurring-workflows.ts
+++ b/sdk/server/src/daemons/imminent-recurring-workflows.ts
@@ -5,9 +5,10 @@ import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type { Schedule, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
+import type { Schedule, ScheduledWorkflowStartOptions, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
 import {
 	NON_TERMINAL_WORKFLOW_RUN_STATUSES,
+	type WorkflowReference,
 	type WorkflowRunId,
 	type WorkflowRunStateCancelled,
 	type WorkflowRunStateQueued,
@@ -165,7 +166,7 @@ async function processOverlapAllowSchedules(
 				status: "queued",
 				input: schedule.workflowRunInput,
 				inputHash: schedule.workflowRunInputHash,
-				options: { reference: { id: referenceId } },
+				options: scheduledRunOptions(schedule, referenceId),
 				referenceId,
 				latestStateTransitionId: stateTransitionId,
 			});
@@ -184,7 +185,7 @@ async function processOverlapAllowSchedules(
 				workflowName: schedule.workflowName,
 				workflowVersionId: schedule.workflowVersionId,
 				rank: computeRank(occurrence),
-				shard: null,
+				shard: schedule.workflowRunOptions?.shard ?? null,
 				status: "pending",
 			});
 		}
@@ -260,7 +261,7 @@ async function processOverlapSkipSchedules(
 			status: "queued",
 			input: schedule.workflowRunInput,
 			inputHash: schedule.workflowRunInputHash,
-			options: { reference: { id: referenceId } },
+			options: scheduledRunOptions(schedule, referenceId),
 			referenceId,
 			latestStateTransitionId: stateTransitionId,
 		});
@@ -279,7 +280,7 @@ async function processOverlapSkipSchedules(
 			workflowName: schedule.workflowName,
 			workflowVersionId: schedule.workflowVersionId,
 			rank: computeRank(occurrence),
-			shard: null,
+			shard: schedule.workflowRunOptions?.shard ?? null,
 			status: "pending",
 		});
 		scheduleUpdates.push({
@@ -355,7 +356,7 @@ async function processOverlapCancelPreviousSchedules(
 			status: "queued",
 			input: schedule.workflowRunInput,
 			inputHash: schedule.workflowRunInputHash,
-			options: { reference: { id: referenceId } },
+			options: scheduledRunOptions(schedule, referenceId),
 			referenceId,
 			latestStateTransitionId: stateTransitionId,
 		});
@@ -374,7 +375,7 @@ async function processOverlapCancelPreviousSchedules(
 			workflowName: schedule.workflowName,
 			workflowVersionId: schedule.workflowVersionId,
 			rank: computeRank(occurrence),
-			shard: null,
+			shard: schedule.workflowRunOptions?.shard ?? null,
 			status: "pending",
 		});
 		scheduleUpdates.push({
@@ -452,6 +453,17 @@ async function processOverlapCancelPreviousSchedules(
 	if (deps.workflowRunPublisher && isNonEmptyArray(insertedOutboxEntries)) {
 		await publishPendingOutboxEntries(context, deps.repos, deps.workflowRunPublisher, insertedOutboxEntries);
 	}
+}
+
+function scheduledRunOptions(
+	schedule: DueSchedule,
+	referenceId: string
+): ScheduledWorkflowStartOptions & { reference: WorkflowReference } {
+	return {
+		reference: { id: referenceId },
+		retry: schedule.workflowRunOptions?.retry,
+		shard: schedule.workflowRunOptions?.shard,
+	};
 }
 
 async function fetchActiveRunsBySchedule(

--- a/sdk/server/src/infra/db/pg/migration/0005_special_stark_industries.sql
+++ b/sdk/server/src/infra/db/pg/migration/0005_special_stark_industries.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedule" ADD COLUMN "workflow_run_options" jsonb;

--- a/sdk/server/src/infra/db/pg/migration/meta/0005_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0005_snapshot.json
@@ -1,0 +1,1804 @@
+{
+	"id": "f4e04858-4a2f-4338-95e9-d70c75375293",
+	"prevId": "340817a7-1132-450e-bd7d-8939535a030f",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_awake_at_id": {
+					"name": "idx_workflow_run_status_awake_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "awake_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"published_at": {
+					"name": "published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_workflow_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_rank_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_workflow_claimed_rank_id": {
+					"name": "idx_workflow_run_outbox_status_workflow_claimed_rank_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_rank_id": {
+					"name": "idx_workflow_run_outbox_status_rank_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_published_id": {
+					"name": "idx_workflow_run_outbox_status_published_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "published_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_status_claimed_id": {
+					"name": "idx_workflow_run_outbox_status_claimed_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "deleted"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1783463524943,
 			"tag": "0004_fluffy_mad_thinker",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1783488137230,
+			"tag": "0005_special_stark_industries",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -25,6 +25,7 @@ type ScheduleRowUpdate = Partial<
 		| "definitionHash"
 		| "referenceId"
 		| "conflictPolicy"
+		| "workflowRunOptions"
 		| "lastOccurrence"
 		| "nextRunAt"
 		| "workflowId"

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -3,6 +3,7 @@ import {
 	SCHEDULE_OVERLAP_POLICIES,
 	SCHEDULE_STATUSES,
 	SCHEDULE_TYPES,
+	type ScheduledWorkflowStartOptions,
 } from "@aikirun/types/schedule";
 import { WORKFLOW_SOURCES } from "@aikirun/types/workflow";
 import {
@@ -97,6 +98,8 @@ export const schedule = pgTable(
 
 		referenceId: text("reference_id"),
 		conflictPolicy: scheduleConflictPolicyEnum("conflict_policy"),
+
+		workflowRunOptions: jsonb("workflow_run_options").$type<ScheduledWorkflowStartOptions>(),
 
 		lastOccurrence: timestampMs("last_occurrence"),
 		nextRunAt: timestampMs("next_run_at"),

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -8,6 +8,7 @@ import type { NamespaceId } from "@aikirun/types/namespace";
 import type {
 	Schedule,
 	ScheduleConflictPolicy,
+	ScheduledWorkflowStartOptions,
 	ScheduleId,
 	ScheduleSpec,
 	ScheduleStatus,
@@ -128,13 +129,14 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		namespaceId: NamespaceId,
 		request: ScheduleActivateRequestV1
 	): Promise<{ schedule: Schedule }> {
-		const { workflowName, workflowVersionId, workflowRunInput, spec, options } = request;
+		const { workflowName, workflowVersionId, workflowRunInput, spec, options, workflowRunOptions } = request;
 		const definitionHash = await sha256Async(
 			stableStringify({
 				workflowName,
 				workflowVersionId,
 				spec,
 				workflowRunInput,
+				workflowRunOptions,
 			})
 		);
 		const referenceId = options?.reference?.id;
@@ -173,6 +175,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 							definitionHash,
 							referenceId: undefined,
 							conflictPolicy: options?.reference?.conflictPolicy,
+							workflowRunOptions,
 							nextRunAt,
 						});
 
@@ -231,6 +234,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 				definitionHash,
 				referenceId,
 				conflictPolicy: options?.reference?.conflictPolicy,
+				workflowRunOptions,
 				nextRunAt,
 			});
 			return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
@@ -350,6 +354,7 @@ async function createSchedule(
 		definitionHash: string;
 		referenceId: string | undefined;
 		conflictPolicy: ScheduleConflictPolicy | undefined | null;
+		workflowRunOptions: ScheduledWorkflowStartOptions | undefined;
 		nextRunAt: TimestampMs;
 	}
 ): Promise<ScheduleRow> {
@@ -368,6 +373,7 @@ async function createSchedule(
 		definitionHash: params.definitionHash,
 		referenceId: params.referenceId,
 		conflictPolicy: params.conflictPolicy,
+		workflowRunOptions: params.workflowRunOptions,
 		nextRunAt: params.nextRunAt,
 	});
 }
@@ -399,6 +405,7 @@ export function scheduleRowToDomain(
 		options: schedule.referenceId
 			? { reference: { id: schedule.referenceId, conflictPolicy: schedule.conflictPolicy ?? undefined } }
 			: undefined,
+		workflowRunOptions: schedule.workflowRunOptions ?? undefined,
 		createdAt: schedule.createdAt,
 		updatedAt: schedule.updatedAt,
 		lastOccurrence: schedule.lastOccurrence ?? undefined,

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -92,6 +92,65 @@ describe("schedule", () => {
 			}));
 	});
 
+	describe("workflow run options", () => {
+		const retryingSyncInventoryWorkflow = workflow({ name: "sync-inventory" }).v<{ warehouseId: string }>("1.0.0", {
+			handler: async () => {},
+			retry: { type: "fixed", maxAttempts: 5, delayMs: 300 },
+		});
+
+		test("opt carries retry and shard to every fired run", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						workflowRunOptions: {
+							retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 },
+							shard: "eu",
+						},
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
+
+				await schedule({ type: "interval", every: { seconds: 1 } })
+					.with()
+					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
+					.opt("workflowRun.shard", "eu")
+					.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
+			}));
+
+		test("carries the workflow's declared retry default when the schedule sets no overrides", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						workflowRunOptions: { retry: { type: "fixed", maxAttempts: 5, delayMs: 300 } },
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
+
+				await schedule({ type: "interval", every: { seconds: 1 } }).activate(client, retryingSyncInventoryWorkflow, {
+					warehouseId: "wh-1",
+				});
+			}));
+
+		test("a schedule retry override replaces the workflow's declared default", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						workflowRunOptions: {
+							retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 },
+							shard: "eu",
+						},
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
+
+				await schedule({ type: "interval", every: { seconds: 1 } })
+					.with()
+					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
+					.opt("workflowRun.shard", "eu")
+					.activate(client, retryingSyncInventoryWorkflow, { warehouseId: "wh-1" });
+			}));
+	});
+
 	describe("handle operations", () => {
 		test("pause calls pauseV1 with the schedule id", () =>
 			withFakeClient(async (client) => {

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -2,7 +2,14 @@ import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
 import type { Client } from "@aikirun/types/client";
-import type { ScheduleActivateOptions, ScheduleId, ScheduleOverlapPolicy, ScheduleSpec } from "@aikirun/types/schedule";
+import type {
+	ScheduleActivateOptions,
+	ScheduledWorkflowStartOptions,
+	ScheduleId,
+	ScheduleOverlapPolicy,
+	ScheduleSpec,
+} from "@aikirun/types/schedule";
+import { INTERNAL } from "@aikirun/types/symbols";
 
 import type { EventsDefinition } from "./run/event";
 import type { WorkflowVersion } from "./workflow-version";
@@ -29,10 +36,14 @@ export interface ScheduleHandle {
 	delete(): Promise<void>;
 }
 
+type ScheduleBuilderActivateOptions = ScheduleActivateOptions & {
+	workflowRun?: ScheduledWorkflowStartOptions;
+};
+
 export interface ScheduleBuilder {
-	opt<Path extends PathFromObject<ScheduleActivateOptions>>(
+	opt<Path extends PathFromObject<ScheduleBuilderActivateOptions>>(
 		path: Path,
-		value: TypeOfValueAtPath<ScheduleActivateOptions, Path>
+		value: TypeOfValueAtPath<ScheduleBuilderActivateOptions, Path>
 	): ScheduleBuilder;
 
 	activate<Input, Output, Context, TEvents extends EventsDefinition>(
@@ -56,10 +67,11 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 	async function activateWithOptions<Input, Output, Context, TEvents extends EventsDefinition>(
 		client: Client<Context>,
 		workflow: WorkflowVersion<Input, Output, Context, TEvents>,
-		options: ScheduleActivateOptions,
+		options: ScheduleBuilderActivateOptions,
 		...args: Input extends void ? [] : [Input]
 	): Promise<ScheduleHandle> {
 		const workflowRunInput = args[0];
+		const { workflowRun: workflowRunOptions, ...scheduleOptions } = options;
 
 		let scheduleSpec: ScheduleSpec;
 		if (params.type === "interval") {
@@ -77,13 +89,14 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 			workflowVersionId: workflow.versionId,
 			spec: scheduleSpec,
 			workflowRunInput,
-			options,
+			options: scheduleOptions,
+			workflowRunOptions,
 		});
 		client.logger.info("Schedule activated", {
 			scheduleSpec,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			referenceId: options?.reference?.id,
+			referenceId: scheduleOptions.reference?.id,
 		});
 
 		const scheduleId = schedule.id as ScheduleId;
@@ -105,12 +118,18 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 		};
 	}
 
-	function createBuilder(optionsBuilder: ObjectBuilder<ScheduleActivateOptions>): ScheduleBuilder {
+	// The builder threads its .opt() calls as a function so they can be applied at activate, once the
+	// workflow (and thus its default run options) is known.
+	function createBuilder(
+		apply: (builder: ObjectBuilder<ScheduleBuilderActivateOptions>) => ObjectBuilder<ScheduleBuilderActivateOptions>
+	): ScheduleBuilder {
 		return {
-			opt: (path, value) => createBuilder(optionsBuilder.with(path, value)),
+			opt: (path, value) => createBuilder((builder) => apply(builder).with(path, value)),
 
 			async activate(client, workflow, ...args) {
-				return activateWithOptions(client, workflow, optionsBuilder.build(), ...args);
+				const base: ScheduleBuilderActivateOptions = { workflowRun: workflow[INTERNAL].definitionStartOptions() };
+				const activateOptions = apply(objectOverrider(base)()).build();
+				return activateWithOptions(client, workflow, activateOptions, ...args);
 			},
 		};
 	}
@@ -119,12 +138,11 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 		...params,
 
 		with(): ScheduleBuilder {
-			const optionsOverrider = objectOverrider<ScheduleActivateOptions>({});
-			return createBuilder(optionsOverrider());
+			return createBuilder((builder) => builder);
 		},
 
 		async activate(client, workflow, ...args) {
-			return activateWithOptions(client, workflow, {}, ...args);
+			return createBuilder((builder) => builder).activate(client, workflow, ...args);
 		},
 	};
 }

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -18,6 +18,7 @@ import { SchemaValidationError } from "@aikirun/types/validator";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
 	ReplayManifest,
+	WorkflowDefinitionStartOptions,
 	WorkflowRunAddress,
 	WorkflowRunId,
 	WorkflowRunRecord,
@@ -75,6 +76,7 @@ export interface WorkflowVersion<Input, Output, Context, TEvents extends EventsD
 	[INTERNAL]: {
 		eventsDefinition: TEvents;
 		handler: (run: WorkflowRun<Input, Context, TEvents>, input: Input) => Promise<void>;
+		definitionStartOptions: () => WorkflowDefinitionStartOptions;
 	};
 }
 
@@ -97,15 +99,16 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		this[INTERNAL] = {
 			eventsDefinition,
 			handler: this.handler.bind(this),
+			definitionStartOptions: this.definitionStartOptions.bind(this),
 		};
 	}
 
-	private definitionStartOptions(): WorkflowStartOptions {
-		return this.params.retry === undefined ? {} : { retry: this.params.retry };
+	private definitionStartOptions(): WorkflowDefinitionStartOptions {
+		return { retry: this.params.retry };
 	}
 
 	public with(): WorkflowBuilder<Input, Output, Context, TEvents> {
-		const startOptionsOverrider = objectOverrider(this.definitionStartOptions());
+		const startOptionsOverrider = objectOverrider<WorkflowStartOptions>(this.definitionStartOptions());
 		return createWorkflowBuilder(this, startOptionsOverrider());
 	}
 

--- a/testing/src/api/schedule.ts
+++ b/testing/src/api/schedule.ts
@@ -8,6 +8,7 @@ export const intervalScheduleActivateRequestFactory = Factory.define<
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
 	options: {},
+	workflowRunOptions: {},
 	spec: { type: "interval", everyMs: 1_000 },
 }));
 
@@ -17,5 +18,6 @@ export const cronScheduleActivateRequestFactory = Factory.define<
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
 	options: {},
+	workflowRunOptions: {},
 	spec: { type: "cron", expression: "* * * * *" },
 }));

--- a/types/src/api/schedule.ts
+++ b/types/src/api/schedule.ts
@@ -1,4 +1,10 @@
-import type { Schedule, ScheduleActivateOptions, ScheduleSpec, ScheduleStatus } from "../schedule";
+import type {
+	Schedule,
+	ScheduleActivateOptions,
+	ScheduledWorkflowStartOptions,
+	ScheduleSpec,
+	ScheduleStatus,
+} from "../schedule";
 import type { WorkflowSource } from "../workflow";
 
 export interface ScheduleApi {
@@ -17,6 +23,7 @@ export interface ScheduleActivateRequestV1 {
 	workflowRunInput?: unknown;
 	spec: ScheduleSpec;
 	options?: ScheduleActivateOptions;
+	workflowRunOptions?: ScheduledWorkflowStartOptions;
 }
 
 export interface ScheduleActivateResponseV1 {

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -1,3 +1,5 @@
+import type { WorkflowStartOptions } from "./workflow/run";
+
 export type ScheduleId = string & { _brand: "schedule_id" };
 
 export const SCHEDULE_STATUSES = ["active", "paused", "deleted"] as const;
@@ -35,6 +37,8 @@ export interface ScheduleReference {
 	conflictPolicy?: ScheduleConflictPolicy;
 }
 
+export type ScheduledWorkflowStartOptions = Pick<WorkflowStartOptions, "retry" | "shard">;
+
 export interface ScheduleActivateOptions {
 	reference?: ScheduleReference;
 }
@@ -47,6 +51,7 @@ export interface Schedule {
 	spec: ScheduleSpec;
 	workflowRunInput?: unknown;
 	options?: ScheduleActivateOptions;
+	workflowRunOptions?: ScheduledWorkflowStartOptions;
 	createdAt: number;
 	updatedAt: number;
 	lastOccurrence?: number;

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -57,6 +57,8 @@ export interface WorkflowStartOptions {
 	shard?: string;
 }
 
+export type WorkflowDefinitionStartOptions = Pick<WorkflowStartOptions, "retry">;
+
 interface WorkflowRunStateBase {
 	status: WorkflowRunStatus;
 }


### PR DESCRIPTION
## Problem

A schedule is a recurring trigger that fires a workflow run on a cron or interval spec. On the server, a scheduling daemon starts the workflow for each due occurrence.

Every workflow run a set of options it can start with — `WorkflowStartOptions`:

- **retry** — how the run retries when it fails.
- **shard** — which pool of workers runs it.
- **reference** — a correlation id that makes the run addressable.
- **trigger** — when the run starts.

For scheduled runs, retry and shard are the useful ones — you'd want a schedule's runs to retry a certain way, or to run on a certain pool. Trigger makes no sense here cos the schedule occurrence is the trigger time. As for reference, the server auto generates a unique one for each occurrence, hence, it is not the caller's to set.

When activating a schedule, there isn't a way to set set retry or shard options. Every scheduled run simply got the server assigned reference and nothing else. So a run's retry is fixed to whatever its workflow definition declares, and its shard is never set. There's no way to say "this schedule's runs retry three times with exponential backoff," or to send them to the `eu` pool.

## Solution

Schedules gain `workflowRunOptions` — the retry and shard subset of the run start options:

```ts
type ScheduledWorkflowStartOptions = Pick<WorkflowStartOptions, "retry" | "shard">;
```

On the SDK, the schedule builder collects them — retry and shard only, with no path to set a run reference or trigger.

```ts
everyFiveSeconds.with()
  .opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
  .opt("workflowRun.shard", "eu")
  .activate(client, notify, input);
```

The workflow's declared default start options merge with the schedule's overrides once, at activate, before the request is sent. The daemon can't do this merge — it has no access to the workflow's declared defaults.

`workflowRunOptions` becomes part of the schedule's definition hash — the idempotency key used for reference-first lookup and conflict detection. That makes the fired-run options immutable identity: a schedule's options are fixed at creation, and re-activating with different options is a different schedule (or a conflict against the same reference).

The scheduling daemon stamps each fired run with the schedule's retry and shard. Retry lands in the run's start options, which the workflow handler applies when it executes. Shard is set on the outbox row, routing the published run to the requested worker pool.

The dashboard's schedule detail now shows the fired-run retry (summarized per strategy) and shard.

## Breaking changes

- New nullable `workflow_run_options` jsonb column on the schedule table (migration included).
- The definition hash now covers run options, including the empty case. Every schedule created before this change re-activates to a new identity: an anonymous schedule's hash lookup misses and creates a new schedule; a referenced schedule matches its reference but mismatches its hash, raising a conflict (or returning the existing schedule, per its conflict policy).