### PR TITLE
Database TLS from the connection URL, with CA verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
         env:
           DATABASE_PROVIDER: ${{ vars.DATABASE_PROVIDER }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_SSL: "true"
+          DATABASE_CA_CERT: ${{ secrets.DATABASE_CA_CERT }}
         run: |
           bun sdk/server/src/bin.ts migrate apply
           bun sdk/iam/src/bin.ts migrate apply

--- a/app/server/.env.example
+++ b/app/server/.env.example
@@ -18,7 +18,8 @@ DATABASE_PROVIDER=pg
 # PostgreSQL / MySQL only
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki
 DATABASE_MAX_CONNECTIONS=10
-DATABASE_SSL=false
+# To verify the DB's cert against a private CA (e.g. DigitalOcean, RDS), set its PEM contents here:
+# DATABASE_CA_CERT=
 
 # SQLite only
 # DATABASE_PATH=:memory:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}
-      DATABASE_SSL: ${DATABASE_SSL:-false}
+      DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: ["migrate", "apply", "--package", "${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}"]
@@ -31,7 +31,7 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
-      DATABASE_SSL: ${DATABASE_SSL:-false}
+      DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
       REDIS_HOST: ${REDIS_HOST:-}
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}
-      DATABASE_SSL: ${DATABASE_SSL:-false}
+      DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command: ["migrate", "apply", "--package", "${AIKI_MIGRATE_PACKAGES:-server${AIKI_SERVER_AUTH_SECRET:+,iam}}"]
@@ -37,7 +37,7 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
-      DATABASE_SSL: ${DATABASE_SSL:-false}
+      DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
       REDIS_HOST: ${REDIS_HOST:-}
       REDIS_PORT: ${REDIS_PORT:-6379}
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -163,7 +163,7 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `DATABASE_PROVIDER` | No | `pg` | Database provider; `pg` is supported today, `sqlite` and `mysql` coming soon |
 | `DATABASE_URL` | Yes | — | Postgres connection string |
 | `DATABASE_MAX_CONNECTIONS` | No | `10` | Connection pool size |
-| `DATABASE_SSL` | No | `false` | Enable SSL for Postgres |
+| `DATABASE_CA_CERT` | No | — | PEM contents of a CA certificate used to verify the database's TLS certificate. Needed to verify against a private CA (e.g. DigitalOcean, RDS) |
 | `AIKI_SERVER_HOST` | No | `0.0.0.0` | Bind address |
 | `AIKI_SERVER_PORT` | No | `9850` | Server port |
 | `AIKI_SERVER_BASE_URL` | If IAM is on | — | Public URL of the server; required only when `AIKI_SERVER_AUTH_SECRET` is also set |

--- a/lib/src/db/config.ts
+++ b/lib/src/db/config.ts
@@ -5,20 +5,18 @@ import { DATABASE_PROVIDERS, type DatabaseProvider, isDatabaseProvider } from ".
 import { omitUndefined } from "../object";
 import type { Equal, ExpectTrue } from "../testing/expect";
 
-const coerceBool = type("'true' | 'false' | '1' | '0'").pipe((v) => v === "true" || v === "1");
-
 const pgDatabaseConfigSchema = type({
 	provider: "'pg'",
 	url: "string > 0",
 	maxConnections: "string.integer.parse | number.integer > 0 = 10",
-	ssl: type("boolean").or(coerceBool).default(false),
+	"caCert?": "string > 0",
 });
 
 const mysqlDatabaseConfigSchema = type({
 	provider: "'mysql'",
 	url: "string > 0",
 	maxConnections: "string.integer.parse | number.integer > 0 = 10",
-	ssl: type("boolean").or(coerceBool).default(false),
+	"caCert?": "string > 0",
 });
 
 const sqliteDatabaseConfigSchema = type({
@@ -57,7 +55,7 @@ export function loadDatabaseConfig(): DatabaseConfig {
 					provider,
 					url: process.env.DATABASE_URL,
 					maxConnections: process.env.DATABASE_MAX_CONNECTIONS,
-					ssl: process.env.DATABASE_SSL,
+					caCert: process.env.DATABASE_CA_CERT || undefined,
 				};
 			default:
 				return provider satisfies never;

--- a/lib/src/db/migrate/commands/apply.ts
+++ b/lib/src/db/migrate/commands/apply.ts
@@ -29,7 +29,7 @@ async function applyPg(config: PgDatabaseConfig, migrations: MigrationMeta[], mi
 	const postgres = await importPostgres();
 	const client = postgres(config.url, {
 		max: 1,
-		ssl: config.ssl ? "require" : undefined,
+		ssl: config.caCert ? { ca: config.caCert, rejectUnauthorized: true } : undefined,
 	});
 	const db = drizzle(client);
 

--- a/sdk/server/src/infra/db/index.ts
+++ b/sdk/server/src/infra/db/index.ts
@@ -20,7 +20,7 @@ async function createDatabase(config: PgDatabaseConfig): Promise<Database> {
 	const postgres = await importPostgres();
 	const client = postgres(config.url, {
 		max: config.maxConnections,
-		ssl: config.ssl,
+		ssl: config.caCert ? { ca: config.caCert, rejectUnauthorized: true } : undefined,
 	});
 	return { provider: "pg", [INTERNAL]: { client } };
 }


### PR DESCRIPTION
## Motivation

Database TLS was configured with a `DATABASE_SSL` boolean. Two places build the Postgres client — the migrate command and the server runtime — and they read that boolean differently. Migrate connected with `sslmode=require`: encrypt the connection, but don't verify the server's certificate. The server runtime connected with verification against the system trust store.

Managed Postgres providers such as DigitalOcean and Amazon RDS present a certificate signed by their own private CA, which is not in the system trust store. So with TLS enabled against one of them, the two paths diverged. The migrate step connected. The running server then failed to connect with `SELF_SIGNED_CERT_IN_CHAIN`. The boolean also had no way to express "verify against this specific CA" — its only settings were verify-against-system-CAs or no encryption at all.

## Solution

TLS strictness now comes from the connection URL's `sslmode`, the standard Postgres surface that managed providers already populate in the URL they give you. A new optional `DATABASE_CA_CERT` holds a CA certificate's PEM contents and serves as the trust anchor for verification. Both client sites apply one rule:

- No CA cert: the driver's `ssl` option is left unset, so it honors the URL's `sslmode`.
- CA cert set: the connection verifies the server's certificate against that CA, and checks the hostname.

The `ssl` option collapses to one expression at both sites:

```ts
// before — migrate command
ssl: config.ssl ? "require" : undefined
// before — server runtime
ssl: config.ssl

// after — both
ssl: config.caCert ? { ca: config.caCert, rejectUnauthorized: true } : undefined
```

The config field changes from a boolean `ssl` to an optional `caCert` string. The server and the migrate step now connect identically against any provider. IAM runs on the server's connection, so it needs no change of its own.

An empty `DATABASE_CA_CERT` is treated as absent. The Docker Compose files and the release workflow inject an empty string when the value is unset, and the schema requires a non-empty string, so the loader maps empty to unset.

## Verification

The failure this fixes only appears against a real managed database, so it is worth checking by hand:

- Point the server at a managed Postgres whose URL carries `?sslmode=require`, with no `DATABASE_CA_CERT`. It connects instead of throwing `SELF_SIGNED_CERT_IN_CHAIN`.
- Set `DATABASE_CA_CERT` to that provider's CA certificate. The connection succeeds and now verifies the server's certificate.

## Breaking changes

`DATABASE_SSL` is removed. Database TLS is controlled by the connection URL's `sslmode`, with an optional `DATABASE_CA_CERT` to verify against a private CA.
