### PR TITLE
Bucket the publish result by outcome

### DIFF
--- a/sdk/adapter/memory/src/queue/publisher.ts
+++ b/sdk/adapter/memory/src/queue/publisher.ts
@@ -27,7 +27,7 @@ export function createInMemoryPublisher(store: Store): CreatePublisher {
 				}
 			}
 
-			return { published: runs, deferred: [], failed: [], declined: [] };
+			return { published: runs.map((run) => ({ run })) };
 		},
 	});
 }

--- a/sdk/adapter/redis/src/queue/publisher.ts
+++ b/sdk/adapter/redis/src/queue/publisher.ts
@@ -1,5 +1,11 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import type { CreatePublisher, Publisher, PublishResult, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
+import type {
+	CreatePublisher,
+	Publisher,
+	PublishResult,
+	PublishResultBucket,
+	ReadyWorkflowRun,
+} from "@aikirun/types/infra/queue";
 import type { Redis } from "ioredis";
 
 import { getWorkflowQueueName } from "./key";
@@ -17,7 +23,7 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 		return {
 			async publishReadyRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishResult> {
 				if (!redisTracker.isAvailable()) {
-					return { published: [], deferred: [], failed: runs, declined: [] };
+					return { failed: runs.map((run) => ({ run })) };
 				}
 
 				const dataByQueueName = new Map<string, QueueData>();
@@ -44,11 +50,11 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 					logger.warn("Publish pipeline returned no results, treating runs as failed", {
 						"aiki.count": runs.length,
 					});
-					return { published: [], deferred: [], failed: runs, declined: [] };
+					return { failed: runs.map((run) => ({ run })) };
 				}
 
-				const published: ReadyWorkflowRun[] = [];
-				const failed: ReadyWorkflowRun[] = [];
+				const published: PublishResultBucket = [];
+				const failed: PublishResultBucket = [];
 				let err: Error | undefined;
 				for (const [i, queueData] of queueDataBatch.entries()) {
 					const result = results[i];
@@ -56,11 +62,11 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 					if (commandError !== null) {
 						err ??= commandError;
 						for (const run of queueData.runs) {
-							failed.push(run);
+							failed.push({ run });
 						}
 					} else {
 						for (const run of queueData.runs) {
-							published.push(run);
+							published.push({ run });
 						}
 					}
 				}
@@ -72,7 +78,14 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 					});
 				}
 
-				return { published, deferred: [], failed, declined: [] };
+				const result: PublishResult = {};
+				if (published.length > 0) {
+					result.published = published;
+				}
+				if (failed.length > 0) {
+					result.failed = failed;
+				}
+				return result;
 			},
 		};
 	};

--- a/sdk/server/src/daemons/publish-ready-runs.ts
+++ b/sdk/server/src/daemons/publish-ready-runs.ts
@@ -15,6 +15,8 @@ export interface PublishReadyRunsDeps {
 	workflowRunPublisher: Publisher;
 }
 
+const PUBLISH_OUTCOMES = ["published", "deferred", "failed", "declined"] as const;
+
 const advanceRankStreamCursor = createRankStreamCursorAdvancer<{ id: string; rank: number }>({
 	getRank: (entry) => entry.rank,
 	getId: (entry) => entry.id,
@@ -70,26 +72,35 @@ export async function publishOutboxEntries(
 	const result = await workflowRunPublisher.publishReadyRuns(runs as NonEmptyArray<ReadyWorkflowRun>);
 
 	const publishedEntryIds: string[] = [];
-	if (isNonEmptyArray(result.published)) {
-		context.logger.debug("Published ready workflow runs", { "aiki.count": result.published.length });
-		for (const run of result.published) {
-			const entryId = entryIdByRunId.get(run.id);
-			if (entryId !== undefined) {
-				publishedEntryIds.push(entryId);
-			}
+
+	for (const outcome of PUBLISH_OUTCOMES) {
+		const bucket = result[outcome];
+		if (!isNonEmptyArray(bucket)) {
+			continue;
 		}
-	}
 
-	if (isNonEmptyArray(result.deferred)) {
-		context.logger.debug("Deferred publishing workflow runs", { "aiki.count": result.deferred.length });
-	}
-
-	if (isNonEmptyArray(result.failed)) {
-		context.logger.debug("Failed to publish workflow runs", { "aiki.count": result.failed.length });
-	}
-
-	if (isNonEmptyArray(result.declined)) {
-		context.logger.warn("Declined to publish workflow runs", { "aiki.count": result.declined.length });
+		switch (outcome) {
+			case "published":
+				context.logger.debug("Published ready workflow runs", { "aiki.count": bucket.length });
+				for (const { run } of bucket) {
+					const entryId = entryIdByRunId.get(run.id);
+					if (entryId !== undefined) {
+						publishedEntryIds.push(entryId);
+					}
+				}
+				break;
+			case "deferred":
+				context.logger.debug("Deferred publishing workflow runs", { "aiki.count": bucket.length });
+				break;
+			case "failed":
+				context.logger.debug("Failed to publish workflow runs", { "aiki.count": bucket.length });
+				break;
+			case "declined":
+				context.logger.warn("Declined to publish workflow runs", { "aiki.count": bucket.length });
+				break;
+			default:
+				outcome satisfies never;
+		}
 	}
 
 	return publishedEntryIds;

--- a/types/src/infra/queue/publisher.ts
+++ b/types/src/infra/queue/publisher.ts
@@ -10,15 +10,18 @@ export interface ReadyWorkflowRun {
 	shard?: string;
 }
 
+export type PublishResultBucket = Array<{ run: ReadyWorkflowRun }>;
+export type TimedPublishResultBucket = Array<{ run: ReadyWorkflowRun; nextPublishAttemptAt: number }>;
+
 export interface PublishResult {
-	/** Delivered. */
-	published: ReadyWorkflowRun[];
+	/** Handoff to broker confirmed. */
+	published?: PublishResultBucket;
 	/** Deliverable, but withheld by policy (admission, fairness, throttling). */
-	deferred: ReadyWorkflowRun[];
-	/** Could not be delivered, or delivery is uncertain. */
-	failed: ReadyWorkflowRun[];
+	deferred?: TimedPublishResultBucket;
+	/** Delivery failure. */
+	failed?: PublishResultBucket;
 	/** Not handled. */
-	declined: ReadyWorkflowRun[];
+	declined?: PublishResultBucket;
 }
 
 export interface Publisher {


### PR DESCRIPTION
`publishReadyRuns` returns a `PublishResult` that sorts each run by outcome — `published`, `deferred`, `failed`, `declined`. Each bucket was a flat, required `ReadyWorkflowRun[]`. The endpoint-delivery work ahead needs per-run result data (a transport-supplied next-attempt time) and a consumption path that can't silently drop a new outcome, so this chunk reshapes the result — the delivery-contract step of the outbox redesign.

Each bucket becomes optional and holds `{ run }` objects instead of bare runs, leaving room for per-run fields without breaking consumers; `deferred` carries the transport's `nextPublishAttemptAt`. Both broker adapters emit the new shape and omit empty buckets. The publish daemon iterates the outcomes under a `satisfies never` exhaustiveness check, so a later outcome is a compile error until it's handled. Behavior is unchanged — only `published` runs drive state, marking their outbox entries published.