### PR TITLE
Rename spawn to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) }
 const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
-const workerHandle = worker({ workflows: [trialV1] }).spawn(aikiClient);
+const workerHandle = worker({ workflows: [trialV1] }).start(aikiClient);
 
 // Start the workflow
 const handle = await trialV1.start(aikiClient, { userId: "user-123" });

--- a/app/website/content/docs/core-concepts/workers.md
+++ b/app/website/content/docs/core-concepts/workers.md
@@ -23,14 +23,14 @@ const aikiWorker = worker({
   },
 });
 
-const handle = aikiWorker.spawn(aikiClient);
+const handle = aikiWorker.start(aikiClient);
 ```
 
-Worker definitions are static and reusable. The `worker()` function creates a definition with a `workflows` array specifying which workflow versions it can execute. Call `spawn(client)` to begin execution; it returns a handle for controlling the running worker.
+Worker definitions are static and reusable. The `worker()` function creates a definition with a `workflows` array specifying which workflow versions it can execute. Call `start(client)` to begin execution; it returns a handle for controlling the running worker.
 
 ## How Workers Operate
 
-When you call `spawn()`, the worker begins discovering ready workflow runs through its subscriber — claiming them from the server by default. When a workflow run is triggered, the worker picks it up, looks up the workflow definition in its registry, and begins execution.
+When you call `start()`, the worker begins discovering ready workflow runs through its subscriber — claiming them from the server by default. When a workflow run is triggered, the worker picks it up, looks up the workflow definition in its registry, and begins execution.
 
 During execution, the worker periodically refreshes its claim on the run. This prevents other workers from thinking it's stuck. If a worker crashes mid-execution, the claim expires after a configurable idle time (default: 90 seconds) and the run is handed to a healthy worker. The workflow then re-executes from its last checkpoint. [Workflow Run Claims](../architecture/workflow-run-claims.md) covers this ownership and recovery in full.
 
@@ -46,8 +46,8 @@ Workers scale naturally. You can add capacity in several ways:
 const worker1 = worker({ workflows: [orderWorkflowV1] });
 const worker2 = worker({ workflows: [orderWorkflowV1] });
 
-const handle1 = worker1.spawn(aikiClient);
-const handle2 = worker2.spawn(aikiClient);
+const handle1 = worker1.start(aikiClient);
+const handle2 = worker2.start(aikiClient);
 ```
 
 **Specialize workers** by registering different workflows on different workers. Each worker only handles the workflows it knows about.

--- a/app/website/content/docs/getting-started/quick-start.mdx
+++ b/app/website/content/docs/getting-started/quick-start.mdx
@@ -87,7 +87,7 @@ const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) }
 const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
-const workerHandle = worker({ workflows: [trialV1] }).spawn(aikiClient);
+const workerHandle = worker({ workflows: [trialV1] }).start(aikiClient);
 ```
 
 `runtime.start()` runs the server's background loops. The worker claims ready runs and executes them. The client is the in-process connection between your code and the server.
@@ -185,7 +185,7 @@ const aikiServer = server({ db: database({ provider: "pg", url: databaseUrl }) }
 const runtimeHandle = aikiServer.runtime.start();
 
 const aikiClient = client({ handler: aikiServer.handler });
-const workerHandle = worker({ workflows: [trialV1] }).spawn(aikiClient);
+const workerHandle = worker({ workflows: [trialV1] }).start(aikiClient);
 
 // Start the workflow
 const handle = await trialV1.start(aikiClient, { userId: "user-123" });
@@ -210,7 +210,7 @@ await runtimeHandle.stop();
 - **Event** — `paymentReceived`: `wait()` suspends with nothing held; `send()` or the 14-day timeout resumes it. → [Events](../core-concepts/events.md)
 - **Server** — `server({ db })` + `runtime.start()`: the orchestrator and its background loops. → [Server](../architecture/server.md)
 - **Client** — `client({ handler })`: the in-process connection; workers and your app both attach. → [Client](../core-concepts/client.mdx)
-- **Worker** — `worker({...}).spawn(client)`: claims ready runs and executes them. → [Workers](../core-concepts/workers.md)
+- **Worker** — `worker({...}).start(client)`: claims ready runs and executes them. → [Workers](../core-concepts/workers.md)
 
 Everything here runs in one process. The same workflow code runs against a separately deployed server — swap `client({ handler: aikiServer.handler })` for `client({ url: "..." })`.
 

--- a/app/website/content/docs/guides/configuration.md
+++ b/app/website/content/docs/guides/configuration.md
@@ -57,7 +57,7 @@ interface ConfigProviderContext {
 }
 ```
 
-The factory runs once, when the component starts — a worker at `spawn`, the server runtime at `start`. The context's `signal` aborts when that same component shuts down (the worker handle's `stop()`, the server runtime handle's `stop()`), so register any teardown your provider needs on it. The `logger` is the component's own logger; the bundled helpers use it to report failed refreshes, and a custom provider can log through it the same way.
+The factory runs once, when the component starts — the worker's `start()` or the server runtime's `start()`. The context's `signal` aborts when that same component shuts down (the worker handle's `stop()`, the server runtime handle's `stop()`), so register any teardown your provider needs on it. The `logger` is the component's own logger; the bundled helpers use it to report failed refreshes, and a custom provider can log through it the same way.
 
 From then on, the component reads values where it uses them: the worker checks its concurrency limit on each claim iteration, the server's daemons read their cadence each tick, the endpoint reads per request, and workflow-execution settings are read live even by runs already in flight. A new snapshot simply takes effect at the next read.
 

--- a/examples/src/runner.ts
+++ b/examples/src/runner.ts
@@ -21,7 +21,7 @@ interface Setup {
 }
 
 /**
- * Spawns two workers that listen for the given workflows, runs the callback,
+ * Starts two workers that listen for the given workflows, runs the callback,
  * then shuts down.
  *
  * Two workers demonstrate the distributed nature of workflows.
@@ -50,8 +50,8 @@ export async function runWithWorker(
 		config: { maxConcurrentWorkflowRuns: 10 },
 	});
 
-	const handleA = workerA.spawn(aikiClient);
-	const handleB = workerB.spawn(aikiClient);
+	const handleA = workerA.start(aikiClient);
+	const handleB = workerB.start(aikiClient);
 
 	const shutdown = async (exitCode: number) => {
 		await Promise.all([handleA.stop(), handleB.stop()]);

--- a/sdk/adapter/redis/src/queue/subscriber.ts
+++ b/sdk/adapter/redis/src/queue/subscriber.ts
@@ -62,7 +62,7 @@ return results
  *    settings can only be applied at construction time, so the factory owns
  *    client creation to guarantee them.
  *
- * 2. Each spawned worker gets its own connection. The subscriber uses
+ * 2. Each started worker gets its own connection. The subscriber uses
  *    `BZPOPMIN`, a blocking command that ties up the underlying connection
  *    while it waits, so connections cannot be shared across concurrent
  *    workers.

--- a/sdk/server/src/daemons/due-timers-consumer.test.ts
+++ b/sdk/server/src/daemons/due-timers-consumer.test.ts
@@ -3,12 +3,12 @@ import { asConfigProvider } from "@aikirun/lib/config";
 import { createConsoleLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 
-import { spawnDueTimersConsumer } from "./due-timers-consumer";
+import { startDueTimersConsumer } from "./due-timers-consumer";
 import { describe, expect, test } from "bun:test";
 import type { Repositories } from "../infra/db/types";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
 
-describe("spawnDueTimersConsumer", () => {
+describe("startDueTimersConsumer", () => {
 	test("resolves when the runtime signal aborts while parked in an indefinite wait", async () => {
 		const abortController = new AbortController();
 		const { signal } = abortController;
@@ -18,7 +18,7 @@ describe("spawnDueTimersConsumer", () => {
 		const configProvider = asConfigProvider(() => ({ limit: 1, overshootMs: 10 }));
 
 		let resolved = false;
-		const consumer = spawnDueTimersConsumer(logger, {
+		const consumer = startDueTimersConsumer(logger, {
 			repos: {} as unknown as Repositories,
 			signal,
 			timerPriorityQueue,

--- a/sdk/server/src/daemons/due-timers-consumer.ts
+++ b/sdk/server/src/daemons/due-timers-consumer.ts
@@ -33,7 +33,7 @@ export interface DueTimersConsumerDeps {
 	configProvider: ConfigProvider<ServerRuntimeConfig["daemons"]["dueTimersConsumer"]>;
 }
 
-export async function spawnDueTimersConsumer(logger: Logger, deps: DueTimersConsumerDeps): Promise<void> {
+export async function startDueTimersConsumer(logger: Logger, deps: DueTimersConsumerDeps): Promise<void> {
 	const timerSignalWaiter = deps.timerPriorityQueue.createSignalWaiter();
 	deps.signal.addEventListener("abort", () => void timerSignalWaiter.close(), { once: true });
 

--- a/sdk/server/src/daemons/index.ts
+++ b/sdk/server/src/daemons/index.ts
@@ -5,7 +5,7 @@ import { withRetry } from "@aikirun/lib/retry";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerPriorityQueue } from "@aikirun/types/infra/timer";
 
-import { spawnDueTimersConsumer } from "./due-timers-consumer";
+import { startDueTimersConsumer } from "./due-timers-consumer";
 import { processImminentChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
 import { processImminentEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
 import { processImminentRecurringWorkflows } from "./imminent-recurring-workflows";
@@ -21,7 +21,7 @@ import type { DaemonContext } from "../middleware/context";
 import { createDaemonContext } from "../middleware/context";
 import type { ChildRunCanceller } from "../service/cancel-child-runs";
 
-export interface SpawnDaemonsDeps {
+export interface StartDaemonsDeps {
 	repos: Repositories;
 	signal: AbortSignal;
 	configProvider: ConfigProvider<ServerRuntimeConfig>;
@@ -35,7 +35,7 @@ const pollingDaemon = (
 	signal: AbortSignal,
 	configProvider: ConfigProvider<ServerRuntimeConfig["daemons"]>
 ) => ({
-	spawn<Deps, DaemonOptions>(
+	start<Deps, DaemonOptions>(
 		getConfig: (config: ServerRuntimeConfig["daemons"]) => DaemonOptions & { intervalMs: number },
 		fn: (context: DaemonContext, deps: Deps, options: DaemonOptions) => Promise<void>,
 		deps: Deps
@@ -73,43 +73,43 @@ const pollingDaemon = (
 	},
 });
 
-export async function spawnDaemons(logger: Logger, deps: SpawnDaemonsDeps): Promise<void> {
+export async function startDaemons(logger: Logger, deps: StartDaemonsDeps): Promise<void> {
 	const { repos, signal, configProvider, workflowRunPublisher, timerPriorityQueue, childRunCanceller } = deps;
 
-	const { spawn: spawnPollingDaemon } = pollingDaemon(logger, signal, configProvider.scope("daemons"));
+	const { start: startPollingDaemon } = pollingDaemon(logger, signal, configProvider.scope("daemons"));
 
 	const daemonPromises: Promise<void>[] = [
-		spawnPollingDaemon((config) => config.imminentScheduledRuns, processImminentScheduledRuns, {
+		startPollingDaemon((config) => config.imminentScheduledRuns, processImminentScheduledRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentSleepElapsedRuns, processImminentSleepElapsedRuns, {
+		startPollingDaemon((config) => config.imminentSleepElapsedRuns, processImminentSleepElapsedRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentRetryableRuns, processImminentRetryableRuns, {
+		startPollingDaemon((config) => config.imminentRetryableRuns, processImminentRetryableRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentRetryableTaskRuns, processImminentRetryableTaskRuns, {
+		startPollingDaemon((config) => config.imminentRetryableTaskRuns, processImminentRetryableTaskRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentEventWaitTimedOutRuns, processImminentEventWaitTimedOutRuns, {
+		startPollingDaemon((config) => config.imminentEventWaitTimedOutRuns, processImminentEventWaitTimedOutRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentChildRunWaitTimedOutRuns, processImminentChildRunWaitTimedOutRuns, {
+		startPollingDaemon((config) => config.imminentChildRunWaitTimedOutRuns, processImminentChildRunWaitTimedOutRuns, {
 			repos,
 			workflowRunPublisher,
 			timerPriorityQueue,
 		}),
-		spawnPollingDaemon((config) => config.imminentRecurringWorkflows, processImminentRecurringWorkflows, {
+		startPollingDaemon((config) => config.imminentRecurringWorkflows, processImminentRecurringWorkflows, {
 			repos,
 			childRunCanceller,
 			workflowRunPublisher,
@@ -119,11 +119,11 @@ export async function spawnDaemons(logger: Logger, deps: SpawnDaemonsDeps): Prom
 
 	if (workflowRunPublisher) {
 		daemonPromises.push(
-			spawnPollingDaemon((config) => config.publishReadyRuns, publishReadyRuns, {
+			startPollingDaemon((config) => config.publishReadyRuns, publishReadyRuns, {
 				repos,
 				workflowRunPublisher,
 			}),
-			spawnPollingDaemon((config) => config.republishStaleRuns, republishStaleRuns, {
+			startPollingDaemon((config) => config.republishStaleRuns, republishStaleRuns, {
 				repos,
 				workflowRunPublisher,
 			})
@@ -132,7 +132,7 @@ export async function spawnDaemons(logger: Logger, deps: SpawnDaemonsDeps): Prom
 
 	if (timerPriorityQueue) {
 		daemonPromises.push(
-			spawnDueTimersConsumer(logger, {
+			startDueTimersConsumer(logger, {
 				repos,
 				signal,
 				timerPriorityQueue,

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -6,7 +6,7 @@ import type { CreatePublisher } from "@aikirun/types/infra/queue/publisher";
 import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 
 import { defaultServerRuntimeConfig, type ServerRuntimeConfig, type ServerRuntimeConfigOverrides } from "./config";
-import { spawnDaemons } from "./daemons";
+import { startDaemons } from "./daemons";
 import { createRepos } from "./infra/db/repo";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
 
@@ -38,7 +38,7 @@ export async function startRuntime(params: StartRuntimeParams): Promise<StartedR
 
 	const repos = await createRepos(db);
 
-	const daemonsPromise = spawnDaemons(logger, {
+	const daemonsPromise = startDaemons(logger, {
 		repos,
 		configProvider,
 		signal,

--- a/sdk/worker/README.md
+++ b/sdk/worker/README.md
@@ -20,7 +20,7 @@ const aikiClient = client({
 	apiKey: "your-api-key",
 });
 
-const handle = worker({ workflows: [orderWorkflowV1] }).spawn(aikiClient);
+const handle = worker({ workflows: [orderWorkflowV1] }).start(aikiClient);
 
 process.on("SIGTERM", async () => {
 	await handle.stop();

--- a/sdk/worker/src/config.ts
+++ b/sdk/worker/src/config.ts
@@ -21,7 +21,7 @@ export const defaultWorkerConfig: WorkerConfig = {
 };
 
 /**
- * Worker config fixed at spawn. Pass `overrides` to change any setting; omit them
+ * Worker config fixed at start. Pass `overrides` to change any setting; omit them
  * for the defaults.
  */
 export function staticWorkerConfigProvider(overrides?: WorkerConfigOverrides): CreateConfigProvider<WorkerConfig> {

--- a/sdk/worker/src/index.ts
+++ b/sdk/worker/src/index.ts
@@ -3,5 +3,5 @@ export { asConfigProvider } from "@aikirun/lib/config";
 
 export type { WorkerConfig, WorkerConfigOverrides } from "./config";
 export { defaultWorkerConfig, dynamicWorkerConfigProvider, staticWorkerConfigProvider } from "./config";
-export type { Worker, WorkerBuilder, WorkerHandle, WorkerParams, WorkerSpawnOptions } from "./worker";
+export type { Worker, WorkerBuilder, WorkerHandle, WorkerParams, WorkerStartOptions } from "./worker";
 export { worker } from "./worker";

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -30,14 +30,14 @@ import { defaultWorkerConfig, type WorkerConfig, type WorkerConfigOverrides } fr
 /**
  * Creates an Aiki worker definition for executing workflows.
  *
- * Worker definitions are static and reusable. Call `spawn(client)` to begin
+ * Worker definitions are static and reusable. Call `start(client)` to begin
  * execution, which returns a handle for controlling the running worker.
  *
  * @param params - Worker configuration parameters
  * @param params.workflows - Array of workflow versions this worker can execute
  * @param params.subscriber - Optional subscriber factory for work discovery (default: claims work from the server over HTTP)
  * @param params.config - Optional runtime tunables: a plain overrides object, or a config provider (e.g. `dynamicWorkerConfigProvider`) for live reloads
- * @returns Worker definition, call spawn(client) to begin execution
+ * @returns Worker definition, call start(client) to begin execution
  *
  * @example
  * ```typescript
@@ -46,7 +46,7 @@ import { defaultWorkerConfig, type WorkerConfig, type WorkerConfigOverrides } fr
  *   config: { maxConcurrentWorkflowRuns: 10 },
  * });
  *
- * const handle = myWorker.spawn(client);
+ * const handle = myWorker.start(client);
  *
  * process.on("SIGINT", async () => {
  *   await handle.stop();
@@ -63,7 +63,7 @@ export interface WorkerParams {
 	config?: WorkerConfigOverrides | CreateConfigProvider<WorkerConfig>;
 }
 
-export interface WorkerSpawnOptions {
+export interface WorkerStartOptions {
 	/**
 	 * Optional array of shards this worker should process.
 	 * When provided, the worker will only subscribe to registered workflows within that shard.
@@ -81,7 +81,7 @@ export interface WorkerSpawnOptions {
 
 export interface Worker {
 	with(): WorkerBuilder;
-	spawn: <Context>(client: Client<Context>) => WorkerHandle;
+	start: <Context>(client: Client<Context>) => WorkerHandle;
 }
 
 export interface WorkerHandle {
@@ -93,16 +93,16 @@ class WorkerImpl implements Worker {
 	constructor(private readonly params: WorkerParams) {}
 
 	public with(): WorkerBuilder {
-		const spawnOptionsOverrider = objectOverrider<WorkerSpawnOptions>({});
-		return createWorkerBuilder(this, spawnOptionsOverrider());
+		const startOptionsOverrider = objectOverrider<WorkerStartOptions>({});
+		return createWorkerBuilder(this, startOptionsOverrider());
 	}
 
-	public spawn<Context>(client: Client<Context>): WorkerHandle {
-		return this.spawnWithOptions(client, {});
+	public start<Context>(client: Client<Context>): WorkerHandle {
+		return this.startWithOptions(client, {});
 	}
 
-	public spawnWithOptions<Context>(client: Client<Context>, spawnOptions: WorkerSpawnOptions): WorkerHandle {
-		return new WorkerHandleImpl(client, this.params, spawnOptions);
+	public startWithOptions<Context>(client: Client<Context>, startOptions: WorkerStartOptions): WorkerHandle {
+		return new WorkerHandleImpl(client, this.params, startOptions);
 	}
 }
 
@@ -131,7 +131,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 	constructor(
 		private readonly client: Client<Context>,
 		private readonly params: WorkerParams,
-		private readonly spawnOptions: WorkerSpawnOptions
+		private readonly startOptions: WorkerStartOptions
 	) {
 		this.id = ulid() as WorkerId;
 		this.registry = workflowRegistry().addMany(getSystemWorkflows(this.client.api)).addMany(this.params.workflows);
@@ -140,7 +140,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			throw new Error("No workflow registered");
 		}
 
-		const reference = this.spawnOptions.reference;
+		const reference = this.startOptions.reference;
 		this.logger = this.client.logger.child({
 			"aiki.component": "worker",
 			"aiki.workerId": this.id,
@@ -164,7 +164,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 		this.primarySubscriber = createPrimarySubscriber({
 			workerId: this.id,
 			workflows,
-			shards: this.spawnOptions.shards,
+			shards: this.startOptions.shards,
 			logger: this.logger.child({ "aiki.subscriber": "primary" }),
 			signal,
 		});
@@ -177,7 +177,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			this.backupSubscriber = createBackupSubscriber({
 				workerId: this.id,
 				workflows,
-				shards: this.spawnOptions.shards,
+				shards: this.startOptions.shards,
 				logger: this.logger.child({ "aiki.subscriber": "backup" }),
 				signal,
 			});
@@ -461,24 +461,24 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 }
 
 export interface WorkerBuilder {
-	opt<Path extends PathFromObject<WorkerSpawnOptions>>(
+	opt<Path extends PathFromObject<WorkerStartOptions>>(
 		path: Path,
-		value: TypeOfValueAtPath<WorkerSpawnOptions, Path>
+		value: TypeOfValueAtPath<WorkerStartOptions, Path>
 	): WorkerBuilder;
-	spawn: Worker["spawn"];
+	start: Worker["start"];
 }
 
 function createWorkerBuilder(
 	worker: WorkerImpl,
-	spawnOptionsBuilder: ObjectBuilder<WorkerSpawnOptions>
+	startOptionsBuilder: ObjectBuilder<WorkerStartOptions>
 ): WorkerBuilder {
 	return {
 		opt(path, value) {
-			return createWorkerBuilder(worker, spawnOptionsBuilder.with(path, value));
+			return createWorkerBuilder(worker, startOptionsBuilder.with(path, value));
 		},
 
-		spawn(client) {
-			return worker.spawnWithOptions(client, spawnOptionsBuilder.build());
+		start(client) {
+			return worker.startWithOptions(client, startOptionsBuilder.build());
 		},
 	};
 }


### PR DESCRIPTION
Rename `worker.spawn` to `worker.start` so users do not get the notion that is starts a child process.

The initial idea behind calling it spawn was to communicate that each call creates a new worker instance, but I'm now convinced `start` is a less overloaded name.