### PR TITLE
Remove SQLite and MySQL from the list of supported providers.

### DIFF
--- a/app/server/.env.example
+++ b/app/server/.env.example
@@ -12,17 +12,12 @@ CORS_ORIGINS=http://localhost:9851
 # REDIS_PORT=6379
 # REDIS_PASSWORD=
 
-# pg, mysql, or sqlite
 DATABASE_PROVIDER=pg
 
-# PostgreSQL / MySQL only
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki
 DATABASE_MAX_CONNECTIONS=10
 # To verify the DB's cert against a private CA (e.g. DigitalOcean, RDS), set its PEM contents here:
 # DATABASE_CA_CERT=
-
-# SQLite only
-# DATABASE_PATH=:memory:
 
 LOG_LEVEL=info
 PRETTY_LOGS=true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     environment:
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
-      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -29,7 +28,6 @@ services:
       CORS_ORIGINS: ${CORS_ORIGINS:-}
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
-      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
       REDIS_HOST: ${REDIS_HOST:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
-      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -35,7 +34,6 @@ services:
       CORS_ORIGINS: ${CORS_ORIGINS:-}
       DATABASE_PROVIDER: ${DATABASE_PROVIDER:-pg}
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
-      DATABASE_PATH: ${DATABASE_PATH:-:memory:}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
       REDIS_HOST: ${REDIS_HOST:-}

--- a/lib/src/db/config.ts
+++ b/lib/src/db/config.ts
@@ -12,23 +12,23 @@ const pgDatabaseConfigSchema = type({
 	"caCert?": "string > 0",
 });
 
-const mysqlDatabaseConfigSchema = type({
-	provider: "'mysql'",
-	url: "string > 0",
-	maxConnections: "string.integer.parse | number.integer > 0 = 10",
-	"caCert?": "string > 0",
-});
+// const mysqlDatabaseConfigSchema = type({
+// 	provider: "'mysql'",
+// 	url: "string > 0",
+// 	maxConnections: "string.integer.parse | number.integer > 0 = 10",
+// 	"caCert?": "string > 0",
+// });
 
-const sqliteDatabaseConfigSchema = type({
-	provider: "'sqlite'",
-	path: "string > 0 = ':memory:'",
-});
+// const sqliteDatabaseConfigSchema = type({
+// 	provider: "'sqlite'",
+// 	path: "string > 0 = ':memory:'",
+// });
 
-const databaseConfigSchema = pgDatabaseConfigSchema.or(mysqlDatabaseConfigSchema).or(sqliteDatabaseConfigSchema);
+const databaseConfigSchema = pgDatabaseConfigSchema /*.or(mysqlDatabaseConfigSchema).or(sqliteDatabaseConfigSchema)*/;
 
 export type PgDatabaseConfig = typeof pgDatabaseConfigSchema.infer;
-export type MysqlDatabaseConfig = typeof mysqlDatabaseConfigSchema.infer;
-export type SqliteDatabaseConfig = typeof sqliteDatabaseConfigSchema.infer;
+// export type MysqlDatabaseConfig = typeof mysqlDatabaseConfigSchema.infer;
+// export type SqliteDatabaseConfig = typeof sqliteDatabaseConfigSchema.infer;
 export type DatabaseConfig = typeof databaseConfigSchema.infer;
 
 type _DbOptionsSatisfiesDbProviders = ExpectTrue<Equal<DatabaseConfig["provider"], DatabaseProvider>>;
@@ -47,10 +47,10 @@ export function loadDatabaseConfig(): DatabaseConfig {
 
 	const raw = (() => {
 		switch (provider) {
-			case "sqlite":
-				return { provider, path: process.env.DATABASE_PATH };
+			// case "sqlite":
+			// 	return { provider, path: process.env.DATABASE_PATH };
 			case "pg":
-			case "mysql":
+				// case "mysql":
 				return {
 					provider,
 					url: process.env.DATABASE_URL,

--- a/lib/src/db/migrate/commands/apply.ts
+++ b/lib/src/db/migrate/commands/apply.ts
@@ -14,11 +14,11 @@ export async function migrateApply(params: MigrateApplyParams): Promise<void> {
 		case "pg":
 			await applyPg(dbConfig, params.source.read(), params.migrationsTable);
 			return;
-		case "sqlite":
-		case "mysql":
-			throw new Error(`DATABASE_PROVIDER=${dbConfig.provider} is not yet supported.`);
+		// case "sqlite":
+		// case "mysql":
+		// 	throw new Error(`DATABASE_PROVIDER=${dbConfig.provider} is not yet supported.`);
 		default:
-			dbConfig satisfies never;
+			dbConfig.provider satisfies never;
 	}
 }
 

--- a/lib/src/db/migrate/commands/generate.ts
+++ b/lib/src/db/migrate/commands/generate.ts
@@ -6,8 +6,8 @@ import { DATABASE_PROVIDERS, type DatabaseProvider } from "../../provider";
 
 const providerDialects: Record<DatabaseProvider, string> = {
 	pg: "postgresql",
-	sqlite: "sqlite",
-	mysql: "mysql",
+	// sqlite: "sqlite",
+	// mysql: "mysql",
 };
 
 interface MigrateGenerateParams {
@@ -19,12 +19,10 @@ interface MigrateGenerateParams {
 }
 
 export async function migrateGenerate(params: MigrateGenerateParams): Promise<void> {
-	let generated = 0;
-
 	for (const provider of DATABASE_PROVIDERS) {
 		const schemaDir = params.resolveSchemaDir(provider);
 		if (!fs.existsSync(schemaDir)) {
-			continue;
+			throw new Error(`no schema sources found for ${provider} database`);
 		}
 
 		console.log(`generating ${provider} migrations`);
@@ -44,11 +42,6 @@ export async function migrateGenerate(params: MigrateGenerateParams): Promise<vo
 		}
 
 		await spawnDrizzle(args, params.packageRoot);
-		generated += 1;
-	}
-
-	if (generated === 0) {
-		throw new Error("no schema sources found for any database provider");
 	}
 }
 

--- a/lib/src/db/provider.ts
+++ b/lib/src/db/provider.ts
@@ -1,4 +1,4 @@
-export const DATABASE_PROVIDERS = ["pg", "sqlite", "mysql"] as const;
+export const DATABASE_PROVIDERS = ["pg" /*, "sqlite", "mysql"*/] as const;
 export type DatabaseProvider = (typeof DATABASE_PROVIDERS)[number];
 
 export function isDatabaseProvider(provider: string): provider is DatabaseProvider {

--- a/sdk/iam/src/auth.ts
+++ b/sdk/iam/src/auth.ts
@@ -39,10 +39,10 @@ async function createDrizzleAdapter(db: Database) {
 			const handle = drizzle(client, { schema: betterAuthSchema });
 			return drizzleAdapter(handle, { provider: db.provider, schema: betterAuthSchema });
 		}
-		case "mysql":
-			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		// case "mysql":
+		// 	throw new Error("MySQL support not yet implemented");
+		// case "sqlite":
+		// 	throw new Error("SQLite support not yet implemented");
 		default:
 			return db.provider satisfies never;
 	}

--- a/sdk/iam/src/index.ts
+++ b/sdk/iam/src/index.ts
@@ -1,4 +1,7 @@
-export type { DatabaseConfig, MysqlDatabaseConfig, PgDatabaseConfig, SqliteDatabaseConfig } from "@aikirun/lib/db";
+export type {
+	DatabaseConfig /*, MysqlDatabaseConfig*/,
+	PgDatabaseConfig /*, SqliteDatabaseConfig*/,
+} from "@aikirun/lib/db";
 
 export type {
 	ApiAuthorizerKeyParams,

--- a/sdk/iam/src/infra/db/repo.ts
+++ b/sdk/iam/src/infra/db/repo.ts
@@ -19,10 +19,10 @@ export async function createRepos(db: Database): Promise<Repositories> {
 			const client = extractDbClient(db) as PgClient;
 			return createPgRepos(client);
 		}
-		case "mysql":
-			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		// case "mysql":
+		// 	throw new Error("MySQL support not yet implemented");
+		// case "sqlite":
+		// 	throw new Error("SQLite support not yet implemented");
 		default:
 			return db.provider satisfies never;
 	}

--- a/sdk/server/src/index.ts
+++ b/sdk/server/src/index.ts
@@ -1,6 +1,9 @@
 export type { ConfigProvider, ConfigProviderContext, CreateConfigProvider } from "@aikirun/lib/config";
 export { asConfigProvider } from "@aikirun/lib/config";
-export type { DatabaseConfig, MysqlDatabaseConfig, PgDatabaseConfig, SqliteDatabaseConfig } from "@aikirun/lib/db";
+export type {
+	DatabaseConfig /*, MysqlDatabaseConfig*/,
+	PgDatabaseConfig /*, SqliteDatabaseConfig*/,
+} from "@aikirun/lib/db";
 export type { Logger } from "@aikirun/lib/logger";
 
 export type { ServerRuntimeConfig, ServerRuntimeConfigOverrides } from "./config";

--- a/sdk/server/src/infra/db/index.ts
+++ b/sdk/server/src/infra/db/index.ts
@@ -1,12 +1,8 @@
-import type { DatabaseConfig, PgDatabaseConfig } from "@aikirun/lib/db";
+import type { DatabaseConfig } from "@aikirun/lib/db";
 import type { CreateDatabase, Database } from "@aikirun/types/infra/db";
 import { INTERNAL } from "@aikirun/types/symbols";
 
 export function database(config: DatabaseConfig): CreateDatabase {
-	if (config.provider !== "pg") {
-		throw new Error(`${config.provider} support not yet implemented`);
-	}
-
 	let createDatabasePromise: Promise<Database> | undefined;
 	return () => {
 		if (!createDatabasePromise) {
@@ -16,13 +12,23 @@ export function database(config: DatabaseConfig): CreateDatabase {
 	};
 }
 
-async function createDatabase(config: PgDatabaseConfig): Promise<Database> {
-	const postgres = await importPostgres();
-	const client = postgres(config.url, {
-		max: config.maxConnections,
-		ssl: config.caCert ? { ca: config.caCert, rejectUnauthorized: true } : undefined,
-	});
-	return { provider: "pg", [INTERNAL]: { client } };
+async function createDatabase(config: DatabaseConfig): Promise<Database> {
+	switch (config.provider) {
+		case "pg": {
+			const postgres = await importPostgres();
+			const client = postgres(config.url, {
+				max: config.maxConnections,
+				ssl: config.caCert ? { ca: config.caCert, rejectUnauthorized: true } : undefined,
+			});
+			return { provider: "pg", [INTERNAL]: { client } };
+		}
+		// case "sqlite":
+		// 	throw new Error("SQLite support not yet implemented");
+		// case "mysql":
+		// 	throw new Error("MySQL support not yet implemented");
+		default:
+			return config.provider satisfies never;
+	}
 }
 
 async function importPostgres() {

--- a/sdk/server/src/infra/db/repo.ts
+++ b/sdk/server/src/infra/db/repo.ts
@@ -19,10 +19,10 @@ export async function createRepos(db: Database): Promise<Repositories> {
 			const client = extractDbClient(db) as PgClient;
 			return createPgRepos(client);
 		}
-		case "mysql":
-			throw new Error("MySQL support not yet implemented");
-		case "sqlite":
-			throw new Error("SQLite support not yet implemented");
+		// case "mysql":
+		// 	throw new Error("MySQL support not yet implemented");
+		// case "sqlite":
+		// 	throw new Error("SQLite support not yet implemented");
 		default:
 			return db.provider satisfies never;
 	}


### PR DESCRIPTION
SQLite and MySQL are not supported at the moment but the db conn factory allowed for specifying as the providers and threw at runtime. Now the factory will reject those providers at compile time.

The is a breaking change as the previusly exported SQLite and MySQL config types are no longer exported. Nevertheless, it is for good. They will be restored when those providers are supported.