### PR TITLE
Split claim keepalive from subscriber heartbeat

### DIFF
--- a/lib/src/async/index.ts
+++ b/lib/src/async/index.ts
@@ -1,5 +1,6 @@
 export * from "./delay";
 export * from "./fire-and-forget";
+export * from "./interval";
 export * from "./latch";
 export * from "./settle-within";
 export * from "./stream";

--- a/lib/src/async/interval.test.ts
+++ b/lib/src/async/interval.test.ts
@@ -1,0 +1,160 @@
+import { delay } from "./delay";
+import { runOnInterval } from "./interval";
+import { describe, expect, spyOn, test } from "bun:test";
+
+describe("runOnInterval", () => {
+	test("does not invoke fn synchronously", () => {
+		let called = false;
+		const { stop } = runOnInterval(
+			async () => {
+				called = true;
+			},
+			{ intervalMs: 1_000, onError: () => {} }
+		);
+
+		expect(called).toBe(false);
+		stop();
+	});
+
+	test("invokes fn repeatedly on the interval", async () => {
+		let calls = 0;
+		let resolveThird: () => void = () => {};
+		const thirdCall = new Promise<void>((resolve) => {
+			resolveThird = resolve;
+		});
+
+		const { stop } = runOnInterval(
+			async () => {
+				calls += 1;
+				if (calls === 3) {
+					resolveThird();
+				}
+			},
+			{ intervalMs: 1, onError: () => {} }
+		);
+
+		await thirdCall;
+		stop();
+		expect(calls).toBeGreaterThanOrEqual(3);
+	});
+
+	test("stop prevents further invocations", async () => {
+		let calls = 0;
+		let resolveFirst: () => void = () => {};
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		const { stop } = runOnInterval(
+			async () => {
+				calls += 1;
+				resolveFirst();
+			},
+			{ intervalMs: 1, onError: () => {} }
+		);
+
+		await firstCall;
+		stop();
+		const callsAtStop = calls;
+
+		await delay(20);
+		expect(calls).toBe(callsAtStop);
+	});
+
+	test("aborting the signal stops further invocations", async () => {
+		const controller = new AbortController();
+		let calls = 0;
+		let resolveFirst: () => void = () => {};
+		const firstCall = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		runOnInterval(
+			async () => {
+				calls += 1;
+				resolveFirst();
+			},
+			{ intervalMs: 1, onError: () => {}, signal: controller.signal }
+		);
+
+		await firstCall;
+		controller.abort();
+		const callsAtAbort = calls;
+
+		await delay(20);
+		expect(calls).toBe(callsAtAbort);
+	});
+
+	test("re-reads a function intervalMs on each tick", async () => {
+		let reads = 0;
+		let calls = 0;
+		let resolveSecond: () => void = () => {};
+		const secondCall = new Promise<void>((resolve) => {
+			resolveSecond = resolve;
+		});
+
+		const { stop } = runOnInterval(
+			async () => {
+				calls += 1;
+				if (calls === 2) {
+					resolveSecond();
+				}
+			},
+			{
+				intervalMs: () => {
+					reads += 1;
+					return 1;
+				},
+				onError: () => {},
+			}
+		);
+
+		await secondCall;
+		stop();
+		expect(reads).toBeGreaterThanOrEqual(2);
+	});
+
+	test("routes fn rejections to onError and keeps running", async () => {
+		const errors: Error[] = [];
+		let calls = 0;
+		let resolveSecondError: () => void = () => {};
+		const secondError = new Promise<void>((resolve) => {
+			resolveSecondError = resolve;
+		});
+
+		const { stop } = runOnInterval(
+			async () => {
+				calls += 1;
+				throw new Error(`boom ${calls}`);
+			},
+			{
+				intervalMs: 1,
+				onError: (error) => {
+					errors.push(error);
+					if (errors.length === 2) {
+						resolveSecondError();
+					}
+				},
+			}
+		);
+
+		await secondError;
+		stop();
+		expect(errors.length).toBeGreaterThanOrEqual(2);
+		expect(errors[0]?.message).toBe("boom 1");
+	});
+
+	test("stop detaches the abort listener", () => {
+		const controller = new AbortController();
+		const removeListener = spyOn(controller.signal, "removeEventListener");
+
+		const { stop } = runOnInterval(async () => {}, {
+			intervalMs: 1_000,
+			onError: () => {},
+			signal: controller.signal,
+		});
+		stop();
+
+		expect(removeListener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/src/async/interval.ts
+++ b/lib/src/async/interval.ts
@@ -1,0 +1,37 @@
+import { fireAndForget } from "./fire-and-forget";
+
+export function runOnInterval(
+	fn: () => Promise<void>,
+	options: {
+		intervalMs: number | (() => number);
+		onError: (error: Error) => void;
+		signal?: AbortSignal;
+	}
+): { stop: () => void } {
+	const { intervalMs, onError, signal } = options;
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const tick = (): void => {
+		timeout = setTimeout(
+			() => {
+				fireAndForget(fn(), onError);
+				if (!signal?.aborted) {
+					tick();
+				}
+			},
+			typeof intervalMs === "number" ? intervalMs : intervalMs()
+		);
+	};
+
+	const stop = (): void => {
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+		signal?.removeEventListener("abort", stop);
+	};
+	signal?.addEventListener("abort", stop, { once: true });
+
+	tick();
+
+	return { stop };
+}

--- a/sdk/adapter/http/src/queue/subscriber.ts
+++ b/sdk/adapter/http/src/queue/subscriber.ts
@@ -16,14 +16,12 @@ export interface HttpSubscriberParams {
 export interface HttpSubscriberOptions {
 	intervalMs?: number;
 	maxRetryIntervalMs?: number;
-	claimMinIdleTimeMs?: number;
 }
 
 export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 	const { api, options } = params;
 	const intervalMs = options?.intervalMs ?? 1_000;
 	const maxRetryIntervalMs = options?.maxRetryIntervalMs ?? 30_000;
-	const claimMinIdleTimeMs = options?.claimMinIdleTimeMs ?? 90_000;
 
 	const getNextDelay = (delayParams: SubscriberDelayParams) => {
 		switch (delayParams.type) {
@@ -55,7 +53,6 @@ export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 						workflows: workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId })),
 						shards,
 						limit: size,
-						claimMinIdleTimeMs,
 					},
 					{ signal }
 				);

--- a/sdk/endpoint/src/endpoint.ts
+++ b/sdk/endpoint/src/endpoint.ts
@@ -2,7 +2,7 @@ import { asConfigProvider, type ConfigProvider, type CreatePassiveConfigProvider
 import { merge } from "@aikirun/lib/object";
 import type { Client } from "@aikirun/types/client";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
-import type { WorkflowRunId, WorkflowRunRecord } from "@aikirun/types/workflow/run";
+import type { WorkflowRunRecord } from "@aikirun/types/workflow/run";
 import { type AnyWorkflowVersion, executeWorkflowRun, getSystemWorkflows, workflowRegistry } from "@aikirun/workflow";
 
 import { defaultEndpointConfig, type EndpointConfig, type EndpointConfigOverrides } from "./config";
@@ -97,7 +97,6 @@ export function endpoint(params: EndpointParams): (request: Request) => Promise<
 			workflowVersion,
 			logger: runLogger,
 			configProvider: configProvider.scope("workflowRun"),
-			heartbeat: () => client.api.workflowRun.heartbeatV1({ id: workflowRun.id as WorkflowRunId }),
 		});
 
 		return jsonResponse(success ? 200 : 500);

--- a/sdk/server/src/config/runtime.ts
+++ b/sdk/server/src/config/runtime.ts
@@ -1,4 +1,5 @@
 import type { DeepPartial } from "@aikirun/lib/object";
+import { DEFAULT_CLAIM_MIN_IDLE_TIME_MS } from "@aikirun/types/workflow/run";
 
 interface PollingDaemonConfig {
 	intervalMs: number;
@@ -76,7 +77,7 @@ export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 		republishStaleRuns: {
 			intervalMs: 1_000,
 			limit: 1_000,
-			claimMinIdleTimeMs: 90_000,
+			claimMinIdleTimeMs: DEFAULT_CLAIM_MIN_IDLE_TIME_MS,
 		},
 		dueTimersConsumer: {
 			limit: 1_000,

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -343,7 +343,7 @@ const claimReadyV1: ContractProcedure<WorkflowRunClaimReadyRequestV1, WorkflowRu
 				.atLeastLength(1),
 			"shards?": type("string > 0").array().or("undefined"),
 			limit: "number.integer > 0",
-			claimMinIdleTimeMs: "number.integer > 0",
+			"claimMinIdleTimeMs?": "number.integer > 0",
 		})
 	)
 	.output(

--- a/sdk/server/src/service/workflow-run-outbox.ts
+++ b/sdk/server/src/service/workflow-run-outbox.ts
@@ -1,6 +1,6 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { WorkflowRunClaimReadyRequestV1 } from "@aikirun/types/api/workflow-run";
-import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import { DEFAULT_CLAIM_MIN_IDLE_TIME_MS, type WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
@@ -63,7 +63,7 @@ async function stealStaleClaimed(
 	return repo.stealStaleClaimed(
 		context.namespaceId,
 		{ workflows, shards: request.shards },
-		request.claimMinIdleTimeMs,
+		request.claimMinIdleTimeMs ?? DEFAULT_CLAIM_MIN_IDLE_TIME_MS,
 		request.limit
 	);
 }

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -126,7 +126,6 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 	private readonly availableCapacityLatch = createBinaryLatch();
 	private readonly pendingWorkflowRunIds = new Set<string>();
 	private readonly activeWorkflowRunsById = new Map<string, ActiveWorkflowRun>();
-	private readonly lastServerHeartbeatByRunId = new Map<string, number>();
 	private stopPromise: Promise<void> | undefined;
 
 	constructor(
@@ -169,9 +168,6 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			logger: this.logger.child({ "aiki.subscriber": "primary" }),
 			signal,
 		});
-		this.primarySubscriber.heartbeat = this.withServerHeartbeatForwarding(
-			this.primarySubscriber.heartbeat?.bind(this.primarySubscriber)
-		);
 
 		// Backup subscriber is only created if the user provided a custom subscriber.
 		// When the custom subscriber is present, we know for sure that it is not httpSubscriber
@@ -185,9 +181,6 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 				logger: this.logger.child({ "aiki.subscriber": "backup" }),
 				signal,
 			});
-			this.backupSubscriber.heartbeat = this.withServerHeartbeatForwarding(
-				this.backupSubscriber.heartbeat?.bind(this.backupSubscriber)
-			);
 		}
 
 		this.subscriberLoopPromise = this.subscriberLoop(signal).catch((error) => {
@@ -235,24 +228,6 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 
 		this.pendingWorkflowRunIds.clear();
 		this.activeWorkflowRunsById.clear();
-		this.lastServerHeartbeatByRunId.clear();
-	}
-
-	private withServerHeartbeatForwarding(heartbeat?: (workflowRunId: WorkflowRunId) => Promise<void>) {
-		const serverHeartbeatIntervalMs = 30_000;
-
-		return async (workflowRunId: WorkflowRunId) => {
-			if (heartbeat) {
-				await heartbeat(workflowRunId);
-			}
-
-			const now = Date.now();
-			const lastServerHeartbeat = this.lastServerHeartbeatByRunId.get(workflowRunId) ?? 0;
-			if (now - lastServerHeartbeat >= serverHeartbeatIntervalMs) {
-				this.lastServerHeartbeatByRunId.set(workflowRunId, now);
-				await this.client.api.workflowRun.heartbeatV1({ id: workflowRunId });
-			}
-		};
 	}
 
 	private async subscriberLoop(signal: AbortSignal): Promise<void> {
@@ -477,7 +452,6 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			}
 		} finally {
 			this.activeWorkflowRunsById.delete(workflowRunId);
-			this.lastServerHeartbeatByRunId.delete(workflowRunId);
 			this.availableCapacityLatch.signal();
 		}
 	}

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -1,14 +1,16 @@
-import { fireAndForget } from "@aikirun/lib/async";
+import { runOnInterval } from "@aikirun/lib/async";
 import type { ConfigProvider } from "@aikirun/lib/config";
 import type { Logger } from "@aikirun/lib/logger";
 import type { Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
-import type { WorkflowRunId, WorkflowRunRecord } from "@aikirun/types/workflow/run";
 import {
+	CLAIM_KEEPALIVE_INTERVAL_MS,
 	NonDeterminismError,
 	WorkflowRunFailedError,
+	type WorkflowRunId,
 	WorkflowRunNotExecutableError,
+	type WorkflowRunRecord,
 	WorkflowRunRevisionConflictError,
 	WorkflowRunSuspendedError,
 } from "@aikirun/types/workflow/run";
@@ -44,34 +46,37 @@ export interface WorkflowExecutionConfig {
 
 export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<Context>): Promise<boolean> {
 	const { client, workflowRun, workflowVersion, logger, configProvider, heartbeat, signal } = params;
+	const workflowRunId = workflowRun.id as WorkflowRunId;
 
-	let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
-	let onAbort: (() => void) | undefined;
-
+	const heartbeats: Array<{ stop: () => void }> = [];
 	try {
+		heartbeats.push(
+			runOnInterval(() => client.api.workflowRun.heartbeatV1({ id: workflowRunId }), {
+				intervalMs: CLAIM_KEEPALIVE_INTERVAL_MS,
+				onError: (error: Error): void => {
+					if (!signal?.aborted) {
+						logger.warn("Failed to send heartbeat", {
+							"aiki.error": error.message,
+						});
+					}
+				},
+				signal,
+			})
+		);
 		if (heartbeat) {
-			const scheduleHeartbeat = (): void => {
-				heartbeatTimeout = setTimeout(() => {
-					fireAndForget(heartbeat(), (error) => {
+			heartbeats.push(
+				runOnInterval(heartbeat, {
+					intervalMs: () => configProvider.config.heartbeatIntervalMs,
+					onError: (error: Error): void => {
 						if (!signal?.aborted) {
 							logger.warn("Failed to send heartbeat", {
 								"aiki.error": error.message,
 							});
 						}
-					});
-					scheduleHeartbeat();
-				}, configProvider.config.heartbeatIntervalMs);
-			};
-			scheduleHeartbeat();
-
-			if (signal) {
-				onAbort = () => {
-					if (heartbeatTimeout) {
-						clearTimeout(heartbeatTimeout);
-					}
-				};
-				signal.addEventListener("abort", onAbort, { once: true });
-			}
+					},
+					signal,
+				})
+			);
 		}
 
 		const eventsDefinition = workflowVersion[INTERNAL].eventsDefinition;
@@ -81,7 +86,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 
 		await workflowVersion[INTERNAL].handler(
 			{
-				id: workflowRun.id as WorkflowRunId,
+				id: workflowRunId,
 				name: workflowRun.name as WorkflowName,
 				versionId: workflowRun.versionId as WorkflowVersionId,
 				options: workflowRun.options ?? {},
@@ -116,11 +121,8 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		});
 		return false;
 	} finally {
-		if (heartbeatTimeout) {
-			clearTimeout(heartbeatTimeout);
-		}
-		if (onAbort) {
-			signal?.removeEventListener("abort", onAbort);
+		for (const heartbeat of heartbeats) {
+			heartbeat.stop();
 		}
 	}
 }

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -296,7 +296,11 @@ export interface WorkflowRunClaimReadyRequestV1 {
 	workflows: Array<{ name: string; versionId: string }>;
 	shards?: string[];
 	limit: number;
-	claimMinIdleTimeMs: number;
+	/**
+	 * Steal actively executing runs whose last heartbeat was received more than
+	 * claimMinIdleTimeMs milliseconds ago. Defaults to 90 seconds.
+	 */
+	claimMinIdleTimeMs?: number;
 }
 
 export interface WorkflowRunClaimReadyResponseV1 {

--- a/types/src/workflow/run/claim.ts
+++ b/types/src/workflow/run/claim.ts
@@ -1,0 +1,15 @@
+/**
+ * Default idle time before a claimed workflow run is considered abandoned and
+ * eligible to be reclaimed by another worker.
+ */
+export const DEFAULT_CLAIM_MIN_IDLE_TIME_MS = 90_000;
+
+/**
+ * Interval at which a worker refreshes its claim on a run it is executing.
+ *
+ * Derived from {@link DEFAULT_CLAIM_MIN_IDLE_TIME_MS} so the keepalive stays
+ * comfortably below the reclaim threshold (a claim survives two missed
+ * heartbeats). Any reclaim threshold should remain greater than this interval,
+ * otherwise a still-running claim could be stolen too early.
+ */
+export const CLAIM_KEEPALIVE_INTERVAL_MS = DEFAULT_CLAIM_MIN_IDLE_TIME_MS / 3;

--- a/types/src/workflow/run/index.ts
+++ b/types/src/workflow/run/index.ts
@@ -1,3 +1,4 @@
+export * from "./claim";
 export * from "./error";
 export * from "./event";
 export * from "./replay-manifest";


### PR DESCRIPTION
## Problem

A worker claims a run before executing it, then sends the server a periodic keepalive to hold the claim. If the claim goes untouched longer than the reclaim threshold (`claimMinIdleTimeMs`, 90s), another worker can steal it.

On the base branch the keepalive had no timer of its own — it piggybacked on the subscriber's heartbeat. A worker-side wrapper forwarded to the server each time that heartbeat fired, throttled to once per 30s, and the heartbeat itself fires on the execution timer paced by `heartbeatIntervalMs`. That coupling caused:

- **No ceiling on keepalive latency.** The throttle capped how often the server was heartbeated, not how rarely. Set `heartbeatIntervalMs` above the 90s reclaim threshold and the claim is not renewed frequently enough to avoid being stolen mid-run.
- **Liveness governed by an unrelated knob.** `heartbeatIntervalMs` paces work, not claim liveness.
- **Three copies of the threshold.** The 30s throttle, the server's 90s reclaim threshold, and the subscriber's own 90s lived in three packages, with nothing enforcing that the keepalive stays under the threshold.

The endpoint skipped the wrapper and heartbeated the server directly, so the two execution paths did the same job differently.

## Solution

Move the keepalive into run execution itself, shared by worker and endpoint. It heartbeats the server directly on a fixed cadence derived from the reclaim threshold (threshold / 3 = 30s), independent of `heartbeatIntervalMs` — which now only paces the optional custom-subscriber heartbeat.

The threshold and its derived keepalive become one pair of constants in the workflow-run domain. The republish daemon default, the claim-request default, and the worker keepalive all read them, with the "keepalive stays under the threshold" invariant stated beside them.

The claim request's threshold becomes optional so the managed path stops sending it:

```ts
claimMinIdleTimeMs?: number; // server defaults to 90s when omitted
```