### PR TITLE
Remove needless event schema validation on replay

### DIFF
--- a/sdk/workflow/src/run/event.test.ts
+++ b/sdk/workflow/src/run/event.test.ts
@@ -2,7 +2,7 @@ import { withFakeClient } from "@aikirun/testing/client";
 import { runningWorkflowRunRecordFactory, workflowRunStateByStatus } from "@aikirun/testing/workflow/run";
 import { SchemaValidationError } from "@aikirun/types/validator";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
-import { WorkflowRunFailedError, WorkflowRunSuspendedError } from "@aikirun/types/workflow/run";
+import { WorkflowRunSuspendedError } from "@aikirun/types/workflow/run";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { createEventMulticasters, createEventSenders, createEventWaiters, event } from "./event";
@@ -66,7 +66,7 @@ describe("createEventWaiters", () => {
 			expect(await waiters.orderShipped.wait({ timeout: { seconds: 1 } })).toEqual({ timeout: true });
 		}));
 
-	test("returns the schema-parsed value when a schema is provided", () =>
+	test("returns recorded data as-is, without applying the event schema", () =>
 		withFakeClient(async (client) => {
 			const record = runningWorkflowRunRecordFactory.build({
 				eventWaitQueues: { orderShipped: { eventWaits: [{ status: "received", data: "raw", receivedAt: 0 }] } },
@@ -77,31 +77,7 @@ describe("createEventWaiters", () => {
 
 			const waiters = createEventWaiters(handle, definition, client.logger);
 
-			expect((await waiters.orderShipped.wait()).data).toBe("raw!");
-		}));
-
-	test("fails the run and throws WorkflowRunFailedError when the received data fails the schema", () =>
-		withFakeClient((client) => {
-			const record = runningWorkflowRunRecordFactory.build({
-				revision: 0,
-				eventWaitQueues: { orderShipped: { eventWaits: [{ status: "received", data: "bad", receivedAt: 0 }] } },
-			});
-			const definition = { orderShipped: event({ schema: alwaysInvalidSchema }) };
-			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
-			client.api.workflowRun.transitionStateV1.once(
-				{
-					type: "optimistic",
-					id: record.id,
-					state: { status: "failed", cause: "self", error: expect.objectContaining({ name: "SchemaValidationError" }) },
-					expectedRevision: 0,
-				},
-				{ revision: 1, state: workflowRunStateByStatus.failed, attempts: record.attempts }
-			);
-
-			const waiters = createEventWaiters(handle, definition, client.logger);
-
-			expect(waiters.orderShipped.wait()).rejects.toBeInstanceOf(WorkflowRunFailedError);
+			expect((await waiters.orderShipped.wait()).data).toBe("raw");
 		}));
 
 	test("transitions to awaiting_event and suspends when no wait is recorded", () =>

--- a/sdk/workflow/src/run/event.ts
+++ b/sdk/workflow/src/run/event.ts
@@ -15,11 +15,7 @@ import type {
 	EventWaitResult,
 	WorkflowRunId,
 } from "@aikirun/types/workflow/run";
-import {
-	WorkflowRunFailedError,
-	WorkflowRunRevisionConflictError,
-	WorkflowRunSuspendedError,
-} from "@aikirun/types/workflow/run";
+import { WorkflowRunRevisionConflictError, WorkflowRunSuspendedError } from "@aikirun/types/workflow/run";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import type { WorkflowRunHandle } from "./handle";
@@ -136,11 +132,10 @@ export function createEventWaiters<TEvents extends EventsDefinition>(
 ): EventWaiters<TEvents> {
 	const waiters = {} as EventWaiters<TEvents>;
 
-	for (const [eventName, eventDefinition] of Object.entries(eventsDefinition)) {
+	for (const eventName of Object.keys(eventsDefinition)) {
 		const waiter = createEventWaiter(
 			handle,
 			eventName as EventName,
-			eventDefinition.schema,
 			logger.child({ "aiki.eventName": eventName })
 		) as EventWaiter<EventData<TEvents[keyof TEvents]>>;
 		waiters[eventName as keyof TEvents] = waiter;
@@ -152,7 +147,6 @@ export function createEventWaiters<TEvents extends EventsDefinition>(
 function createEventWaiter<TEvents extends EventsDefinition, Data>(
 	handle: WorkflowRunHandle<unknown, unknown, unknown, TEvents>,
 	eventName: EventName,
-	schema: StandardSchemaV1<Data> | undefined,
 	logger: Logger
 ): EventWaiter<Data> {
 	let nextIndex = 0;
@@ -173,28 +167,8 @@ function createEventWaiter<TEvents extends EventsDefinition, Data>(
 				return { timeout: true };
 			}
 
-			let data = existingEventWait.data;
-			if (schema) {
-				const schemaValidation = schema["~standard"].validate(existingEventWait.data);
-				const schemaValidationResult = schemaValidation instanceof Promise ? await schemaValidation : schemaValidation;
-				if (!schemaValidationResult.issues) {
-					data = schemaValidationResult.value;
-				} else {
-					logger.error("Invalid event data", { "aiki.issues": schemaValidationResult.issues });
-					await handle[INTERNAL].transitionState({
-						status: "failed",
-						cause: "self",
-						error: {
-							name: "SchemaValidationError",
-							message: JSON.stringify(schemaValidationResult.issues),
-						},
-					});
-					throw new WorkflowRunFailedError(handle.run.id as WorkflowRunId, handle.run.attempts);
-				}
-			}
-
 			logger.debug("Event received");
-			return { timeout: false, data: data as Data };
+			return { timeout: false, data: existingEventWait.data as Data };
 		}
 
 		const timeoutInMs = options?.timeout && toMilliseconds(options.timeout);


### PR DESCRIPTION
The event waiter re-applied the schema to recorded event data on every read, re-running validation on already-persisted values. Mirror #57, which removed this for task and child-workflow outputs:

- the sender validates on the way in, so recorded data was valid when persisted
- a transforming schema double-applies on each replay ("raw" -> "raw!" -> "raw!!")
- a schema that drifted in code would wrongly fail a once-valid event

Validation stays on the sender/multicaster. The waiter returns recorded data as-is.