### PR TITLE
Fill available worker workflowRun slot immediately.

### DIFF
--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -248,6 +248,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 				maxConcurrentWorkflowRuns - this.pendingWorkflowRunIds.size - this.activeWorkflowRunsById.size;
 			if (availableCapacity <= 0) {
 				await this.availableCapacityLatch.wait();
+				nextDelayMs = 0;
 				continue;
 			}
 


### PR DESCRIPTION
When the capacity latch is signalled, it means that there is an available slot to be filled.

Not setting `nextDelayMs` to zero was a latency bug. It caused the worker to delay before refilling the slot.