### PR TITLE
Separate website codegen from the check command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,9 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
+      - name: Generate website types
+        run: bun run website:generate
+
       - name: Typecheck
         run: bun run check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
+      - run: bun run website:generate
+
       - run: bun run check
 
       - run: bun run lint

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,31 @@
+# Determine whether the pushed commits touch the docs site. Read git's pre-push
+# stdin (one line per ref: <local ref> <local sha> <remote ref> <remote sha>)
+# up front so nothing else consumes it.
+zero_sha="0000000000000000000000000000000000000000"
+website_changed=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+	if [ "$local_sha" = "$zero_sha" ]; then
+		# Branch deletion — nothing to check.
+		continue
+	fi
+
+	if [ "$remote_sha" = "$zero_sha" ]; then
+		# New branch the remote hasn't seen — diff against the default branch.
+		range="origin/main...$local_sha"
+	else
+		range="$remote_sha..$local_sha"
+	fi
+
+	if [ -n "$(git diff --name-only "$range" -- app/website 2>/dev/null)" ]; then
+		website_changed=1
+	fi
+done
+
+# Regenerate the docs types only when the push touches app/website (or the
+# generated output is missing), then type-check everything.
+if [ "$website_changed" = "1" ] || [ ! -d app/website/.source ]; then
+	bun run website:generate
+fi
+
 bun run check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ environment running. For cutting releases, see [`.github/RELEASING.md`](.github/
 
 ## Prerequisites
 
-- **[Bun](https://bun.sh) 1.1+** — Aiki is a Bun workspace. `npm` and `pnpm`
+- **[Bun](https://bun.sh) 1.0+** — Aiki is a Bun workspace. `npm` and `pnpm`
   won't work at the repo root (the internal packages link via the `workspace:*`
   protocol, which only Bun/pnpm/Yarn understand — `npm install` here fails with
   `EUNSUPPORTEDPROTOCOL`).
@@ -85,8 +85,9 @@ bun run check && bun run lint && bun test
 ```
 
 A Husky pre-commit hook auto-formats staged files with Biome, so formatting is
-handled for you on commit. A pre-push hook runs `bun run check` (type checking)
-before your changes leave your machine; commits stay fast so you can freely save
+handled for you on commit. A pre-push hook type-checks your changes with
+`bun run check` before they leave your machine; if the push touches `app/website`
+it first regenerates the docs types. Commits stay fast so you can freely save
 work in progress.
 
 ## TODO — planned additions to this guide

--- a/app/website/package.json
+++ b/app/website/package.json
@@ -4,7 +4,8 @@
 	"version": "0.34.1",
 	"type": "module",
 	"scripts": {
-		"check": "react-router typegen && fumadocs-mdx && tsc --noEmit",
+		"generate": "react-router typegen && fumadocs-mdx",
+		"check": "tsc --noEmit",
 		"build": "react-router build && bun run scripts/postbuild.ts",
 		"dev": "react-router dev",
 		"preview": "bun run build && bunx serve --no-clipboard -l 9852 build/client"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"server:watch": "bun run --cwd app/server start:watch",
 		"dashboard": "bun run --cwd app/dashboard dev",
 		"website": "bun run --cwd app/website dev",
+		"website:generate": "bun run --cwd app/website generate",
 		"website:preview": "bun run --cwd app/website preview",
 		"bump": "bun scripts/bump.ts",
 		"clean": "rm -rf lib/dist types/dist app/server/dist app/dashboard/dist cli/dist sdk/*/dist sdk/adapter/*/dist sdk/iam/dist app/website/build app/website/.react-router app/website/.source",
@@ -48,7 +49,7 @@
 		"docker:up": "docker compose up -d",
 		"docker:down": "docker compose down",
 		"docker:logs": "docker compose logs -f",
-		"prepare": "husky"
+		"prepare": "husky && bun run website:generate"
 	},
 	"lint-staged": {
 		"*.{ts,tsx,js,jsx,json}": [


### PR DESCRIPTION
The website check embedded `react-router typegen && fumadocs-mdx`, so every `bun run check` regenerated the docs types. Split that out: `check` is now a single typecheck across packages, dashboard, and website, and the codegen lives in a `website:generate` script. The website's own `check` is a plain `tsc --noEmit`, consistent with the others.

Because `check` now assumes the generated types (`.source`, `.react-router/types`) already exist, ensure they do wherever it runs: `prepare` generates on install, CI runs `website:generate` before the typecheck, and the pre-push hook regenerates when the push touches `app/website` (or `.source` is missing) before running the full check.