### PR TITLE
Publish the aiki binary; configurable standalone server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
   # with nothing pushed, migrated, or published.
   verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -94,6 +94,28 @@ jobs:
             done
             rm -rf "$workdir" "$dir/$tarball"
           done
+
+      - name: Compile the aiki binaries
+        working-directory: cli
+        run: |
+          bun scripts/generate-embedded-data.ts
+          for target in bun-linux-x64 bun-linux-arm64 bun-darwin-arm64; do
+            bun build src/index.ts --compile --target="$target" --outfile "dist/aiki-${target#bun-}"
+          done
+
+      - name: Smoke-test the linux-x64 binary
+        env:
+          DATABASE_PROVIDER: pg
+        run: |
+          chmod +x cli/dist/aiki-linux-x64
+          cli/dist/aiki-linux-x64 migrate list --package server,iam
+
+      - name: Upload the aiki binaries
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: aiki-binaries
+          path: cli/dist/aiki-*
+          if-no-files-found: error
 
   images:
     needs: verify
@@ -266,15 +288,23 @@ jobs:
             (cd "$dir" && bun publish --access public)
           done
 
-      # The standalone compose file is attached as an asset so
-      # releases/latest/download/docker-compose.yml always serves the newest
-      # release's pins. Safe to re-run: upload replaces the asset.
+      - name: Download the aiki binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: aiki-binaries
+          path: binaries
+
+      # The standalone compose file and the per-platform aiki binaries are
+      # attached as assets so releases/latest/download/ always serves the
+      # newest release's pins and executables. Safe to re-run: upload replaces
+      # the assets.
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          assets="deploy/docker-compose.yml binaries/aiki-linux-x64 binaries/aiki-linux-arm64 binaries/aiki-darwin-arm64"
           if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" deploy/docker-compose.yml --clobber
+            gh release upload "$GITHUB_REF_NAME" $assets --clobber
           else
-            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes deploy/docker-compose.yml
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes $assets
           fi

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ docker-compose up -d
 # Server: http://localhost:9850 — Dashboard: http://localhost:9851
 ```
 
-See the [Installation Guide](./docs/getting-started/installation.md) for env vars and configuration.
+That is the container path. You can also run the stack from the standalone `aiki` binary — one downloaded executable with its own runtime, no Node, Bun, or Docker — or from source with Bun. See the [Installation Guide](./docs/getting-started/installation.md) for all three, plus env vars and configuration.
 
 <br>
 <p align="center">

--- a/app/dashboard/src/main.tsx
+++ b/app/dashboard/src/main.tsx
@@ -55,8 +55,9 @@ function CapabilitiesError({ error }: { error: unknown }) {
 					Could not load server capabilities from <code>{AIKI_SERVER_URL}</code>
 				</p>
 				<p style={{ fontSize: 13, color: "#888", lineHeight: 1.5, marginBottom: 16 }}>
-					If the dashboard is served on a different origin than the server, it must be built with{" "}
-					<code>VITE_AIKI_SERVER_URL</code> set to the server's URL
+					When this dashboard is on a different origin from the server, ensure the dashboard is built with{" "}
+					<code>VITE_AIKI_SERVER_URL</code> set to the server's URL, and the server's <code>CORS_ORIGINS</code> allows
+					this dashboard's origin.
 				</p>
 				<pre
 					style={{

--- a/app/server/src/config/loader.ts
+++ b/app/server/src/config/loader.ts
@@ -1,19 +1,15 @@
-import { dirname, join } from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
 import { type DatabaseConfig, loadDatabaseConfig } from "@aikirun/lib/db";
 import { omitUndefined } from "@aikirun/lib/object";
 import { type } from "arktype";
-import { config } from "dotenv";
+import { config as loadEnv } from "dotenv";
 
 import { type Config, configSchema } from "./schema";
 
-export async function loadConfig(): Promise<Config & { db: DatabaseConfig }> {
-	const __filename = fileURLToPath(import.meta.url);
-	const __dirname = dirname(__filename);
-	const envPath = join(__dirname, "../../.env");
-
-	config({ path: envPath });
+export async function loadAppServerConfig(params?: { path?: string }): Promise<Config & { db: DatabaseConfig }> {
+	if (params?.path) {
+		loadEnv({ path: params.path });
+	}
 
 	const db = loadDatabaseConfig();
 
@@ -48,3 +44,5 @@ export async function loadConfig(): Promise<Config & { db: DatabaseConfig }> {
 	}
 	return { ...result, db };
 }
+
+export type AppServerConfig = Awaited<ReturnType<typeof loadAppServerConfig>>;

--- a/app/server/src/config/schema.ts
+++ b/app/server/src/config/schema.ts
@@ -29,7 +29,7 @@ export const configSchema = type({
 	host: "string > 0 = '0.0.0.0'",
 	port: "string.integer.parse | number.integer > 0 = 9850",
 	"baseURL?": "string > 0",
-	corsOrigins: uniqueCommaSeparatedToItems.default(""),
+	corsOrigins: uniqueCommaSeparatedToItems.default("http://localhost:9851"),
 	"redis?": redisConfigSchema.or(type("undefined")),
 	"auth?": authConfigSchema.or(type("undefined")),
 	logLevel: type.enumerated(...logLevels).default("info"),

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -1,1 +1,3 @@
+export type { AppServerConfig } from "./config/loader";
+export { loadAppServerConfig } from "./config/loader";
 export { startAppServer } from "./serve";

--- a/app/server/src/main.ts
+++ b/app/server/src/main.ts
@@ -1,3 +1,13 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadAppServerConfig } from "./config/loader";
 import { startAppServer } from "./serve";
 
-await startAppServer();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const envPath = join(__dirname, "../.env");
+
+const config = await loadAppServerConfig({ path: envPath });
+
+await startAppServer({ config });

--- a/app/server/src/serve.ts
+++ b/app/server/src/serve.ts
@@ -5,13 +5,12 @@ import { attachConnectionSupervisor, redisCache, redisPublisher, redisTimerPrior
 import { database, server } from "@aikirun/server";
 import { Redis } from "ioredis";
 
-import { loadConfig } from "./config/loader";
+import type { AppServerConfig } from "./config/loader";
 import type { RedisConfig } from "./config/schema";
 import { createCorsHelpers } from "./cors";
 import { createLogger } from "./logger";
 
-export async function startAppServer(): Promise<void> {
-	const config = await loadConfig();
+export async function startAppServer({ config }: { config: AppServerConfig }): Promise<void> {
 	const logger = createLogger(config.logLevel, config.prettyLogs);
 
 	const redis = config.redis && createRedis(config.redis, logger);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -102,6 +102,7 @@ cli
 					if (!migrations) {
 						throw new Error(`${pkg} ships no ${dbProvider} migrations`);
 					}
+					console.log(`${pkg}`);
 					migrateList({ source: migrationSource(migrations), dbProvider });
 				}
 				return;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/suspicious/noConsole: this prints command output, not logs
 import process from "node:process";
-import { startAppServer } from "@aikirun/app-server";
+import { loadAppServerConfig, startAppServer } from "@aikirun/app-server";
 import { loadDatabaseConfig, loadDatabaseProvider } from "@aikirun/lib/db";
 import { migrateApply, migrateList, migrationSource } from "@aikirun/lib/db/migrate";
 import { isMigrateSubcommand, MIGRATE_SUBCOMMAND_HELP, MIGRATE_SUBCOMMANDS } from "@aikirun/lib/db/migrate/cli";
@@ -114,8 +114,9 @@ cli
 
 cli
 	.command("server [subcommand]", "Run the Aiki server (start)")
+	.option("--env-file <path>", "Path to env file")
 	.example((name) => `  $ ${name} server start   run the server`)
-	.action(async (subcommand: string | undefined) => {
+	.action(async (subcommand: string | undefined, options: { envFile?: string }) => {
 		if (subcommand === undefined) {
 			cli.outputHelp();
 			return;
@@ -123,7 +124,8 @@ cli
 		if (subcommand !== "start") {
 			throw new Error(`Unknown server subcommand "${subcommand}". Expected: start.`);
 		}
-		await startAppServer();
+		const config = await loadAppServerConfig({ path: options.envFile });
+		await startAppServer({ config });
 	});
 
 const SUBCOMMAND_HELP: Record<string, Record<string, string>> = {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 How you install Aiki depends on what you're doing:
 
 - **Building workflows** — add the SDK to your TypeScript project and run the server embedded in your app, or point your app at a hosted Aiki server. Follow [Add Aiki to your project](#add-aiki-to-your-project).
-- **Hosting Aiki** — stand up the standalone server and web dashboard as infrastructure, with no SDK install. You need a PostgreSQL database, plus either Docker for the ready-made stack or Bun to run from source. Follow [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
+- **Hosting Aiki** — run the standalone server and web dashboard as infrastructure, with no SDK install. You need a PostgreSQL database. Run it from the prebuilt `aiki` binary, the ready-made Docker stack, or from source with Bun. Follow [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
 
 ## Add Aiki to your project
 
@@ -17,7 +17,7 @@ npm install @aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server
 
 ### Apply the schema migration
 
-If your server will be the standalone stack from [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard), skip this step — the Docker Compose path applies migrations itself on `up`, and the from-source instructions include their own migrate step.
+If you will [run the standalone server](#run-the-standalone-server-and-dashboard), skip this step — that section covers migration for each way of running it.
 
 ```bash
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
@@ -28,21 +28,51 @@ Re-run this command when upgrading Aiki to apply new migrations.
 
 ### Run the server
 
-Mount `aikiServer.handler` in any HTTP framework — in the same process as your app, or in a process dedicated to Aiki. The [Quick Start](./quick-start.md) walks through this end-to-end, including worker and client.
+Mount aiki server handler in any HTTP framework — in the same process as your app, or in a process dedicated to Aiki. The [Quick Start](./quick-start.md) walks through this end-to-end, including worker and client.
 
 Workflow code is identical against an embedded or standalone server, so you can also skip embedding entirely and point your client at a server hosted per [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
 
+Want the web dashboard against your embedded server? Serve it separately — see [Run the dashboard on its own](#run-the-dashboard-on-its-own).
+
 ## Run the standalone server and dashboard
 
-The stack is three containers:
+Hosting Aiki as infrastructure means running two components:
 
-- **Migrate** — runs `aiki migrate apply --package server` and exits. Also runs `aiki migrate apply --package iam` if the server will run with auth (`AIKI_SERVER_AUTH_SECRET`). Needs `DATABASE_URL`.
 - **Server** — the Aiki server. Needs `DATABASE_URL`.
-- **Dashboard** — the web UI; proxies browser calls to the server set in `AIKI_SERVER_UPSTREAM_URL`.
 
-Start them in that order: migrate must finish before the server starts. You only need the migrate step on a fresh database or when an upgrade ships new migrations, but it is safe to run every time — already-applied migrations are skipped. Docker Compose is the easy path; one command does all of this.
+However you run the server, applications connect the same way:
+```typescript
+const aikiClient = client({ url: "http://localhost:9850" });
+```
 
-### With Docker Compose
+- **Dashboard** — the web UI, a single-page app that talks to the server.
+
+Before the server starts, apply the schema. This one-off **migration step** applies the server package's migrations, plus the iam package's when the server runs with auth (`AIKI_SERVER_AUTH_SECRET`). It needs `DATABASE_URL`, and is safe to repeat: run it on a fresh database or when an aiki upgrade ships new migrations. Already-applied migrations are skipped.
+
+There are three ways to run this stack:
+
+- **The `aiki` binary** — one downloaded executable with its own runtime, no Node, Bun, or Docker to install.
+- **Docker** — run the published images, brought up together by Compose or on their own. Best if you already run containers.
+- **From source** — clone at a release tag and run with Bun. Best for contributors.
+
+### With the aiki binary
+
+Download the `aiki` binary for your platform from the [latest release](https://github.com/aikirun/aiki/releases/latest) and put it on your `PATH`. It carries the migrate and server commands plus its own runtime.
+
+```bash
+export DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
+
+aiki migrate apply     # migrates the server package; use --package server,iam to include iam
+aiki server start      # serves on :9850
+```
+
+The dashboard ships separately — serve it as a static site (see [Run the dashboard on its own](#run-the-dashboard-on-its-own)) or from the dashboard image (see [With Docker](#with-docker)). A dashboard on a different origin than the server needs its origin added to the server's `CORS_ORIGINS`.
+
+### With Docker
+
+The published images cover the stack: `ghcr.io/aikirun/cli` — the same `aiki` binary — runs the migration, `ghcr.io/aikirun/server` runs the server, and `ghcr.io/aikirun/dashboard` serves the web UI. Compose wires them together; you can also run them yourself.
+
+#### With Docker Compose
 
 Download the standalone compose file from the latest release into an empty directory — it pulls that release's published images, so there is nothing to clone or build:
 
@@ -64,13 +94,27 @@ docker-compose up -d
 - Server: http://localhost:9850
 - Dashboard: http://localhost:9851
 
-The migrate step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker-compose up -d`.
+The migration step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker-compose up -d`.
 
-Applications connect by pointing their client at the server's URL:
+#### Without Docker Compose
 
-```typescript
-const aikiClient = client({ url: "http://localhost:9850" });
+Run the images yourself when you orchestrate containers with your own tooling. Migrate first, then start the server and dashboard against it:
+
+```bash
+# migration
+docker run --rm -e DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki \
+  ghcr.io/aikirun/cli:<version> migrate apply --package server
+
+# server
+docker run -p 9850:9850 -e DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki \
+  ghcr.io/aikirun/server:<version>
+
+# dashboard, proxying browser calls to the server
+docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 \
+  ghcr.io/aikirun/dashboard:<version>
 ```
+
+Add `--package server,iam` to the migration when the server runs with auth. The dashboard image proxies to the server, so it needs no `CORS_ORIGINS`; to serve the dashboard from a static host instead, see [Run the dashboard on its own](#run-the-dashboard-on-its-own). Pick versions from the [releases](https://github.com/aikirun/aiki/releases).
 
 ### From source
 
@@ -83,7 +127,7 @@ bun install
 cp app/server/.env.example app/server/.env
 # Edit app/server/.env with your DATABASE_URL
 
-bun run db:migrate:apply:server   # the migrate step
+bun run db:migrate:apply:server   # the migration step
 bun run server                    # Terminal 1
 bun run dashboard                 # Terminal 2
 ```
@@ -92,11 +136,9 @@ Run `bun run db:migrate:apply:iam` too when the server will run with auth. One p
 
 ## Run the dashboard on its own
 
-If you ran the standalone stack above, the dashboard is already up — skip this section. Run the dashboard separately when your server is embedded in your app or hosted elsewhere. It is a single-page app that calls the server from the browser, and there are two ways to serve it.
+Serve the dashboard by itself when the server is embedded in your app (the [SDK path above](#add-aiki-to-your-project)) or hosted somewhere the bundled stack does not reach. It is a single-page app that calls the server from the browser. Serve it as a static site; to run it as a container instead, use the dashboard image under [With Docker](#with-docker).
 
-### On a static host
-
-The right fit when the server is embedded in your app or hosted on its own. The server's URL is baked in at build time, so the dashboard is built per deployment (the build needs Bun) — from the release tag matching your installed `@aikirun/*` version:
+The server's URL is baked into the bundle at build time, so the dashboard is built per deployment (the build needs Bun) — from the release tag matching your installed `@aikirun/*` version:
 
 ```bash
 git clone --branch v0.32.0 https://github.com/aikirun/aiki.git
@@ -106,15 +148,7 @@ bun run build:types
 VITE_AIKI_SERVER_URL=https://aiki.example.com bun run build:dashboard
 ```
 
-Deploy `app/dashboard/dist/` to any static file host, and add the dashboard's origin to the server's `CORS_ORIGINS`. A build that forgot `VITE_AIKI_SERVER_URL` fails loudly in the browser: the dashboard reaches no server, and its error screen names the variable.
-
-### As a Docker image
-
-The image needs no build-time configuration: nginx inside it serves the dashboard and proxies its server calls to the address in `AIKI_SERVER_UPSTREAM_URL`, read at container start. Browser traffic stays on one origin, so no CORS setup is needed. Pick the version matching your server from the [releases](https://github.com/aikirun/aiki/releases):
-
-```bash
-docker run -p 9851:9851 -e AIKI_SERVER_UPSTREAM_URL=http://your-server:9850 ghcr.io/aikirun/dashboard:<version>
-```
+Deploy `app/dashboard/dist/` to any static file host. Because the browser calls the server cross-origin, two things must line up: the build sets `VITE_AIKI_SERVER_URL` to the server's URL, and the server's `CORS_ORIGINS` allows the dashboard's origin. Miss either and the dashboard fails loudly in the browser — its error screen names both.
 
 ## Environment Variable Reference
 
@@ -147,7 +181,7 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `AIKI_DASHBOARD_PORT` | No | `9851` | Port for the dashboard |
 | `VITE_AIKI_SERVER_URL` | If on a static host | — | Build-time server URL for a dashboard served outside the docker image |
 
-Which variable applies depends on the deployment mode — see [Run the dashboard on its own](#run-the-dashboard-on-its-own). The bundled `docker-compose.yml` sets `AIKI_SERVER_UPSTREAM_URL` for you.
+Which variable applies depends on how you serve the dashboard: the docker image reads `AIKI_SERVER_UPSTREAM_URL` (see [With Docker](#with-docker)), and a static-host build reads `VITE_AIKI_SERVER_URL` (see [Run the dashboard on its own](#run-the-dashboard-on-its-own)). The bundled `docker-compose.yml` sets `AIKI_SERVER_UPSTREAM_URL` for you.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -66,7 +66,9 @@ aiki migrate apply     # migrates the server package; use --package server,iam t
 aiki server start      # serves on :9850
 ```
 
-The dashboard ships separately — serve it as a static site (see [Run the dashboard on its own](#run-the-dashboard-on-its-own)) or from the dashboard image (see [With Docker](#with-docker)). A dashboard on a different origin than the server needs its origin added to the server's `CORS_ORIGINS`.
+Both commands read configuration from the environment; pass `--env-file <path>` to load it from a file instead.
+
+The dashboard ships separately — serve it as a static site (see [Run the dashboard on its own](#run-the-dashboard-on-its-own)) or from a container (see [With Docker](#with-docker)). A dashboard on a different origin than the server needs its origin added to the server's `CORS_ORIGINS` (via `--env-file` or the environment).
 
 ### With Docker
 


### PR DESCRIPTION
## Background

The standalone `aiki` binary — the executable that bundles the `migrate` and `server` commands — shipped on `main`, but only inside the `aikirun/cli` container image. Three gaps kept the binary from being a real deployment option:

- **Nothing published it for download.** The binary was compiled only inside the cli image, so there was no executable to grab from the release page.
- **`aiki server start` couldn't be configured.** The standalone server loaded its own config from a fixed `.env` path next to its source, with no way for a caller to point it elsewhere. A binary user had no file-based way to pass `DATABASE_URL`, `CORS_ORIGINS`, or anything else.
- **A browser dashboard couldn't reach a binary-run server out of the box.** `CORS_ORIGINS` defaulted to empty, so the dashboard's cross-origin calls were rejected unless the operator set the variable.

## Solution

**Publish the binary.** The release compiles the binary for each target platform (linux x64, linux arm64, darwin arm64), smoke-tests the one the runner can execute, and attaches all three to the GitHub release. The compile and smoke test run before any image push or npm publish, so a build failure aborts the release with nothing shipped.

**Config is passed into the server, not loaded by it.** `startAppServer` takes its resolved config as a parameter, and a separate loader reads the environment — plus a dotenv file when handed a path.

```ts
// before
startAppServer(): Promise<void>                            // loaded a fixed .env internally

// after
loadAppServerConfig({ path? }): Promise<AppServerConfig>   // reads env; dotenv only when path is given
startAppServer({ config }): Promise<void>
```

`aiki server start` gains `--env-file`: it loads config from that path and passes it in, so a binary user supplies `DATABASE_URL`, `CORS_ORIGINS`, and the rest from a file. Without the flag it reads the process environment.

**CORS defaults to the local dashboard.** When `CORS_ORIGINS` is unset, the standalone server now allows `http://localhost:9851` — the dashboard's default origin — so a local dashboard reaches a binary-run server with no configuration. Setting `CORS_ORIGINS` replaces the default.

**The dashboard error screen names both cross-origin fixes.** When the dashboard's startup probe can't load the server's capabilities, the browser reports an unreachable server and a CORS rejection identically — it can't tell them apart. The screen now names both fixes — the build-time server URL and the server's `CORS_ORIGINS` — instead of only the former.

**Hosting docs reworked.** The guide frames the standalone deployment as two components (server, dashboard) plus a one-off migration step, presents three deploy paths (the binary, Docker, from source), makes Docker an umbrella over Compose and running the images directly, and scopes the standalone-dashboard section to static hosting.

Also minor: `aiki migrate list` prints each package's name before its migrations, so a multi-package listing is legible.

## Breaking changes

- The standalone server's `CORS_ORIGINS` now defaults to `http://localhost:9851` instead of empty. A server started with no `CORS_ORIGINS` set accepts browser requests from that origin (and trusts it for auth). Setting `CORS_ORIGINS` overrides the default.
