### PR TITLE
Query release tags via ls-remote; gate releases to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,14 @@ jobs:
     outputs:
       version: ${{ steps.lockstep.outputs.version }}
     steps:
+      - name: Releases run from main only
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "releases must be dispatched from main, got $GITHUB_REF" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-tags: true
 
       - id: lockstep
         uses: ./.github/actions/check-lockstep
@@ -47,12 +52,17 @@ jobs:
           VERSION: ${{ steps.lockstep.outputs.version }}
         run: |
           tag="v$VERSION"
-          if git rev-parse -q --verify "refs/tags/$tag^{commit}" >/dev/null; then
-            tagged_sha="$(git rev-parse "refs/tags/$tag^{commit}")"
-            if [ "$tagged_sha" != "$GITHUB_SHA" ]; then
-              echo "tag $tag already exists at $tagged_sha, not $GITHUB_SHA — run bun run bump" >&2
-              exit 1
-            fi
+          # Query the remote, not the local checkout: a shallow clone may not
+          # have the tag's commit object, and the remote is the push target that
+          # must not collide. Compare the peeled commit an annotated tag points
+          # to, falling back to the ref itself for a lightweight tag.
+          tagged_sha="$(git ls-remote --tags origin "refs/tags/$tag^{}" | awk '{print $1}')"
+          if [ -z "$tagged_sha" ]; then
+            tagged_sha="$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')"
+          fi
+          if [ -n "$tagged_sha" ] && [ "$tagged_sha" != "$GITHUB_SHA" ]; then
+            echo "tag $tag already exists at $tagged_sha, not $GITHUB_SHA — run bun run bump" >&2
+            exit 1
           fi
 
       - uses: ./.github/actions/setup-workspace
@@ -119,6 +129,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: release
     env:
       VERSION: ${{ needs.verify.outputs.version }}
     steps:
@@ -127,19 +138,20 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          fetch-tags: true
 
       - name: Create and push the release tag
         run: |
           tag="v$VERSION"
-          if git rev-parse -q --verify "refs/tags/$tag^{commit}" >/dev/null; then
-            echo "tag $tag already present — heal re-run, nothing to do"
+          # verify already failed the run if the tag exists at another commit,
+          # so a tag on the remote here is a heal re-run at this same commit.
+          if [ -n "$(git ls-remote --tags origin "refs/tags/$tag")" ]; then
+            echo "tag $tag already present on the remote — heal re-run, nothing to do"
             exit 0
           fi
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"


### PR DESCRIPTION
The re-release guard and the tag job's heal check ran git rev-parse against the shallow verify checkout, which can't resolve a fetched tag's commit — so the guard fell through and a no-bump run wasn't caught. Query the remote with git ls-remote instead; it needs no local objects and the remote is the actual push target.

Also gate the pipeline: a github.ref check in verify fails a dispatch from anywhere but main, and the tag job moves into the release environment so the App token (now via client-id) is environment-scoped and issued only on main.