### PR TITLE
Configurable claim refresh, distinct from subscriber heartbeat

### DIFF
--- a/app/website/content/docs/architecture/meta.json
+++ b/app/website/content/docs/architecture/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Architecture",
-	"pages": ["overview", "server", "subscribers", "cam"]
+	"pages": ["overview", "server", "subscribers", "workflow-run-claims", "cam"]
 }

--- a/app/website/content/docs/architecture/server.md
+++ b/app/website/content/docs/architecture/server.md
@@ -30,7 +30,7 @@ When a workflow run becomes ready, the server records it in an **outbox** — th
 
 See [Subscribers](./subscribers.md) for the worker side of this.
 
-## Background Jobs
+## Background Daemons
 
 The runtime's daemons drive workflow state transitions:
 
@@ -44,10 +44,10 @@ The runtime's daemons drive workflow state transitions:
 | Child wait timeouts | Resume workflows that timed out waiting for child workflows |
 | Recurring schedules | Create new runs for cron and interval schedules |
 | Publish ready runs | Publish pending outbox entries to the work queue |
-| Republish stale runs | Re-publish runs whose worker stopped heartbeating |
+| Republish stale runs | Re-publish runs whose worker stopped refreshing its claim |
 | Due-timers consumer | Fire near-term timers from the timer priority queue (when configured) |
 
-The two publishing daemons run only when a publisher is configured. Without one, workers claim work directly from the outbox, and stale claims are recovered by the claim API itself.
+The two publishing daemons run only when a publisher is configured. Without one, workers claim work directly from the outbox, and stale claims are recovered by the claim API itself (see [Workflow Run Claims](./workflow-run-claims.md)).
 
 By default, due work is detected by periodic database scans. Configuring a **timer priority queue** (`@aikirun/redis`) promotes near-term timers into a sorted queue that fires them with sub-second precision.
 
@@ -87,4 +87,5 @@ For the bundled standalone server's environment variables, see the [Installation
 ## Next Steps
 
 - **[Subscribers](./subscribers.md)** - How workers discover work
+- **[Runtime Configuration](../guides/configuration.md)** - Tune the runtime's, statically or live
 - **[Overview](./overview.mdx)** - High-level architecture

--- a/app/website/content/docs/architecture/subscribers.md
+++ b/app/website/content/docs/architecture/subscribers.md
@@ -17,7 +17,7 @@ const aikiWorker = worker({
 });
 ```
 
-The claim endpoint atomically fetches and claims ready runs. It also recovers orphaned work by claiming runs that have been idle longer than `claimMinIdleTimeMs` (see [Fault Tolerance](#fault-tolerance)).
+The claim endpoint atomically fetches and claims ready runs. It also recovers orphaned work by stealing runs whose previous claim has been idle longer than `claimMinIdleTimeMs` (see [Workflow Run Claims](./workflow-run-claims.md)).
 
 ### HTTP Subscriber Configuration
 
@@ -25,7 +25,6 @@ The claim endpoint atomically fetches and claims ready runs. It also recovers or
 |--------|---------|-------------|
 | `intervalMs` | 1,000 | Poll interval when no work is found (ms) |
 | `maxRetryIntervalMs` | 30,000 | Max backoff on errors (ms) |
-| `claimMinIdleTimeMs` | 90,000 | Claim runs idle longer than this (ms) |
 
 ## Redis Subscriber (Optional)
 
@@ -95,9 +94,11 @@ const mySubscriber: CreateSubscriber = (context) => {
       return [];
     },
     // Optional:
-    heartbeat: async (workflowRunId) => { /* ... */ },
+    heartbeat: {
+      send: async (workflowRunId) => { /* ... */ },
+      intervalMs: 30_000,
+    },
     acknowledge: async (workflowRunId) => { /* ... */ },
-    close: async () => { /* ... */ },
   };
 };
 
@@ -113,69 +114,19 @@ The `Subscriber` interface:
 |--------|----------|-------------|
 | `getReadyRuns(limit)` | Yes | Fetch up to `limit` ready workflow runs; may block until work arrives |
 | `getNextDelay(params)` | Yes | Return milliseconds to wait before the next call (`no_work` or `retry`) |
-| `heartbeat(workflowRunId)` | No | Keep an in-flight run's claim alive in your transport (e.g. extending an SQS visibility timeout) |
+| `heartbeat` | No | `{ send, intervalMs }` — `send(workflowRunId)` renews an in-flight run in your transport (e.g. extending an SQS visibility timeout), called every `intervalMs` |
 | `acknowledge(workflowRunId)` | No | Mark a workflow run as processed in your transport |
-| `close()` | No | Cleanup when the worker shuts down |
 
 If your subscriber blocks inside `getReadyRuns` until work arrives — as the Redis subscriber does — return `0` from `getNextDelay` for `no_work`; the delay between calls only matters for polling subscribers. Give the `retry` variant a real backoff either way: it's applied when `getReadyRuns` fails, and a zero delay there means hammering a failing dependency.
 
-## Fault Tolerance
+There is no `close` hook. The factory receives a `context` whose `signal` is an `AbortSignal` that fires on worker shutdown; release resources by listening for its `abort` event, as the Redis subscriber does to disconnect.
 
-Crashed or stuck workers don't strand workflow runs. Recovery is driven by the server and works the same regardless of subscriber.
-
-### Heartbeats
-
-While executing a workflow run, the worker sends periodic heartbeats to the server to keep its claim alive. If the worker crashes, heartbeats stop and the claim eventually goes stale.
-
-Heartbeat interval is configured in worker options:
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `workflowRun.heartbeatIntervalMs` | 30,000 | How often workers refresh their claim |
-
-If a custom subscriber provides its own `heartbeat` method, the worker calls both — the server's and the subscriber's.
-
-### Work Stealing
-
-When a worker crashes mid-execution:
-
-1. The workflow run's claim goes stale (no heartbeats)
-2. After `claimMinIdleTimeMs`, the run is up for grabs again — the claim API hands it to the next claiming worker, and when a publisher is configured, the server's republish daemon also puts it back on the queue
-3. A healthy worker picks up the orphaned run
-4. The workflow re-executes from its last checkpoint
-
-### Zombie Worker Prevention
-
-Work stealing assumes the original worker is dead, but what if it's just slow? A worker that was presumed dead might wake up and try to continue executing a workflow run that another worker has already claimed.
-
-Aiki handles this through **revision-based optimistic locking**. Every workflow run has a `revision` counter that increments on each state transition. When a worker transitions a workflow run to running, the revision increments. Every subsequent operation the worker performs — state transitions, task updates — includes the `expectedRevision` it last saw. The server atomically checks that the current revision matches before applying the update.
-
-When Worker B steals a run from Worker A:
-
-1. Worker A holds the run at `revision: 5`
-2. Worker B claims the run and transitions it to running, incrementing to `revision: 6`
-3. Worker A wakes up and tries to report a task result with `expectedRevision: 5`
-4. The server rejects the update — the revision is now `6`
-5. Worker A receives a revision conflict error and stops execution cleanly
-
-This check happens at the database level in a single atomic operation (check revision + increment revision + apply update), so there's no race condition window.
-
-### Safe Re-execution
-
-When a claimed workflow re-executes:
-
-- **Tasks return cached results** - Already-completed tasks don't run again
-- **State is preserved** - The workflow resumes from its persisted state
-
-Work stealing is safe. Re-executing a workflow doesn't cause duplicate side effects for properly designed tasks.
-
-**Choosing `claimMinIdleTimeMs`**: Set this higher than the heartbeat interval. Workers refresh their claim every heartbeat, so a run only becomes "idle" when a worker stops heartbeating (crashes or hangs). The default of 90 seconds with 30-second heartbeats gives plenty of margin.
-
-### Backup Subscriber
+## Backup Subscriber
 
 When you provide a custom subscriber (including the Redis subscriber), the worker also creates a backup HTTP subscriber. If the primary subscriber fails, the worker switches to the backup to maintain availability. This ensures workflow execution continues even if an external dependency like Redis goes down.
 
 ## Next Steps
 
+- **[Workflow Run Claims](./workflow-run-claims.md)** - How runs are owned and recovered
 - **[Workers](../core-concepts/workers.md)** - Worker configuration
 - **[Overview](./overview.mdx)** - High-level architecture

--- a/app/website/content/docs/architecture/workflow-run-claims.md
+++ b/app/website/content/docs/architecture/workflow-run-claims.md
@@ -1,0 +1,62 @@
+---
+title: Workflow Run Claims
+---
+
+An executor — a worker or a serverless endpoint — owns a workflow run by **claiming** it. The claim guarantees a single live owner: while one executor holds a run, no other executor runs it. If the owner dies mid-execution, the server hands the run to a healthy executor, which resumes from the last checkpoint.
+
+Claims are driven by the server and work the same regardless of how a run was delivered. A worker claiming over HTTP or Redis and an endpoint receiving a signed HTTP push hold and refresh the claim identically.
+
+## Claim Refresh
+
+While executing a run, the executor periodically refreshes its claim on the server to keep it alive. If the executor crashes, the refreshes stop and the claim eventually goes stale.
+
+The refresh interval is configured on the worker or endpoint:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `workflowRun.claimRefreshIntervalMs` | 30,000 | How often the executor refreshes its claim (ms) |
+
+A claim refresh is separate from a subscriber's optional `heartbeat`, which renews a run in the subscriber's own transport (e.g. an SQS visibility timeout). See [Subscribers](./subscribers.md).
+
+## Work Stealing
+
+When an executor crashes mid-execution:
+
+1. The run's claim goes stale (no refreshes)
+2. After `claimMinIdleTimeMs`, the run is up for grabs again — the claim API hands it to the next claiming worker, and when a publisher is configured, the server's republish daemon also puts it back on the queue
+3. A healthy executor picks up the orphaned run
+4. The workflow re-executes from its last checkpoint
+
+**`claimMinIdleTimeMs`** is a server-side threshold, 90 seconds by default. It's how long the server waits after the last claim refresh before treating a run as abandoned. Keep it above the claim refresh interval, so a run only goes idle when an executor actually stops refreshing. The default 90 seconds against 30-second refreshes leaves ample margin. The republish-stale-runs daemon reads it from the server runtime config under `daemons.republishStaleRuns`; the claim API applies the same 90-second default when reclaiming runs directly. See [Runtime Configuration](../guides/configuration.md).
+
+## Zombie Executor Prevention
+
+Work stealing assumes the original executor is dead, but what if it's just slow? An executor presumed dead might wake up and try to continue executing a run that another has already claimed.
+
+Aiki handles this through **revision-based optimistic locking**. Every workflow run has a `revision` counter that increments on each state transition. When an executor transitions a run to running, the revision increments. Every subsequent operation the executor performs — state transitions, task updates — includes the `expectedRevision` it last saw. The server atomically checks that the current revision matches before applying the update.
+
+When Executor B steals a run from Executor A:
+
+1. Executor A holds the run at `revision: 5`
+2. Executor B claims the run and transitions it to running, incrementing to `revision: 6`
+3. Executor A wakes up and tries to report a task result with `expectedRevision: 5`
+4. The server rejects the update — the revision is now `6`
+5. Executor A receives a revision conflict error and stops execution cleanly
+
+This check happens at the database level in a single atomic operation (check revision + increment revision + apply update), so there's no race condition window.
+
+## Safe Re-execution
+
+When a claimed workflow re-executes:
+
+- **Tasks return cached results** — already-completed tasks don't run again
+- **State is preserved** — the workflow resumes from its persisted state
+
+Work stealing is safe. Re-executing a workflow doesn't cause duplicate side effects for properly designed tasks. [Crash Recovery](./cam.md) covers how replay returns recorded task results.
+
+## Next Steps
+
+- **[Workers](../core-concepts/workers.md)** — Worker configuration
+- **[Subscribers](./subscribers.md)** — Work discovery and delivery
+- **[Server](./server.md)** — Orchestration and recovery daemons
+- **[Crash Recovery](./cam.md)** — The replay mechanism behind safe re-execution

--- a/app/website/content/docs/core-concepts/workers.md
+++ b/app/website/content/docs/core-concepts/workers.md
@@ -32,7 +32,7 @@ Worker definitions are static and reusable. The `worker()` function creates a de
 
 When you call `spawn()`, the worker begins discovering ready workflow runs through its subscriber — claiming them from the server by default. When a workflow run is triggered, the worker picks it up, looks up the workflow definition in its registry, and begins execution.
 
-During execution, the worker sends periodic heartbeats to maintain its claim on the run. This prevents other workers from thinking it's stuck. If a worker crashes mid-execution, the claim expires after a configurable idle time (default: 90 seconds) and the run is handed to a healthy worker. The workflow then re-executes from its last checkpoint.
+During execution, the worker periodically refreshes its claim on the run. This prevents other workers from thinking it's stuck. If a worker crashes mid-execution, the claim expires after a configurable idle time (default: 90 seconds) and the run is handed to a healthy worker. The workflow then re-executes from its last checkpoint. [Workflow Run Claims](../architecture/workflow-run-claims.md) covers this ownership and recovery in full.
 
 When execution completes or fails, the worker reports the terminal state to the server.
 
@@ -84,7 +84,7 @@ Worker configuration is split between **params** (identity) and **options** (tun
 |--------|---------|-------------|
 | `maxConcurrentWorkflowRuns` | 1 | Max parallel executions |
 | `gracefulShutdownTimeoutMs` | 5,000 | Shutdown wait time (ms) |
-| `workflowRun.heartbeatIntervalMs` | 30,000 | Heartbeat frequency (ms) |
+| `workflowRun.claimRefreshIntervalMs` | 30,000 | How often the worker refreshes its run claim (ms) |
 | `shards` | — | Shards to process |
 
 ## Pluggable Subscribers
@@ -111,3 +111,4 @@ You can also implement your own subscriber by providing a function that matches 
 - **[Client](./client.mdx)** — Connect to Aiki server
 - **[Workflows](./workflows.md)** — Define workflow logic
 - **[Tasks](./tasks.md)** — Create reusable task units
+- **[Workflow Run Claims](../architecture/workflow-run-claims.md)** — How runs are owned and recovered

--- a/app/website/content/docs/guides/logging.md
+++ b/app/website/content/docs/guides/logging.md
@@ -48,7 +48,7 @@ Task handlers are plain functions and receive no logger. If a task needs one, in
 
 ## What Aiki Logs
 
-The SDK logs run lifecycle (claims, execution, retries, heartbeats etc.) and component activity at `info` and below, with problems at `warn` and `error`. Aiki's metadata keys are namespaced under `aiki.*` (for example `aiki.workflowRunId`), so they do not collide with your fields, and errors are attached under the `err` key.
+The SDK logs run lifecycle (claims, execution, retries, claim refreshes etc.) and component activity at `info` and below, with problems at `warn` and `error`. Aiki's metadata keys are namespaced under `aiki.*` (for example `aiki.workflowRunId`), so they do not collide with your fields, and errors are attached under the `err` key.
 
 ## Next Steps
 

--- a/app/website/content/docs/index.mdx
+++ b/app/website/content/docs/index.mdx
@@ -47,7 +47,8 @@ Deep dive into system design:
 
 - **[Overview](./architecture/overview.mdx)** - High-level architecture and design principles
 - **[Server](./architecture/server.md)** - Workflow orchestration and state management
-- **[Subscribers](./architecture/subscribers.md)** - Work discovery and fault tolerance
+- **[Subscribers](./architecture/subscribers.md)** - Work discovery and delivery
+- **[Workflow Run Claims](./architecture/workflow-run-claims.md)** - How runs are owned and recovered
 - **[Crash recovery](./architecture/cam.md)** - Underlying replay-based crash recovery mechanism
 
 ## 🔗 Quick Links

--- a/lib/src/async/interval.test.ts
+++ b/lib/src/async/interval.test.ts
@@ -61,6 +61,23 @@ describe("runOnInterval", () => {
 		expect(calls).toBe(callsAtStop);
 	});
 
+	test("an already aborted signal prevents any invocations", async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		let calls = 0;
+
+		runOnInterval(
+			async () => {
+				calls += 1;
+			},
+			{ intervalMs: 1, onError: () => {}, signal: controller.signal }
+		);
+
+		await delay(20);
+		expect(calls).toBe(0);
+	});
+
 	test("aborting the signal stops further invocations", async () => {
 		const controller = new AbortController();
 		let calls = 0;

--- a/lib/src/async/interval.ts
+++ b/lib/src/async/interval.ts
@@ -10,6 +10,10 @@ export function runOnInterval(
 ): { stop: () => void } {
 	const { intervalMs, onError, signal } = options;
 
+	if (signal?.aborted) {
+		return { stop: () => {} };
+	}
+
 	let timeout: ReturnType<typeof setTimeout> | undefined;
 	const tick = (): void => {
 		timeout = setTimeout(

--- a/sdk/endpoint/src/config.ts
+++ b/sdk/endpoint/src/config.ts
@@ -1,12 +1,11 @@
 import { asConfigProvider, type CreatePassiveConfigProvider } from "@aikirun/lib/config";
 import { type DeepPartial, merge } from "@aikirun/lib/object";
+import { CLAIM_REFRESH_INTERVAL_MS } from "@aikirun/types/workflow";
+import type { WorkflowExecutionConfig } from "@aikirun/workflow";
 
 export interface EndpointConfig {
 	signatureMaxAgeMs: number;
-	workflowRun: {
-		heartbeatIntervalMs: number;
-		spinThresholdMs: number;
-	};
+	workflowRun: WorkflowExecutionConfig;
 }
 
 export type EndpointConfigOverrides = DeepPartial<EndpointConfig>;
@@ -14,7 +13,7 @@ export type EndpointConfigOverrides = DeepPartial<EndpointConfig>;
 export const defaultEndpointConfig: EndpointConfig = {
 	signatureMaxAgeMs: 30_000,
 	workflowRun: {
-		heartbeatIntervalMs: 30_000,
+		claimRefreshIntervalMs: CLAIM_REFRESH_INTERVAL_MS,
 		spinThresholdMs: 10,
 	},
 };

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -343,7 +343,7 @@ const claimReadyV1: ContractProcedure<WorkflowRunClaimReadyRequestV1, WorkflowRu
 				.atLeastLength(1),
 			"shards?": type("string > 0").array().or("undefined"),
 			limit: "number.integer > 0",
-			"claimMinIdleTimeMs?": "number.integer > 0",
+			"previousClaimMinIdleTimeMs?": "number.integer > 0",
 		})
 	)
 	.output(

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -5,6 +5,7 @@ import type {
 	WorkflowRunCancelByIdsResponseV1,
 	WorkflowRunClaimReadyRequestV1,
 	WorkflowRunClaimReadyResponseV1,
+	WorkflowRunClaimRefreshRequestV1,
 	WorkflowRunCreateRequestV1,
 	WorkflowRunCreateResponseV1,
 	WorkflowRunGetByIdRequestV1,
@@ -15,7 +16,6 @@ import type {
 	WorkflowRunGetStateResponseV1,
 	WorkflowRunHasTerminatedRequestV1,
 	WorkflowRunHasTerminatedResponseV1,
-	WorkflowRunHeartbeatRequestV1,
 	WorkflowRunListChildRunsRequestV1,
 	WorkflowRunListChildRunsResponseV1,
 	WorkflowRunListRequestV1,
@@ -352,7 +352,7 @@ const claimReadyV1: ContractProcedure<WorkflowRunClaimReadyRequestV1, WorkflowRu
 		})
 	);
 
-const heartbeatV1: ContractProcedure<WorkflowRunHeartbeatRequestV1, void> = oc
+const claimRefreshV1: ContractProcedure<WorkflowRunClaimRefreshRequestV1, void> = oc
 	.input(
 		type({
 			id: "string > 0",
@@ -390,7 +390,7 @@ export const workflowRunContract = {
 	listChildRunsV1,
 	cancelByIdsV1,
 	claimReadyV1,
-	heartbeatV1,
+	claimRefreshV1,
 	hasTerminatedV1,
 };
 

--- a/sdk/server/src/router/workflow-run.ts
+++ b/sdk/server/src/router/workflow-run.ts
@@ -106,7 +106,7 @@ export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps) {
 			return { runs: await workflowRunOutboxService.claimReady(context, request) };
 		}),
 
-		heartbeatV1: os.heartbeatV1.handler(async ({ input: request, context }) => {
+		claimRefreshV1: os.claimRefreshV1.handler(async ({ input: request, context }) => {
 			await workflowRunOutboxService.reclaim(context, request.id as WorkflowRunId);
 		}),
 

--- a/sdk/server/src/service/workflow-run-outbox.ts
+++ b/sdk/server/src/service/workflow-run-outbox.ts
@@ -63,7 +63,7 @@ async function stealStaleClaimed(
 	return repo.stealStaleClaimed(
 		context.namespaceId,
 		{ workflows, shards: request.shards },
-		request.claimMinIdleTimeMs ?? DEFAULT_CLAIM_MIN_IDLE_TIME_MS,
+		request.previousClaimMinIdleTimeMs ?? DEFAULT_CLAIM_MIN_IDLE_TIME_MS,
 		request.limit
 	);
 }

--- a/sdk/worker/src/config.ts
+++ b/sdk/worker/src/config.ts
@@ -1,13 +1,12 @@
 import { asConfigProvider, type CreateConfigProvider, dynamicConfigProvider } from "@aikirun/lib/config";
 import { type DeepPartial, merge } from "@aikirun/lib/object";
+import { CLAIM_REFRESH_INTERVAL_MS } from "@aikirun/types/workflow";
+import type { WorkflowExecutionConfig } from "@aikirun/workflow";
 
 export interface WorkerConfig {
 	maxConcurrentWorkflowRuns: number;
 	gracefulShutdownTimeoutMs: number;
-	workflowRun: {
-		heartbeatIntervalMs: number;
-		spinThresholdMs: number;
-	};
+	workflowRun: WorkflowExecutionConfig;
 }
 
 export type WorkerConfigOverrides = DeepPartial<WorkerConfig>;
@@ -16,7 +15,7 @@ export const defaultWorkerConfig: WorkerConfig = {
 	maxConcurrentWorkflowRuns: 1,
 	gracefulShutdownTimeoutMs: 5_000,
 	workflowRun: {
-		heartbeatIntervalMs: 30_000,
+		claimRefreshIntervalMs: CLAIM_REFRESH_INTERVAL_MS,
 		spinThresholdMs: 10,
 	},
 };

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -430,7 +430,9 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 				workflowVersion,
 				logger,
 				configProvider: this.configProvider.scope("workflowRun"),
-				heartbeat: heartbeat ? () => heartbeat(workflowRunId) : undefined,
+				heartbeat: heartbeat
+					? { send: () => heartbeat.send(workflowRunId), intervalMs: heartbeat.intervalMs }
+					: undefined,
 				signal,
 			});
 

--- a/sdk/workflow/src/run/execute.test.ts
+++ b/sdk/workflow/src/run/execute.test.ts
@@ -1,0 +1,252 @@
+import { asConfigProvider } from "@aikirun/lib/config";
+import { withFakeClient } from "@aikirun/testing/client";
+import { runningWorkflowRunRecordFactory } from "@aikirun/testing/workflow/run";
+import { INTERNAL } from "@aikirun/types/symbols";
+import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import {
+	CLAIM_KEEPALIVE_INTERVAL_MS,
+	NonDeterminismError,
+	WorkflowRunFailedError,
+	WorkflowRunNotExecutableError,
+	WorkflowRunRevisionConflictError,
+	WorkflowRunSuspendedError,
+} from "@aikirun/types/workflow/run";
+
+import type { EventsDefinition } from "./event";
+import { executeWorkflowRun } from "./execute";
+import type { WorkflowRun } from "./index";
+import { describe, expect, jest, spyOn, test } from "bun:test";
+import type { AnyWorkflowVersion } from "../workflow-version";
+
+const configProvider = asConfigProvider(() => ({ heartbeatIntervalMs: 30_000, spinThresholdMs: 10 }));
+
+function fakeWorkflowVersion(
+	handler: (run: WorkflowRun<unknown, unknown, EventsDefinition>, input: unknown) => Promise<void>
+): AnyWorkflowVersion {
+	return {
+		name: "dummy-workflow" as WorkflowName,
+		versionId: "1.0.0" as WorkflowVersionId,
+		[INTERNAL]: { eventsDefinition: {}, handler },
+	} as unknown as AnyWorkflowVersion;
+}
+
+describe("executeWorkflowRun", () => {
+	describe("error classification", () => {
+		const controlFlowErrors: Array<{ name: string; make: () => Error }> = [
+			{
+				name: "WorkflowRunNotExecutableError",
+				make: () => new WorkflowRunNotExecutableError("run-1" as WorkflowRunId, "paused"),
+			},
+			{ name: "WorkflowRunSuspendedError", make: () => new WorkflowRunSuspendedError("run-1" as WorkflowRunId) },
+			{ name: "WorkflowRunFailedError", make: () => new WorkflowRunFailedError("run-1" as WorkflowRunId, 1) },
+			{
+				name: "WorkflowRunRevisionConflictError",
+				make: () => new WorkflowRunRevisionConflictError("run-1" as WorkflowRunId),
+			},
+			{
+				name: "NonDeterminismError",
+				make: () => new NonDeterminismError("run-1" as WorkflowRunId, 1, { taskIds: [], childWorkflowRunIds: [] }),
+			},
+		];
+
+		for (const errorCase of controlFlowErrors) {
+			test(`returns true when the handler throws ${errorCase.name}`, () =>
+				withFakeClient(async (client) => {
+					const workflowRun = runningWorkflowRunRecordFactory.build();
+					const workflowVersion = fakeWorkflowVersion(async () => {
+						throw errorCase.make();
+					});
+
+					const result = await executeWorkflowRun({
+						client,
+						workflowRun,
+						workflowVersion,
+						logger: client.logger,
+						configProvider,
+					});
+
+					expect(result).toBe(true);
+				}));
+		}
+
+		test("returns false and logs when the handler throws an unexpected error", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				const workflowVersion = fakeWorkflowVersion(async () => {
+					throw new Error("boom");
+				});
+				const errorLog = spyOn(client.logger, "error");
+
+				const result = await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(result).toBe(false);
+				expect(errorLog).toHaveBeenCalled();
+			}));
+
+		test("returns true when the handler resolves", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				const workflowVersion = fakeWorkflowVersion(async () => {});
+
+				const result = await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(result).toBe(true);
+			}));
+	});
+
+	describe("context", () => {
+		test("passes null context when the client has no context factory", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				let capturedContext: unknown = "unset";
+				const workflowVersion = fakeWorkflowVersion(async (run) => {
+					capturedContext = run.context;
+				});
+
+				await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(capturedContext).toBeNull();
+			}));
+
+		test("resolves a synchronous context factory", () =>
+			withFakeClient({ context: () => ({ tenantId: "t1" }) }, async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				let capturedContext: unknown;
+				const workflowVersion = fakeWorkflowVersion(async (run) => {
+					capturedContext = run.context;
+				});
+
+				await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(capturedContext).toEqual({ tenantId: "t1" });
+			}));
+
+		test("awaits an asynchronous context factory", () =>
+			withFakeClient({ context: async () => ({ tenantId: "t2" }) }, async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				let capturedContext: unknown;
+				const workflowVersion = fakeWorkflowVersion(async (run) => {
+					capturedContext = run.context;
+				});
+
+				await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(capturedContext).toEqual({ tenantId: "t2" });
+			}));
+	});
+
+	test("invokes the handler with the run input", () =>
+		withFakeClient(async (client) => {
+			const workflowRun = runningWorkflowRunRecordFactory.build({ input: { orderId: "o1" } });
+			let capturedInput: unknown;
+			const workflowVersion = fakeWorkflowVersion(async (_run, input) => {
+				capturedInput = input;
+			});
+
+			await executeWorkflowRun({
+				client,
+				workflowRun,
+				workflowVersion,
+				logger: client.logger,
+				configProvider,
+			});
+
+			expect(capturedInput).toEqual({ orderId: "o1" });
+		}));
+
+	describe("heartbeats", () => {
+		test("keeps the claim alive by heartbeating while the handler runs", () =>
+			withFakeClient(async (client) => {
+				jest.useFakeTimers();
+				try {
+					const workflowRun = runningWorkflowRunRecordFactory.build();
+					let release = () => {};
+					const blocked = new Promise<void>((resolve) => {
+						release = resolve;
+					});
+					const workflowVersion = fakeWorkflowVersion(async () => {
+						await blocked;
+					});
+					client.api.workflowRun.heartbeatV1.once({ id: workflowRun.id });
+
+					const runPromise = executeWorkflowRun({
+						client,
+						workflowRun,
+						workflowVersion,
+						logger: client.logger,
+						configProvider,
+					});
+
+					jest.advanceTimersByTime(CLAIM_KEEPALIVE_INTERVAL_MS);
+					expect(client.api.workflowRun.heartbeatV1).toHaveBeenCalledWith({ id: workflowRun.id });
+
+					release();
+					expect(await runPromise).toBe(true);
+				} finally {
+					jest.useRealTimers();
+				}
+			}));
+
+		test("fires the provided heartbeat on its configured interval", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				let heartbeatCalls = 0;
+				let resolveFirstHeartbeat = () => {};
+				const firstHeartbeat = new Promise<void>((resolve) => {
+					resolveFirstHeartbeat = resolve;
+				});
+				const heartbeat = async () => {
+					heartbeatCalls++;
+					resolveFirstHeartbeat();
+				};
+				// The handler blocks until the heartbeat has fired once.
+				const workflowVersion = fakeWorkflowVersion(async () => {
+					await firstHeartbeat;
+				});
+				const config = asConfigProvider(() => ({ heartbeatIntervalMs: 1, spinThresholdMs: 10 }));
+
+				const result = await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider: config,
+					heartbeat,
+				});
+
+				expect(result).toBe(true);
+				expect(heartbeatCalls).toBeGreaterThanOrEqual(1);
+			}));
+	});
+});

--- a/sdk/workflow/src/run/execute.test.ts
+++ b/sdk/workflow/src/run/execute.test.ts
@@ -1,3 +1,4 @@
+import { delay } from "@aikirun/lib/async";
 import { asConfigProvider } from "@aikirun/lib/config";
 import { withFakeClient } from "@aikirun/testing/client";
 import { runningWorkflowRunRecordFactory } from "@aikirun/testing/workflow/run";
@@ -5,7 +6,6 @@ import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 import {
-	CLAIM_KEEPALIVE_INTERVAL_MS,
 	NonDeterminismError,
 	WorkflowRunFailedError,
 	WorkflowRunNotExecutableError,
@@ -16,10 +16,13 @@ import {
 import type { EventsDefinition } from "./event";
 import { executeWorkflowRun } from "./execute";
 import type { WorkflowRun } from "./index";
-import { describe, expect, jest, spyOn, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { AnyWorkflowVersion } from "../workflow-version";
 
-const configProvider = asConfigProvider(() => ({ heartbeatIntervalMs: 30_000, spinThresholdMs: 10 }));
+const configProvider = asConfigProvider(() => ({
+	claimRefreshIntervalMs: 30_000,
+	spinThresholdMs: 10,
+}));
 
 function fakeWorkflowVersion(
 	handler: (run: WorkflowRun<unknown, unknown, EventsDefinition>, input: unknown) => Promise<void>
@@ -185,39 +188,71 @@ describe("executeWorkflowRun", () => {
 			expect(capturedInput).toEqual({ orderId: "o1" });
 		}));
 
-	describe("heartbeats", () => {
-		test("keeps the claim alive by heartbeating while the handler runs", () =>
+	describe("claim refresh", () => {
+		test("keeps the claim alive by refreshing it while the handler runs", () =>
 			withFakeClient(async (client) => {
-				jest.useFakeTimers();
-				try {
-					const workflowRun = runningWorkflowRunRecordFactory.build();
-					let release = () => {};
-					const blocked = new Promise<void>((resolve) => {
-						release = resolve;
-					});
-					const workflowVersion = fakeWorkflowVersion(async () => {
-						await blocked;
-					});
-					client.api.workflowRun.heartbeatV1.once({ id: workflowRun.id });
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				let resolveFirstClaimRefresh = () => {};
+				const firstClaimRefresh = new Promise<void>((resolve) => {
+					resolveFirstClaimRefresh = resolve;
+				});
+				client.api.workflowRun.heartbeatV1.onNextCall(resolveFirstClaimRefresh);
+				client.api.workflowRun.heartbeatV1.once({ id: workflowRun.id });
 
-					const runPromise = executeWorkflowRun({
-						client,
-						workflowRun,
-						workflowVersion,
-						logger: client.logger,
-						configProvider,
-					});
+				// The handler blocks until the first claim refresh fires.
+				const workflowVersion = fakeWorkflowVersion(async () => {
+					await firstClaimRefresh;
+				});
 
-					jest.advanceTimersByTime(CLAIM_KEEPALIVE_INTERVAL_MS);
-					expect(client.api.workflowRun.heartbeatV1).toHaveBeenCalledWith({ id: workflowRun.id });
+				const result = await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider: asConfigProvider(() => ({
+						...configProvider.config,
+						claimRefreshIntervalMs: 10,
+					})),
+				});
 
-					release();
-					expect(await runPromise).toBe(true);
-				} finally {
-					jest.useRealTimers();
-				}
+				expect(result).toBe(true);
 			}));
 
+		test("stops refreshing the claim once the signal is aborted", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				const controller = new AbortController();
+				let resolveHandler = () => {};
+				const handler = new Promise<void>((resolve) => {
+					resolveHandler = resolve;
+				});
+				const workflowVersion = fakeWorkflowVersion(async () => {
+					await handler;
+				});
+
+				controller.abort();
+
+				const executionPromise = executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider: asConfigProvider(() => ({
+						...configProvider.config,
+						claimRefreshIntervalMs: 1,
+					})),
+					signal: controller.signal,
+				});
+
+				// Absence check: a 1ms claimRefreshIntervalMs would fire within this window had abort not torn it down.
+				await delay(20);
+
+				resolveHandler();
+				expect(await executionPromise).toBe(true);
+			}));
+	});
+
+	describe("heartbeats", () => {
 		test("fires the provided heartbeat on its configured interval", () =>
 			withFakeClient(async (client) => {
 				const workflowRun = runningWorkflowRunRecordFactory.build();
@@ -226,7 +261,7 @@ describe("executeWorkflowRun", () => {
 				const firstHeartbeat = new Promise<void>((resolve) => {
 					resolveFirstHeartbeat = resolve;
 				});
-				const heartbeat = async () => {
+				const heartbeatFn = async () => {
 					heartbeatCalls++;
 					resolveFirstHeartbeat();
 				};
@@ -234,19 +269,58 @@ describe("executeWorkflowRun", () => {
 				const workflowVersion = fakeWorkflowVersion(async () => {
 					await firstHeartbeat;
 				});
-				const config = asConfigProvider(() => ({ heartbeatIntervalMs: 1, spinThresholdMs: 10 }));
 
 				const result = await executeWorkflowRun({
 					client,
 					workflowRun,
 					workflowVersion,
 					logger: client.logger,
-					configProvider: config,
-					heartbeat,
+					configProvider: asConfigProvider(() => ({
+						...configProvider.config,
+						// Claim refresh is never fired because claimRefreshIntervalMs >> heartbeat.intervalMs
+						claimRefreshIntervalMs: 30_000,
+					})),
+					heartbeat: { send: heartbeatFn, intervalMs: 1 },
 				});
 
 				expect(result).toBe(true);
 				expect(heartbeatCalls).toBeGreaterThanOrEqual(1);
+			}));
+
+		test("stops firing the heartbeat once the signal is aborted", () =>
+			withFakeClient(async (client) => {
+				const workflowRun = runningWorkflowRunRecordFactory.build();
+				const controller = new AbortController();
+				let resolveHandler = () => {};
+				const handler = new Promise<void>((resolve) => {
+					resolveHandler = resolve;
+				});
+				const workflowVersion = fakeWorkflowVersion(async () => {
+					await handler;
+				});
+				let heartbeatCalls = 0;
+				const heartbeatFn = async () => {
+					heartbeatCalls++;
+				};
+
+				controller.abort();
+
+				const executionPromise = executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+					heartbeat: { send: heartbeatFn, intervalMs: 1 },
+					signal: controller.signal,
+				});
+
+				// Absence check: a 1ms heartbeat would fire within this window had abort not torn it down.
+				await delay(20);
+				expect(heartbeatCalls).toBe(0);
+
+				resolveHandler();
+				expect(await executionPromise).toBe(true);
 			}));
 	});
 });

--- a/sdk/workflow/src/run/execute.test.ts
+++ b/sdk/workflow/src/run/execute.test.ts
@@ -196,8 +196,8 @@ describe("executeWorkflowRun", () => {
 				const firstClaimRefresh = new Promise<void>((resolve) => {
 					resolveFirstClaimRefresh = resolve;
 				});
-				client.api.workflowRun.heartbeatV1.onNextCall(resolveFirstClaimRefresh);
-				client.api.workflowRun.heartbeatV1.once({ id: workflowRun.id });
+				client.api.workflowRun.claimRefreshV1.onNextCall(resolveFirstClaimRefresh);
+				client.api.workflowRun.claimRefreshV1.once({ id: workflowRun.id });
 
 				// The handler blocks until the first claim refresh fires.
 				const workflowVersion = fakeWorkflowVersion(async () => {

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -48,9 +48,9 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 	const { client, workflowRun, workflowVersion, logger, configProvider, heartbeat, signal } = params;
 	const workflowRunId = workflowRun.id as WorkflowRunId;
 
-	const heartbeats: Array<{ stop: () => void }> = [];
+	const intervals: Array<{ stop: () => void }> = [];
 	try {
-		heartbeats.push(
+		intervals.push(
 			runOnInterval(() => client.api.workflowRun.heartbeatV1({ id: workflowRunId }), {
 				intervalMs: CLAIM_REFRESH_INTERVAL_MS,
 				onError: (error: Error): void => {
@@ -64,7 +64,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 			})
 		);
 		if (heartbeat) {
-			heartbeats.push(
+			intervals.push(
 				runOnInterval(heartbeat, {
 					intervalMs: () => configProvider.config.heartbeatIntervalMs,
 					onError: (error: Error): void => {
@@ -122,8 +122,8 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		});
 		return false;
 	} finally {
-		for (const heartbeat of heartbeats) {
-			heartbeat.stop();
+		for (const interval of intervals) {
+			interval.stop();
 		}
 	}
 }

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -5,7 +5,7 @@ import type { Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import {
-	CLAIM_KEEPALIVE_INTERVAL_MS,
+	CLAIM_REFRESH_INTERVAL_MS,
 	NonDeterminismError,
 	WorkflowRunFailedError,
 	type WorkflowRunId,
@@ -52,7 +52,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 	try {
 		heartbeats.push(
 			runOnInterval(() => client.api.workflowRun.heartbeatV1({ id: workflowRunId }), {
-				intervalMs: CLAIM_KEEPALIVE_INTERVAL_MS,
+				intervalMs: CLAIM_REFRESH_INTERVAL_MS,
 				onError: (error: Error): void => {
 					if (!signal?.aborted) {
 						logger.warn("Failed to send heartbeat to keep claim alive", {

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -55,7 +55,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 				intervalMs: CLAIM_REFRESH_INTERVAL_MS,
 				onError: (error: Error): void => {
 					if (!signal?.aborted) {
-						logger.warn("Failed to send heartbeat to keep claim alive", {
+						logger.warn("Failed to refresh claim", {
 							"aiki.error": error.message,
 						});
 					}

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -5,7 +5,6 @@ import type { Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import {
-	CLAIM_REFRESH_INTERVAL_MS,
 	NonDeterminismError,
 	WorkflowRunFailedError,
 	type WorkflowRunId,
@@ -26,13 +25,19 @@ export interface ExecuteWorkflowParams<Context> {
 	workflowRun: WorkflowRunRecord;
 	workflowVersion: AnyWorkflowVersion;
 	logger: Logger;
-	configProvider: ConfigProvider<Required<WorkflowExecutionConfig>>;
-	heartbeat?: () => Promise<void>;
+	configProvider: ConfigProvider<WorkflowExecutionConfig>;
+	heartbeat?: {
+		send: () => Promise<void>;
+		intervalMs: number | (() => number);
+	};
 	signal?: AbortSignal;
 }
 
 export interface WorkflowExecutionConfig {
-	heartbeatIntervalMs?: number;
+	/**
+	 * Interval at which a worker refreshes its claim on a workflow run it is executing.
+	 */
+	claimRefreshIntervalMs: number;
 	/**
 	 * Threshold for spinning vs persisting task retry delays (default: 10ms).
 	 *
@@ -41,7 +46,7 @@ export interface WorkflowExecutionConfig {
 	 *
 	 * Set to 0 to record all task delays in transition history.
 	 */
-	spinThresholdMs?: number;
+	spinThresholdMs: number;
 }
 
 export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<Context>): Promise<boolean> {
@@ -52,7 +57,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 	try {
 		intervals.push(
 			runOnInterval(() => client.api.workflowRun.heartbeatV1({ id: workflowRunId }), {
-				intervalMs: CLAIM_REFRESH_INTERVAL_MS,
+				intervalMs: () => configProvider.config.claimRefreshIntervalMs,
 				onError: (error: Error): void => {
 					if (!signal?.aborted) {
 						logger.warn("Failed to refresh claim", {
@@ -65,8 +70,8 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		);
 		if (heartbeat) {
 			intervals.push(
-				runOnInterval(heartbeat, {
-					intervalMs: () => configProvider.config.heartbeatIntervalMs,
+				runOnInterval(heartbeat.send, {
+					intervalMs: heartbeat.intervalMs,
 					onError: (error: Error): void => {
 						if (!signal?.aborted) {
 							logger.warn("Failed to send heartbeat", {

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -56,7 +56,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 	const intervals: Array<{ stop: () => void }> = [];
 	try {
 		intervals.push(
-			runOnInterval(() => client.api.workflowRun.heartbeatV1({ id: workflowRunId }), {
+			runOnInterval(() => client.api.workflowRun.claimRefreshV1({ id: workflowRunId }), {
 				intervalMs: () => configProvider.config.claimRefreshIntervalMs,
 				onError: (error: Error): void => {
 					if (!signal?.aborted) {

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -82,7 +82,8 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		const eventsDefinition = workflowVersion[INTERNAL].eventsDefinition;
 		const handle = workflowRunHandle(client, workflowRun, eventsDefinition, logger);
 
-		const context = client[INTERNAL].context ? client[INTERNAL].context(workflowRun) : null;
+		const createContext = client[INTERNAL].context;
+		const context = createContext ? createContext(workflowRun) : null;
 
 		await workflowVersion[INTERNAL].handler(
 			{

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -21,6 +21,6 @@ export interface WorkflowRun<Input, Context, TEvents extends EventsDefinition = 
 	[INTERNAL]: {
 		handle: WorkflowRunHandle<Input, unknown, Context, TEvents>;
 		replayManifest: ReplayManifest;
-		configProvider: ConfigProvider<Required<WorkflowExecutionConfig>>;
+		configProvider: ConfigProvider<WorkflowExecutionConfig>;
 	};
 }

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -53,8 +53,8 @@ function createTestWorkflowRun(
 			handle,
 			replayManifest: createReplayManifest(record),
 			configProvider: asConfigProvider(() => ({
+				claimRefreshIntervalMs: 30_000,
 				spinThresholdMs: options.spinThresholdMs ?? 10,
-				heartbeatIntervalMs: 30_000,
 			})),
 		},
 	};

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -284,7 +284,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		taskId: TaskId,
 		retryStrategy: RetryStrategy,
 		currentAttempt: number,
-		configProvider: ConfigProvider<Required<WorkflowExecutionConfig>>,
+		configProvider: ConfigProvider<WorkflowExecutionConfig>,
 		logger: Logger
 	): Promise<{ output: Output; lastAttempt: number }> {
 		let attempts = currentAttempt;

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -51,7 +51,7 @@ function createTestWorkflowRun(
 		[INTERNAL]: {
 			handle,
 			replayManifest: createReplayManifest(record),
-			configProvider: asConfigProvider(() => ({ heartbeatIntervalMs: 30_000, spinThresholdMs: 10 })),
+			configProvider: asConfigProvider(() => ({ claimRefreshIntervalMs: 30_000, spinThresholdMs: 10 })),
 		},
 	};
 }

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -290,18 +290,18 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 
 	private async handler(run: WorkflowRun<Input, Context, TEvents>, input: Input): Promise<void> {
 		const { logger } = run;
-		const { handle } = run[INTERNAL];
+		const { assertExecutionAllowed, transitionState } = run[INTERNAL].handle[INTERNAL];
 
-		handle[INTERNAL].assertExecutionAllowed();
+		assertExecutionAllowed();
 
 		const retryStrategy = run.options.retry ?? this.params.retry ?? { type: "never" };
 
 		logger.info("Starting workflow");
-		await handle[INTERNAL].transitionState({ status: "running" });
+		await transitionState({ status: "running" });
 
 		const output = await this.tryExecuteWorkflow(input, run, retryStrategy);
 
-		await handle[INTERNAL].transitionState({ status: "completed", output });
+		await transitionState({ status: "completed", output });
 		logger.info("Workflow complete");
 	}
 

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -1,6 +1,7 @@
 import { createConsoleLogger } from "@aikirun/lib/logger";
 import type { ApiClient, Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
+import type { WorkflowRunRecord } from "@aikirun/types/workflow/run";
 
 import { expect, type Mock, mock } from "bun:test";
 
@@ -62,7 +63,7 @@ interface RegisteredEndpoint {
  *
  * Use it through {@link withFakeClient}, which calls `verify()` for you on success:
  */
-function fakeClient<Context = null>(): FakeClient<Context> {
+function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): FakeClient<Context> {
 	const endpoints: RegisteredEndpoint[] = [];
 
 	const createEndpoint = (endpointName: string): unknown => {
@@ -149,10 +150,17 @@ function fakeClient<Context = null>(): FakeClient<Context> {
 	return {
 		api,
 		logger: createConsoleLogger({ level: "DEBUG" }),
-		[INTERNAL]: {},
+		[INTERNAL]: options.context ? { context: options.context } : {},
 		verify,
 	};
 }
+
+/** Configures a fake client. `context` supplies the per-run context factory the SDK reads from the client. */
+export interface FakeClientOptions<Context> {
+	context?: (run: WorkflowRunRecord) => Context | Promise<Context>;
+}
+
+type FakeClientFn<Context> = (client: Omit<FakeClient<Context>, "verify">) => Promise<void> | void;
 
 /**
  * Runs `fn` with a fresh fake client, then asserts every queued call was made.
@@ -167,10 +175,20 @@ function fakeClient<Context = null>(): FakeClient<Context> {
  *     await schedule(params).activate(client, workflow, input);
  *   }));
  */
-export async function withFakeClient<Context = null>(
-	fn: (client: Omit<FakeClient<Context>, "verify">) => Promise<void> | void
+export async function withFakeClient<Context = null>(fn: FakeClientFn<Context>): Promise<void>;
+export async function withFakeClient<Context>(
+	options: FakeClientOptions<Context>,
+	fn: FakeClientFn<Context>
+): Promise<void>;
+export async function withFakeClient<Context>(
+	optionsOrFn: FakeClientOptions<Context> | FakeClientFn<Context>,
+	maybeFn?: FakeClientFn<Context>
 ): Promise<void> {
-	const client = fakeClient<Context>();
-	await fn(client);
+	const options = typeof optionsOrFn === "function" ? {} : optionsOrFn;
+	const fn = typeof optionsOrFn === "function" ? optionsOrFn : maybeFn;
+	const client = fakeClient<Context>(options);
+	if (fn) {
+		await fn(client);
+	}
 	client.verify();
 }

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -30,6 +30,12 @@ type MockEndpoint<Args extends unknown[], Return> = Mock<(...args: Args) => Retu
 	 * instead of resolving.
 	 */
 	rejectsOnce(request: Args[0], error: unknown): MockEndpoint<Args, Return>;
+
+	/**
+	 * Registers `callback` that is invoked once the next time this endpoint is called — regardless of
+	 * whether that call matches an expectation.
+	 */
+	onNextCall(callback: () => void): void;
 };
 
 /** Every API method becomes a `MockEndpoint` of its own signature. */
@@ -75,10 +81,14 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 	const createEndpoint = (endpointName: string): unknown => {
 		const expectedCalls: ExpectedCall[] = [];
 		const actualCalls: ActualCall[] = [];
+		const callbacks: Array<() => void> = [];
 		endpoints.push({ name: endpointName, expectedCalls, actualCalls });
 
 		const handler = async (actualRequest: unknown) => {
 			actualCalls.push({ request: actualRequest });
+			for (const callback of callbacks.splice(0)) {
+				callback();
+			}
 
 			const expectedCall = expectedCalls[actualCalls.length - 1];
 			if (expectedCall === undefined) {
@@ -93,6 +103,7 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 		const endpoint = mock(handler) as Mock<typeof handler> & {
 			once: (request: unknown, response?: unknown) => unknown;
 			rejectsOnce: (request: unknown, error: unknown) => unknown;
+			onNextCall: (callback: () => void) => void;
 		};
 		endpoint.once = (request, response) => {
 			expectedCalls.push({ request, result: { type: "resolve", response } });
@@ -101,6 +112,9 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 		endpoint.rejectsOnce = (request, error) => {
 			expectedCalls.push({ request, result: { type: "reject", error } });
 			return endpoint;
+		};
+		endpoint.onNextCall = (callback) => {
+			callbacks.push(callback);
 		};
 
 		return endpoint;

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -7,15 +7,16 @@ import { expect, type Mock, mock } from "bun:test";
 
 type MockEndpoint<Args extends unknown[], Return> = Mock<(...args: Args) => Return> & {
 	/**
-	 * Queues a single expected call: the next call to this endpoint asserts its request
-	 * `toEqual`s `request` and resolves with `response`. Each `once` covers exactly one call;
-	 * queue several to expect several calls, matched in order.
+	 * Queues a single expected call: the Nth call to this endpoint is paired with the
+	 * Nth `once` and resolves with `response`. Queue several to expect several calls.
 	 *
 	 * The match is EXACT by default — every field must be accounted for. For a partial match,
 	 * pass an asymmetric matcher, e.g. `expect.objectContaining({ ... })` or `expect.anything()`.
 	 *
-	 * A queued `once` that is never called fails `verify()`.
-	 * A call with no queued expectation throws.
+	 * A call with no expectation throws immediately. Separately, `verify()` compares the
+	 * expected calls against the calls actually made — position by position — and reports any that
+	 * were missing, unexpected, or sent with the wrong request. So a mismatch is caught even for a
+	 * fire-and-forget call whose inline throw is swallowed by the caller.
 	 *
 	 * The `response` argument is omitted for endpoints that resolve to `void`.
 	 */
@@ -25,9 +26,8 @@ type MockEndpoint<Args extends unknown[], Return> = Mock<(...args: Args) => Retu
 	): MockEndpoint<Args, Return>;
 
 	/**
-	 * Queues a single expected call that rejects: the next call to this endpoint asserts its
-	 * request `toEqual`s `request`, then throws `error`. Request matching and `verify()`
-	 * accounting are identical to {@link once}; only the outcome differs.
+	 * Queues a single expected call that rejects: matched like {@link once}, but throws `error`
+	 * instead of resolving.
 	 */
 	rejectsOnce(request: Args[0], error: unknown): MockEndpoint<Args, Return>;
 };
@@ -40,25 +40,31 @@ type MockApi<T> = {
 export interface FakeClient<Context = null> extends Client<Context> {
 	api: MockApi<ApiClient>;
 	/**
-	 * Throws if any call queued via `once` was never made.
+	 * Throws unless the calls made match the expected calls via `once`/`rejectsOnce`, in order —
+	 * reporting any that were missing, unexpected, or sent with the wrong request.
 	 */
 	verify(): void;
 }
 
-type QueuedCallResult = { type: "resolve"; response: unknown } | { type: "reject"; error: unknown };
+type ExpectedCallResult = { type: "resolve"; response: unknown } | { type: "reject"; error: unknown };
 
-interface QueuedCall {
+interface ExpectedCall {
 	request: unknown;
-	result: QueuedCallResult;
+	result: ExpectedCallResult;
+}
+
+interface ActualCall {
+	request: unknown;
 }
 
 interface RegisteredEndpoint {
 	name: string;
-	queuedCalls: QueuedCall[];
+	expectedCalls: ExpectedCall[];
+	actualCalls: ActualCall[];
 }
 
 /**
- * A `Client` whose every API endpoint is an auto-created mock augmented with `once`.
+ * A `Client` whose every API endpoint is an auto-created mock augmented with `once` and `rejectsOnce`.
  * Queue the calls a test expects; any call with no queued expectation throws.
  *
  * Use it through {@link withFakeClient}, which calls `verify()` for you on success:
@@ -67,30 +73,33 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 	const endpoints: RegisteredEndpoint[] = [];
 
 	const createEndpoint = (endpointName: string): unknown => {
-		const queuedCalls: QueuedCall[] = [];
-		endpoints.push({ name: endpointName, queuedCalls });
+		const expectedCalls: ExpectedCall[] = [];
+		const actualCalls: ActualCall[] = [];
+		endpoints.push({ name: endpointName, expectedCalls, actualCalls });
 
-		const handler = async (actual: unknown) => {
-			const call = queuedCalls.shift();
-			if (call === undefined) {
-				throw new Error(`Fake client: unexpected call to ${endpointName}(${Bun.inspect(actual)})`);
+		const handler = async (actualRequest: unknown) => {
+			actualCalls.push({ request: actualRequest });
+
+			const expectedCall = expectedCalls[actualCalls.length - 1];
+			if (expectedCall === undefined) {
+				throw new Error(`Fake client: unexpected call to ${endpointName}(${Bun.inspect(actualRequest)})`);
 			}
-			expect(actual).toEqual(call.request);
-			if (call.result.type === "reject") {
-				throw call.result.error;
+			expect(actualRequest).toEqual(expectedCall.request);
+			if (expectedCall.result.type === "reject") {
+				throw expectedCall.result.error;
 			}
-			return call.result.response;
+			return expectedCall.result.response;
 		};
 		const endpoint = mock(handler) as Mock<typeof handler> & {
 			once: (request: unknown, response?: unknown) => unknown;
 			rejectsOnce: (request: unknown, error: unknown) => unknown;
 		};
 		endpoint.once = (request, response) => {
-			queuedCalls.push({ request, result: { type: "resolve", response } });
+			expectedCalls.push({ request, result: { type: "resolve", response } });
 			return endpoint;
 		};
 		endpoint.rejectsOnce = (request, error) => {
-			queuedCalls.push({ request, result: { type: "reject", error } });
+			expectedCalls.push({ request, result: { type: "reject", error } });
 			return endpoint;
 		};
 
@@ -139,11 +148,30 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 	) as MockApi<ApiClient>;
 
 	const verify = () => {
-		const unconsumed = endpoints
-			.filter((endpoint) => endpoint.queuedCalls.length > 0)
-			.flatMap((endpoint) => endpoint.queuedCalls.map((call) => `${endpoint.name}(${Bun.inspect(call.request)})`));
-		if (unconsumed.length > 0) {
-			throw new Error(`Fake client: expected calls were never made: ${unconsumed.join(", ")}`);
+		const problems: string[] = [];
+		for (const { name, expectedCalls, actualCalls } of endpoints) {
+			const count = Math.max(expectedCalls.length, actualCalls.length);
+			for (let i = 0; i < count; i++) {
+				const expectedCall = expectedCalls[i];
+				const actualCall = actualCalls[i];
+
+				if (expectedCall === undefined) {
+					problems.push(`unexpected call to ${name}(${Bun.inspect(actualCall?.request)})`);
+				} else if (actualCall === undefined) {
+					problems.push(`expected call to ${name}(${Bun.inspect(expectedCall.request)}) was never made`);
+				} else {
+					try {
+						expect(actualCall.request).toEqual(expectedCall.request);
+					} catch {
+						problems.push(
+							`call to ${name} expected ${Bun.inspect(expectedCall.request)} but received ${Bun.inspect(actualCall.request)}`
+						);
+					}
+				}
+			}
+		}
+		if (problems.length > 0) {
+			throw new Error(`Fake client: ${problems.join("; ")}`);
 		}
 	};
 

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -298,9 +298,9 @@ export interface WorkflowRunClaimReadyRequestV1 {
 	limit: number;
 	/**
 	 * Steal actively executing runs whose last claim refresh was received more than
-	 * claimMinIdleTimeMs milliseconds ago. Defaults to 90 seconds.
+	 * previousClaimMinIdleTimeMs milliseconds ago. Defaults to 90 seconds.
 	 */
-	claimMinIdleTimeMs?: number;
+	previousClaimMinIdleTimeMs?: number;
 }
 
 export interface WorkflowRunClaimReadyResponseV1 {

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -47,7 +47,7 @@ export interface WorkflowRunApi {
 	listChildRunsV1: (_: WorkflowRunListChildRunsRequestV1) => Promise<WorkflowRunListChildRunsResponseV1>;
 	cancelByIdsV1: (_: WorkflowRunCancelByIdsRequestV1) => Promise<WorkflowRunCancelByIdsResponseV1>;
 	claimReadyV1: (_: WorkflowRunClaimReadyRequestV1) => Promise<WorkflowRunClaimReadyResponseV1>;
-	heartbeatV1: (_: WorkflowRunHeartbeatRequestV1) => Promise<void>;
+	claimRefreshV1: (_: WorkflowRunClaimRefreshRequestV1) => Promise<void>;
 	hasTerminatedV1: (_: WorkflowRunHasTerminatedRequestV1) => Promise<WorkflowRunHasTerminatedResponseV1>;
 }
 
@@ -297,7 +297,7 @@ export interface WorkflowRunClaimReadyRequestV1 {
 	shards?: string[];
 	limit: number;
 	/**
-	 * Steal actively executing runs whose last heartbeat was received more than
+	 * Steal actively executing runs whose last claim refresh was received more than
 	 * claimMinIdleTimeMs milliseconds ago. Defaults to 90 seconds.
 	 */
 	claimMinIdleTimeMs?: number;
@@ -307,7 +307,7 @@ export interface WorkflowRunClaimReadyResponseV1 {
 	runs: Array<{ id: string }>;
 }
 
-export interface WorkflowRunHeartbeatRequestV1 {
+export interface WorkflowRunClaimRefreshRequestV1 {
 	id: string;
 }
 

--- a/types/src/infra/queue/subscriber.ts
+++ b/types/src/infra/queue/subscriber.ts
@@ -13,7 +13,10 @@ export type SubscriberDelayParams = { type: "no_work" } | { type: "retry"; attem
 export interface Subscriber {
 	getNextDelay: (params: SubscriberDelayParams) => number;
 	getReadyRuns: (limit: number) => Promise<WorkflowRunMessage[]>;
-	heartbeat?: (workflowRunId: WorkflowRunId) => Promise<void>;
+	heartbeat?: {
+		send: (workflowRunId: WorkflowRunId) => Promise<void>;
+		intervalMs: number | (() => number);
+	};
 	acknowledge?: (workflowRunId: WorkflowRunId) => Promise<void>;
 }
 

--- a/types/src/workflow/run/claim.ts
+++ b/types/src/workflow/run/claim.ts
@@ -7,9 +7,9 @@ export const DEFAULT_CLAIM_MIN_IDLE_TIME_MS = 90_000;
 /**
  * Interval at which a worker refreshes its claim on a run it is executing.
  *
- * Derived from {@link DEFAULT_CLAIM_MIN_IDLE_TIME_MS} so the keepalive stays
+ * Derived from {@link DEFAULT_CLAIM_MIN_IDLE_TIME_MS} so the interval stays
  * comfortably below the reclaim threshold (a claim survives two missed
- * heartbeats). Any reclaim threshold should remain greater than this interval,
- * otherwise a still-running claim could be stolen too early.
+ * refreshes). Any reclaim threshold should remain greater than this interval,
+ * otherwise an active claim claim could be stolen too early.
  */
-export const CLAIM_KEEPALIVE_INTERVAL_MS = DEFAULT_CLAIM_MIN_IDLE_TIME_MS / 3;
+export const CLAIM_REFRESH_INTERVAL_MS = DEFAULT_CLAIM_MIN_IDLE_TIME_MS / 3;


### PR DESCRIPTION
## Background

While a workflow run executes, `executeWorkflowRun` runs two periodic background operations:

- **Claim refresh** — the executor (a worker or a serverless endpoint) tells the server it's still working the run, so the server doesn't treat the claim as abandoned and hand the run to another executor. Always runs.
- **Subscriber heartbeat** — an optional hook a custom subscriber uses to renew the run in its own transport, e.g. extending an SQS visibility timeout. Runs only when the subscriber provides one.

On `main`, the two are conflated:

- Both are called "heartbeat" in code. The server keepalive is the `heartbeatV1` RPC and logs "Failed to send heartbeat to keep claim alive"; the subscriber hook is also "heartbeat". They share one `heartbeats` array and the same log vocabulary.
- The claim refresh interval is a hardcoded constant — `CLAIM_KEEPALIVE_INTERVAL_MS` (30s). It can't be tuned.
- The subscriber heartbeat's interval, by contrast, lives in `WorkflowExecutionConfig.heartbeatIntervalMs` — detached from the subscriber that owns the heartbeat.
- `Subscriber.heartbeat` is a bare function `(workflowRunId) => Promise<void>`; its cadence is configured elsewhere.

## Solution

Separate the two operations and name each for what it does.

**Claim refresh.** Renamed throughout: `CLAIM_KEEPALIVE_INTERVAL_MS` → `CLAIM_REFRESH_INTERVAL_MS`, the RPC `heartbeatV1` → `claimRefreshV1` (and its request type), the warning becomes "Failed to refresh claim". Its interval is now read live from `WorkflowExecutionConfig.claimRefreshIntervalMs` through the config provider, so it's tunable at runtime alongside the other execution settings instead of frozen at a compile-time constant.

**Subscriber heartbeat.** The interval moves onto the subscriber, next to the function it paces:

```ts
// before
interface Subscriber {
  heartbeat?: (workflowRunId: WorkflowRunId) => Promise<void>;
}
// after
interface Subscriber {
  heartbeat?: {
    send: (workflowRunId: WorkflowRunId) => Promise<void>;
    intervalMs: number | (() => number);
  };
}
```

`ExecuteWorkflowParams.heartbeat` takes the same `{ send, intervalMs }` shape. Bundling the interval with the function makes the "there's only an interval when there's a heartbeat" invariant hold in the type, rather than sitting in a config field that's meaningless without a subscriber.

**Config shape.** `WorkflowExecutionConfig` becomes:

```ts
interface WorkflowExecutionConfig {
  claimRefreshIntervalMs: number;  // was: heartbeatIntervalMs?: number
  spinThresholdMs: number;         // was: spinThresholdMs?: number
}
```

Both fields are required, so consumers drop the `Required<WorkflowExecutionConfig>` wrapper. The worker and endpoint default configs set `claimRefreshIntervalMs` to `CLAIM_REFRESH_INTERVAL_MS`.

**Claim-steal param.** The claim API's optional "steal runs idle longer than this" parameter is renamed `claimMinIdleTimeMs` → `previousClaimMinIdleTimeMs`, so it stops colliding with the server runtime config's own `claimMinIdleTimeMs` (which the republish daemon reads). Same 90s default when omitted.

## Testing the interval behavior

The two intervals are fire-and-forget, so a failed or unexpected call is swallowed and never reaches the test. Three changes to the interval helper and the fake client (`@aikirun/testing`) make them testable deterministically, without fake timers:

- **`runOnInterval` returns a no-op when its signal is already aborted**, instead of scheduling a first timer that the already-fired abort listener never clears. A pre-aborted interval no longer fires once — a real behavior fix, and what lets the "stops on abort" assertions hold.
- **`verify()` reconciles two arrays — expected calls and actual calls — positionally**, replacing a queue it shifted as calls arrived. A fire-and-forget call with the wrong body, or one with no expectation, throws inline; `fireAndForget` swallows that throw. Recording every actual call and checking at the end catches the mismatch the swallowed throw hid.
- **`onNextCall(callback)`** fires a callback the next time an endpoint is called, so a test can block a workflow handler until an interval genuinely fires.

The reworked `execute.test.ts` uses these to cover error classification, context resolution, input forwarding, and both intervals under normal completion and abort.

## Docs

Claim refresh, work stealing, zombie-executor prevention, and safe re-execution moved out of the Subscribers page into a new **Workflow Run Claims** architecture page. Those are the server's execution-reliability contract; they apply to any executor, not to subscribers specifically. The Subscribers page keeps only subscriber-owned topics — the `heartbeat` capability and the backup subscriber. Doc terminology was swept so "heartbeat" now means only the subscriber transport renewal, and "claim refresh" the server keepalive.

## Breaking changes

- `WorkflowExecutionConfig.heartbeatIntervalMs` removed in favor of `claimRefreshIntervalMs`; worker and endpoint config move `workflowRun.heartbeatIntervalMs` → `workflowRun.claimRefreshIntervalMs`. Both `WorkflowExecutionConfig` fields are now required.
- `Subscriber.heartbeat` changes from a function to `{ send, intervalMs }`.
- The RPC `heartbeatV1` is renamed `claimRefreshV1` (with its request type); client and server must deploy together.
- `WorkflowRunClaimReadyRequestV1.claimMinIdleTimeMs` is renamed `previousClaimMinIdleTimeMs`.
