### PR TITLE
Enable incremental typechecking and move it to pre-push

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bun check && bunx lint-staged
+bunx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+bun check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-bun check
+bun run check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,9 @@ bun run check && bun run lint && bun test
 ```
 
 A Husky pre-commit hook auto-formats staged files with Biome, so formatting is
-handled for you on commit.
+handled for you on commit. A pre-push hook runs `bun run check` (type checking)
+before your changes leave your machine; commits stay fast so you can freely save
+work in progress.
 
 ## TODO — planned additions to this guide
 

--- a/app/dashboard/tsconfig.json
+++ b/app/dashboard/tsconfig.json
@@ -20,6 +20,7 @@
 		"isolatedModules": true,
 		"moduleDetection": "force",
 		"noEmit": true,
+		"incremental": true,
 		"jsx": "react-jsx",
 		"strict": true,
 		"noUnusedLocals": true,

--- a/app/website/tsconfig.json
+++ b/app/website/tsconfig.json
@@ -15,6 +15,7 @@
 		"esModuleInterop": true,
 		"verbatimModuleSyntax": true,
 		"noEmit": true,
+		"incremental": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"types"
 	],
 	"scripts": {
-		"check": "tsc --noEmit && tsc --noEmit -p app/dashboard/tsconfig.json && bun run --cwd app/website check",
+		"check": "tsc --noEmit -p tsconfig.check.json && tsc --noEmit -p app/dashboard/tsconfig.json && bun run --cwd app/website check",
 		"lint": "bunx @biomejs/biome check .",
 		"lint:fix": "bunx @biomejs/biome check --write .",
 		"test:watch": "bun test --watch",

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"incremental": true
+	}
+}


### PR DESCRIPTION
Turn on TypeScript incremental compilation in the root, dashboard, and website
tsconfigs so repeat `bun run check` runs only re-check changed files.

Move the typecheck from pre-commit to pre-push so commits stay fast for work in
progress. Pre-commit still runs lint-staged (Biome on staged files), and CI
remains the authoritative check.