### PR TITLE
Pending-only outbox claim path

### DIFF
--- a/.agents/skills/DB.md
+++ b/.agents/skills/DB.md
@@ -6,6 +6,7 @@
 - Schema sources:
     - `sdk/server/src/infra/db/pg/schema.ts`
     - `sdk/iam/src/infra/db/pg/schema.ts`
+- Repository get-by-key methods return `T | null`, never `T | undefined` — coalesce drizzle's row access (`rows[0] ?? null`).
 
 Generate migrations:
 

--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -25,6 +25,10 @@ Before writing any test, study the exemplars for its tier and match their idioms
   - **`withFakeClock(seedTimestampMs, fn)`** (`sdk/server/src/testing/clock.ts`): freezes the JS
     clock so aged state is minted through the real code paths. Callers wrap seeds; seed helpers
     stay clock-neutral. Integration-only (test files run sequentially in one process).
+- Use these tools only where the test's semantics need them. The fake clock earns its place
+  where state must look stale or aged (a recovery threshold, an age cap keyed on a row id's
+  mint time), not where mere status suffices. Derive each piece of harness machinery from what
+  the test asserts; don't inherit it from the neighboring test.
 - Waits ride event-signaled promises (see `lib/src/async/latch.ts`), never polling loops or
   sized sleeps. The one legitimate fixed wait is an absence check: wait a window, assert nothing
   changed.
@@ -42,8 +46,8 @@ Before writing any test, study the exemplars for its tier and match their idioms
   assertion reads only.
 - The daemon harness (`createDaemonHarness` in `sdk/server/src/testing/`) provisions what needs
   lifecycle and reset: the database connection, a scriptable fake publisher (verified on
-  teardown), and a daemon context. Compose services file-locally in the test; take pure filler
-  data (request contexts, rows) from the factories in `sdk/server/src/testing/`.
+  teardown), and a daemon context. Take pure filler data (request contexts, rows) from the
+  factories in `sdk/server/src/testing/`.
 
 ## Assertions
 

--- a/.agents/skills/TYPESCRIPT.md
+++ b/.agents/skills/TYPESCRIPT.md
@@ -53,6 +53,8 @@ No AI-style explanatory comments. Don't document the framework default. Don't pa
 
 Comments describe the current design in present tense — the constraint the code can't show. Never chronicle bugs fixed, reference prior approaches ("no longer", "instead of the old X"), or contrast with alternatives that were never shipped.
 
+Write for the package's audience. A comment's vocabulary must not exceed what a reader of that package can see: `types/` is read by SDK consumers, so its doc comments describe the contract as visible from the package boundary (workers, claims, refreshes), never internals of another package (server daemons, outbox rows, database statuses). Put mechanism detail in a comment in the package that implements the mechanism.
+
 ## 6. Security
 
 - Input Sanitization: Assume all external inputs (user-provided, API requests) are untrusted. Sanitize/validate thoroughly.

--- a/app/dashboard/src/components/runs/StatusChips.tsx
+++ b/app/dashboard/src/components/runs/StatusChips.tsx
@@ -1,21 +1,7 @@
-import type { WorkflowRunStatus } from "@aikirun/types/workflow/run";
+import { WORKFLOW_RUN_STATUSES, type WorkflowRunStatus } from "@aikirun/types/workflow/run";
 
 import { WORKFLOW_RUN_STATUS_COLORS } from "../../constants/status-colors";
 import { WORKFLOW_STATUS_CONFIG } from "../../constants/workflow-status";
-
-const ALL_STATUSES: WorkflowRunStatus[] = [
-	"scheduled",
-	"queued",
-	"running",
-	"paused",
-	"sleeping",
-	"awaiting_event",
-	"awaiting_retry",
-	"awaiting_child_workflow",
-	"cancelled",
-	"completed",
-	"failed",
-];
 
 interface StatusChipsProps {
 	selected: WorkflowRunStatus[];
@@ -35,7 +21,7 @@ export function StatusChips({ selected, onChange }: StatusChipsProps) {
 
 	return (
 		<div style={{ display: "flex", flexWrap: "wrap", gap: 4, alignItems: "center" }}>
-			{ALL_STATUSES.map((status) => {
+			{WORKFLOW_RUN_STATUSES.map((status) => {
 				const config = WORKFLOW_STATUS_CONFIG[status];
 				const color = WORKFLOW_RUN_STATUS_COLORS[status].tint;
 				const isActive = selected.includes(status);

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -343,7 +343,6 @@ const claimReadyV1: ContractProcedure<WorkflowRunClaimReadyRequestV1, WorkflowRu
 				.atLeastLength(1),
 			"shards?": type("string > 0").array().or("undefined"),
 			limit: "number.integer > 0",
-			"previousClaimMinIdleTimeMs?": "number.integer > 0",
 		})
 	)
 	.output(

--- a/sdk/server/src/daemons/recover-stale-outbox-entries.integration.test.ts
+++ b/sdk/server/src/daemons/recover-stale-outbox-entries.integration.test.ts
@@ -1,17 +1,11 @@
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 
-import { processImminentScheduledRuns } from "./imminent-scheduled-runs";
-import { publishReadyRuns } from "./publish-ready-runs";
 import { recoverStaleOutboxEntries } from "./recover-stale-outbox-entries";
 import { stallUndeliverableRuns } from "./stall-undeliverable-runs";
 import { describe, expect, test } from "bun:test";
-import type { Repositories } from "../infra/db/types";
-import { createChildRunCanceller } from "../service/cancel-child-runs";
-import { createWorkflowRunService } from "../service/workflow-run";
-import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
 import { withFakeClock } from "../testing/clock";
-import { createDaemonHarness, type DaemonHarnessDeps } from "../testing/daemon-harness";
-import { namespaceRequestContextFactory } from "../testing/middleware/context";
+import { createDaemonHarness } from "../testing/daemon-harness";
+import { claimRun, namespaceContext, seedClaimedRun, seedPublishedRun, seedQueuedRun } from "../testing/outbox-seed";
 
 const withHarness = createDaemonHarness();
 
@@ -22,8 +16,6 @@ const EVERY_CLAIM_IS_STALE_MS = -1;
 const NO_CLAIM_GOES_STALE_MS = 1 * 60 * 60 * 1000;
 
 const EPOCH_MS = 1 as TimestampMs;
-
-const namespaceContext = namespaceRequestContextFactory.build();
 
 describe("recoverStaleOutboxEntries", () => {
 	describe("stale claimed rows", () => {
@@ -135,15 +127,15 @@ describe("recoverStaleOutboxEntries", () => {
 			}));
 	});
 
-	describe("stale published rows", () => {
-		test("returns a stale published row to pending with firstPublishedAt preserved", () =>
+	describe("publishable rows", () => {
+		test("returns a publishable row to pending with firstPublishedAt preserved", () =>
 			withHarness(async (deps) => {
 				const { context, repos } = deps;
 				const { runId, outboxRowId } = await withFakeClock(EPOCH_MS, () => seedPublishedRun(deps));
 
-				const publishedRows = await repos.workflowRunOutbox.listStalePublished(context, 100);
-				expect(publishedRows).toHaveLength(1);
-				const firstPublishedAt = publishedRows[0]?.firstPublishedAt;
+				const publishableRows = await repos.workflowRunOutbox.listPublishable(context, 100);
+				expect(publishableRows).toHaveLength(1);
+				const firstPublishedAt = publishableRows[0]?.firstPublishedAt;
 				expect(firstPublishedAt).toBeGreaterThan(0);
 
 				await recoverStaleOutboxEntries(
@@ -195,7 +187,7 @@ describe("recoverStaleOutboxEntries", () => {
 						status: "stalled",
 					})
 				);
-				expect(await repos.workflowRunOutbox.listStalePublished(context, 100)).toHaveLength(0);
+				expect(await repos.workflowRunOutbox.listPublishable(context, 100)).toHaveLength(0);
 			}));
 
 		test("does not stall a claimed row regardless of age", () =>
@@ -218,82 +210,3 @@ describe("recoverStaleOutboxEntries", () => {
 			}));
 	});
 });
-
-function createServices(repos: Repositories) {
-	const childRunCanceller = createChildRunCanceller();
-	const workflowRunStateMachine = createWorkflowRunStateMachineService({ repos, childRunCanceller });
-	const workflowRun = createWorkflowRunService({
-		repos,
-		childRunCanceller,
-		workflowRunStateMachineService: workflowRunStateMachine,
-	});
-	return { workflowRun, workflowRunStateMachine };
-}
-
-async function seedQueuedRun({ context, repos }: DaemonHarnessDeps) {
-	const services = createServices(repos);
-
-	const runId = await services.workflowRun.createWorkflowRun(namespaceContext, {
-		name: "ship-orders",
-		versionId: "v2",
-		input: { orderId: "order-7" },
-	});
-
-	await processImminentScheduledRuns(
-		context,
-		{ repos },
-		{ limit: 100, imminenceThresholdMs: 0, republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000 } }
-	);
-
-	const outboxRows = await repos.workflowRunOutbox.listPending(context, 100);
-	expect(outboxRows).toHaveLength(1);
-	// biome-ignore lint/style/noNonNullAssertion: the length has already been asserted
-	const outboxRow = outboxRows[0]!;
-
-	return { runId, outboxRowId: outboxRow.id };
-}
-
-async function claimRun(repos: Repositories, runId: string) {
-	const services = createServices(repos);
-
-	const run = await repos.workflowRun.getByIdWithState(namespaceContext.namespaceId, runId);
-	if (!run) {
-		throw new Error(`Run not found: ${runId}`);
-	}
-
-	const claim = await services.workflowRunStateMachine.transitionState(namespaceContext, {
-		type: "optimistic",
-		id: runId,
-		state: { status: "running" },
-		expectedRevision: run.revision,
-	});
-
-	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };
-}
-
-async function seedClaimedRun(deps: DaemonHarnessDeps) {
-	const { context, repos, publisher } = deps;
-	const { runId, outboxRowId } = await seedQueuedRun(deps);
-
-	await publishReadyRuns(
-		context,
-		{ repos, workflowRunPublisher: publisher },
-		{ limit: 100, republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000 } }
-	);
-
-	const claim = await claimRun(repos, runId);
-	return { runId, outboxRowId, ...claim };
-}
-
-async function seedPublishedRun(deps: DaemonHarnessDeps) {
-	const { context, repos, publisher } = deps;
-	const seeded = await seedQueuedRun(deps);
-
-	await publishReadyRuns(
-		context,
-		{ repos, workflowRunPublisher: publisher },
-		{ limit: 100, republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000 } }
-	);
-
-	return seeded;
-}

--- a/sdk/server/src/daemons/recover-stale-outbox-entries.ts
+++ b/sdk/server/src/daemons/recover-stale-outbox-entries.ts
@@ -77,25 +77,25 @@ export async function recoverStaleOutboxEntries(
 				}
 			}
 
-			await txRepos.workflowRunOutbox.returnToPending(entryIds);
+			await txRepos.workflowRunOutbox.returnToPending(entryIds, "claimed");
 		});
 
 		context.logger.debug("Recovered stale claimed outbox entries", { "aiki.count": staleEntries.length });
 	}
 
-	for await (const staleEntries of streamChunks(
-		(cursor) => repos.workflowRunOutbox.listStalePublished(context, limit, cursor),
+	for await (const publishableEntries of streamChunks(
+		(cursor) => repos.workflowRunOutbox.listPublishable(context, limit, cursor),
 		{
 			advanceCursor: advancePublishedCursor,
 			until: (chunk) => chunk.length < limit,
 		}
 	)) {
-		const entryIds = staleEntries.map((entry) => entry.id);
+		const entryIds = publishableEntries.map((entry) => entry.id);
 		if (!isNonEmptyArray(entryIds)) {
 			continue;
 		}
 
-		await repos.workflowRunOutbox.returnToPending(entryIds);
-		context.logger.debug("Recovered stale published outbox entries", { "aiki.count": staleEntries.length });
+		await repos.workflowRunOutbox.returnToPending(entryIds, "published");
+		context.logger.debug("Recovered publishable outbox entries", { "aiki.count": publishableEntries.length });
 	}
 }

--- a/sdk/server/src/infra/db/pg/migration/0011_optimal_roughhouse.sql
+++ b/sdk/server/src/infra/db/pg/migration/0011_optimal_roughhouse.sql
@@ -1,0 +1,2 @@
+DROP INDEX "idx_workflow_run_outbox_claim_published";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_outbox_steal_claim";

--- a/sdk/server/src/infra/db/pg/migration/meta/0011_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0011_snapshot.json
@@ -1,0 +1,1763 @@
+{
+	"id": "0173f204-29e1-4a35-89df-2a88db649ee1",
+	"prevId": "112b6048-a667-4fd3-96a6-e8e67d7902b5",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awake_at": {
+					"name": "awake_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_awake_at_id": {
+					"name": "idx_workflow_run_status_awake_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "awake_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_at": {
+					"name": "next_publish_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR (\"workflow_run_outbox\".\"first_published_at\" IS NOT NULL AND \"workflow_run_outbox\".\"next_publish_attempt_at\" IS NOT NULL)"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -78,6 +78,13 @@
 			"when": 1785023789368,
 			"tag": "0010_wise_young_avengers",
 			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1785311136498,
+			"tag": "0011_optimal_roughhouse",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
@@ -27,22 +27,6 @@ interface ClaimFilter {
 	shards?: string[];
 }
 
-function buildClaimFilterPredicate(filters: ClaimFilter) {
-	const workflowsPredicate = or(
-		...filters.workflows.map((workflow) =>
-			and(
-				eq(workflowRunOutbox.workflowName, workflow.name),
-				eq(workflowRunOutbox.workflowVersionId, workflow.versionId)
-			)
-		)
-	);
-	const shardsPredicate = isNonEmptyArray(filters.shards)
-		? inArray(workflowRunOutbox.shard, filters.shards)
-		: isNull(workflowRunOutbox.shard);
-
-	return and(workflowsPredicate, shardsPredicate);
-}
-
 export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 	async createBatch(rows: NonEmptyArray<WorkflowRunOutboxRowInsert>): Promise<void> {
 		await db.insert(workflowRunOutbox).values(rows);
@@ -94,13 +78,12 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 			.where(and(eq(workflowRunOutbox.status, "pending"), sql`${workflowRunOutbox.id} = v.id`));
 	},
 
-	// Returns rows in claimed or published status back to pending.
 	// firstPublishedAt and lastPublishedAt are not cleared so that backoff anchors survive recovery churn.
-	async returnToPending(ids: NonEmptyArray<string>): Promise<void> {
+	async returnToPending(ids: NonEmptyArray<string>, fromStatus: "claimed" | "published"): Promise<void> {
 		await db
 			.update(workflowRunOutbox)
 			.set({ status: "pending", claimedAt: null, nextPublishAttemptAt: null })
-			.where(and(inArray(workflowRunOutbox.status, ["claimed", "published"]), inArray(workflowRunOutbox.id, ids)));
+			.where(and(inArray(workflowRunOutbox.id, ids), eq(workflowRunOutbox.status, fromStatus)));
 	},
 
 	async markClaimed(namespaceId: string, workflowRunId: WorkflowRunId): Promise<void> {
@@ -110,7 +93,7 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 			.where(and(eq(workflowRunOutbox.namespaceId, namespaceId), eq(workflowRunOutbox.workflowRunId, workflowRunId)));
 	},
 
-	async reclaim(namespaceId: string, workflowRunId: WorkflowRunId): Promise<void> {
+	async refreshClaim(namespaceId: string, workflowRunId: WorkflowRunId): Promise<void> {
 		await db
 			.update(workflowRunOutbox)
 			.set({ claimedAt: Date.now() as TimestampMs })
@@ -123,7 +106,7 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 			);
 	},
 
-	async listStalePublished(
+	async listPublishable(
 		_context: DaemonContext,
 		limit: number,
 		cursor?: KeysetStreamCursor
@@ -188,97 +171,50 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 			.limit(limit);
 	},
 
+	async getByWorkflowRunId(namespaceId: string, workflowRunId: string): Promise<WorkflowRunOutboxRow | null> {
+		const result = await db
+			.select()
+			.from(workflowRunOutbox)
+			.where(and(eq(workflowRunOutbox.namespaceId, namespaceId), eq(workflowRunOutbox.workflowRunId, workflowRunId)))
+			.limit(1);
+
+		return result[0] ?? null;
+	},
+
 	async deleteByWorkflowRunId(namespaceId: string, workflowRunId: string): Promise<void> {
 		await db
 			.delete(workflowRunOutbox)
 			.where(and(eq(workflowRunOutbox.namespaceId, namespaceId), eq(workflowRunOutbox.workflowRunId, workflowRunId)));
 	},
 
-	async stealStaleClaimed(namespaceId: string, filters: ClaimFilter, claimMinIdleTimeMs: number, limit: number) {
-		const now = Date.now();
-		const staleThreshold = (now - claimMinIdleTimeMs) as TimestampMs;
-
-		const staleEntries = await db
-			.select({ id: workflowRunOutbox.id })
-			.from(workflowRunOutbox)
-			.where(
-				and(
-					eq(workflowRunOutbox.namespaceId, namespaceId),
-					eq(workflowRunOutbox.status, "claimed"),
-					buildClaimFilterPredicate(filters),
-					lt(workflowRunOutbox.claimedAt, staleThreshold)
-				)
-			)
-			.orderBy(workflowRunOutbox.claimedAt, workflowRunOutbox.rank, workflowRunOutbox.id)
-			.limit(limit);
-
-		const staleEntryIds = staleEntries.map(({ id }) => id);
-		if (!isNonEmptyArray(staleEntryIds)) {
-			return [];
-		}
-
-		return db
-			.update(workflowRunOutbox)
-			.set({ claimedAt: now as TimestampMs })
-			.where(
-				and(
-					eq(workflowRunOutbox.status, "claimed"),
-					inArray(workflowRunOutbox.id, staleEntryIds),
-					lt(workflowRunOutbox.claimedAt, staleThreshold)
-				)
-			)
-			.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
-	},
-
-	async claimPublished(namespaceId: string, filters: ClaimFilter, limit: number) {
-		const entries = await db
-			.select({ id: workflowRunOutbox.id })
-			.from(workflowRunOutbox)
-			.where(
-				and(
-					eq(workflowRunOutbox.namespaceId, namespaceId),
-					eq(workflowRunOutbox.status, "published"),
-					buildClaimFilterPredicate(filters)
-				)
-			)
-			.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
-			.limit(limit);
-
-		const entryIds = entries.map(({ id }) => id);
-		if (!isNonEmptyArray(entryIds)) {
-			return [];
-		}
-
-		return db
-			.update(workflowRunOutbox)
-			.set({ status: "claimed", claimedAt: Date.now() as TimestampMs })
-			.where(and(eq(workflowRunOutbox.status, "published"), inArray(workflowRunOutbox.id, entryIds)))
-			.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
-	},
-
 	async claimPending(namespaceId: string, filters: ClaimFilter, limit: number) {
-		const pendingEntries = await db
+		const claimableEntryIds = db
 			.select({ id: workflowRunOutbox.id })
 			.from(workflowRunOutbox)
 			.where(
 				and(
 					eq(workflowRunOutbox.namespaceId, namespaceId),
 					eq(workflowRunOutbox.status, "pending"),
-					buildClaimFilterPredicate(filters)
+					or(
+						...filters.workflows.map((workflow) =>
+							and(
+								eq(workflowRunOutbox.workflowName, workflow.name),
+								eq(workflowRunOutbox.workflowVersionId, workflow.versionId)
+							)
+						)
+					),
+					isNonEmptyArray(filters.shards)
+						? inArray(workflowRunOutbox.shard, filters.shards)
+						: isNull(workflowRunOutbox.shard)
 				)
 			)
 			.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)
 			.limit(limit);
 
-		const pendingEntryIds = pendingEntries.map(({ id }) => id);
-		if (!isNonEmptyArray(pendingEntryIds)) {
-			return [];
-		}
-
 		return db
 			.update(workflowRunOutbox)
 			.set({ status: "claimed", claimedAt: Date.now() as TimestampMs })
-			.where(and(eq(workflowRunOutbox.status, "pending"), inArray(workflowRunOutbox.id, pendingEntryIds)))
+			.where(and(eq(workflowRunOutbox.status, "pending"), inArray(workflowRunOutbox.id, claimableEntryIds)))
 			.returning({ workflowRunId: workflowRunOutbox.workflowRunId });
 	},
 });

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -396,26 +396,10 @@ export const workflowRunOutbox = pgTable(
 	(table) => [
 		uniqueIndex("uqidx_workflow_run_outbox_workflow_run_id").on(table.workflowRunId),
 
-		// Claim paths: worker pulls pending or published rows filtered by workflow identity and shard.
+		// Claim path: worker claims rank ordered pending rows by workflow identity and shard.
 		index("idx_workflow_run_outbox_claim_pending")
 			.on(table.namespaceId, table.workflowName, table.workflowVersionId, table.shard, table.rank, table.id)
 			.where(sql`${table.status} = 'pending'`),
-		index("idx_workflow_run_outbox_claim_published")
-			.on(table.namespaceId, table.workflowName, table.workflowVersionId, table.shard, table.rank, table.id)
-			.where(sql`${table.status} = 'published'`),
-
-		// Steal stale-claim path: identifies claimed rows whose last refresh is older than a threshold.
-		index("idx_workflow_run_outbox_steal_claim")
-			.on(
-				table.namespaceId,
-				table.workflowName,
-				table.workflowVersionId,
-				table.shard,
-				table.claimedAt,
-				table.rank,
-				table.id
-			)
-			.where(sql`${table.status} = 'claimed'`),
 
 		// Daemon list paths: broad scans over one status to feed broker.
 		index("idx_workflow_run_outbox_list_pending").on(table.rank, table.id).where(sql`${table.status} = 'pending'`),

--- a/sdk/server/src/router/workflow-run.ts
+++ b/sdk/server/src/router/workflow-run.ts
@@ -107,7 +107,7 @@ export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps) {
 		}),
 
 		claimRefreshV1: os.claimRefreshV1.handler(async ({ input: request, context }) => {
-			await workflowRunOutboxService.reclaim(context, request.id as WorkflowRunId);
+			await workflowRunOutboxService.refreshClaim(context, request.id as WorkflowRunId);
 		}),
 
 		hasTerminatedV1: os.hasTerminatedV1.handler(async ({ input: request, context }) => {

--- a/sdk/server/src/service/workflow-run-outbox.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-outbox.integration.test.ts
@@ -1,0 +1,176 @@
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+
+import { describe, expect, test } from "bun:test";
+import { recoverStaleOutboxEntries } from "../daemons/recover-stale-outbox-entries";
+import { createWorkflowRunOutboxService } from "../service/workflow-run-outbox";
+import { withFakeClock } from "../testing/clock";
+import { createDaemonHarness } from "../testing/daemon-harness";
+import {
+	claimRun,
+	namespaceContext,
+	seedClaimedRun,
+	seedPublishedRun,
+	seedQueuedRun,
+	seedShardedQueuedRun,
+} from "../testing/outbox-seed";
+
+const withHarness = createDaemonHarness();
+
+// -1 makes every claimed row stale by arithmetic (claimedAt < now + 1 always holds), so tests
+// never depend on real time elapsing between the claim and the daemon run.
+const EVERY_CLAIM_IS_STALE_MS = -1;
+
+const EPOCH_MS = 1 as TimestampMs;
+
+describe("WorkflowRunOutboxService.claimReady", () => {
+	test("returns a pending row for the requested workflow and transitions its outbox row to claimed", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const { runId, workflowName, workflowVersionId } = await seedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 10,
+			});
+
+			expect(result).toEqual([expect.objectContaining({ id: runId })]);
+
+			const pendingRows = await repos.workflowRunOutbox.listPending(context, 100);
+			expect(pendingRows).toHaveLength(0);
+
+			const claimedRows = await repos.workflowRunOutbox.listStaleClaimed(context, EVERY_CLAIM_IS_STALE_MS, 100);
+			expect(claimedRows).toEqual([expect.objectContaining({ workflowRunId: runId, status: "claimed" })]);
+			expect(claimedRows[0]?.claimedAt).toBeGreaterThan(0);
+		}));
+
+	test("does not return a pending row for a workflow not in the request workflows list", () =>
+		withHarness(async (deps) => {
+			await seedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: "unknown-workflow", versionId: "v1" }],
+				limit: 10,
+			});
+
+			expect(result).toHaveLength(0);
+		}));
+
+	test("does not return a pending row outside the requested shards", () =>
+		withHarness(async (deps) => {
+			// The seeded run has no shard; requesting a specific shard excludes it.
+			const { workflowName, workflowVersionId } = await seedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				shards: ["eu-east"],
+				limit: 10,
+			});
+
+			expect(result).toHaveLength(0);
+		}));
+
+	test("claims a pending row in the requested shard", () =>
+		withHarness(async (deps) => {
+			const { runId, workflowName, workflowVersionId, shard } = await seedShardedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				shards: [shard],
+				limit: 10,
+			});
+
+			expect(result).toEqual([expect.objectContaining({ id: runId })]);
+		}));
+
+	test("does not return a sharded row when the request has no shards", () =>
+		withHarness(async (deps) => {
+			const { workflowName, workflowVersionId } = await seedShardedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 10,
+			});
+
+			expect(result).toHaveLength(0);
+		}));
+
+	test("respects the limit and does not return more rows than requested", () =>
+		withHarness(async (deps) => {
+			const { workflowName, workflowVersionId } = await seedQueuedRun(deps);
+			await seedQueuedRun(deps);
+			await seedQueuedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 2,
+			});
+
+			expect(result).toHaveLength(2);
+		}));
+
+	test("does not return a claimed row", () =>
+		withHarness(async (deps) => {
+			const { runId, workflowName, workflowVersionId } = await seedQueuedRun(deps);
+			await claimRun(deps.repos, runId);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 10,
+			});
+
+			expect(result).toHaveLength(0);
+		}));
+
+	test("does not return a published row", () =>
+		withHarness(async (deps) => {
+			const { workflowName, workflowVersionId } = await seedPublishedRun(deps);
+
+			const outboxService = createWorkflowRunOutboxService({ repos: deps.repos });
+			const result = await outboxService.claimReady(namespaceContext, {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 10,
+			});
+
+			expect(result).toHaveLength(0);
+		}));
+});
+
+describe("claimReady visibility after recovery", () => {
+	test("a stale claimed row and a publishable row are invisible to claimReady until recovery returns them to pending", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+
+			const { runId: claimedRunId, workflowName, workflowVersionId } = await seedClaimedRun(deps);
+			const { runId: publishedRunId } = await withFakeClock(EPOCH_MS, () => seedPublishedRun(deps));
+
+			const outboxService = createWorkflowRunOutboxService({ repos });
+			const claimRequest = {
+				workflows: [{ name: workflowName, versionId: workflowVersionId }],
+				limit: 10,
+			};
+
+			// Both rows are in non-pending statuses; claimReady sees nothing.
+			const beforeRecovery = await outboxService.claimReady(namespaceContext, claimRequest);
+			expect(beforeRecovery).toHaveLength(0);
+
+			// Recovery returns the stale claimed row and the publishable row to pending.
+			await recoverStaleOutboxEntries(context, { repos }, { claimMinIdleTimeMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 });
+
+			// Both runs are now visible to claimReady.
+			const afterRecovery = await outboxService.claimReady(namespaceContext, claimRequest);
+			expect(afterRecovery).toHaveLength(2);
+			expect(afterRecovery).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ id: claimedRunId }),
+					expect.objectContaining({ id: publishedRunId }),
+				])
+			);
+		}));
+});

--- a/sdk/server/src/service/workflow-run-outbox.ts
+++ b/sdk/server/src/service/workflow-run-outbox.ts
@@ -1,6 +1,6 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { WorkflowRunClaimReadyRequestV1 } from "@aikirun/types/api/workflow-run";
-import { DEFAULT_CLAIM_MIN_IDLE_TIME_MS, type WorkflowRunId } from "@aikirun/types/workflow/run";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
@@ -11,83 +11,23 @@ export interface WorkflowRunOutboxServiceDeps {
 
 export const createWorkflowRunOutboxService = ({ repos }: WorkflowRunOutboxServiceDeps) => ({
 	async claimReady(context: NamespaceRequestContext, request: WorkflowRunClaimReadyRequestV1) {
-		const workflowRunOutboxRepo = repos.workflowRunOutbox;
-
-		const stolenEntries = await stealStaleClaimed(context, workflowRunOutboxRepo, request);
-		let remainingSlots = request.limit - stolenEntries.length;
-
-		const publishedEntries =
-			remainingSlots > 0 ? await claimPublished(context, workflowRunOutboxRepo, request, remainingSlots) : [];
-		remainingSlots -= publishedEntries.length;
-
-		const pendingEntries =
-			remainingSlots > 0
-				? await claimPending(context, workflowRunOutboxRepo, {
-						workflows: request.workflows,
-						shards: request.shards,
-						limit: remainingSlots,
-					})
-				: [];
-
-		const runs: Array<{ id: string }> = [];
-		for (const entry of stolenEntries) {
-			runs.push({ id: entry.workflowRunId });
-		}
-		for (const entry of publishedEntries) {
-			runs.push({ id: entry.workflowRunId });
-		}
-		for (const entry of pendingEntries) {
-			runs.push({ id: entry.workflowRunId });
-		}
-
-		return runs;
+		const claimedEntries = await claimPending(context, repos.workflowRunOutbox, request);
+		return claimedEntries.map((entry) => ({ id: entry.workflowRunId }));
 	},
 
-	async reclaim(context: NamespaceRequestContext, workflowRunId: WorkflowRunId) {
-		return repos.workflowRunOutbox.reclaim(context.namespaceId, workflowRunId);
+	async refreshClaim(context: NamespaceRequestContext, workflowRunId: WorkflowRunId) {
+		return repos.workflowRunOutbox.refreshClaim(context.namespaceId, workflowRunId);
 	},
 });
 
 export type WorkflowRunOutboxService = ReturnType<typeof createWorkflowRunOutboxService>;
 
-async function stealStaleClaimed(
+async function claimPending(
 	context: NamespaceRequestContext,
 	repo: Repositories["workflowRunOutbox"],
 	request: WorkflowRunClaimReadyRequestV1
 ) {
-	const workflows = request.workflows;
-	if (!isNonEmptyArray(workflows)) {
-		return [];
-	}
-
-	return repo.stealStaleClaimed(
-		context.namespaceId,
-		{ workflows, shards: request.shards },
-		request.previousClaimMinIdleTimeMs ?? DEFAULT_CLAIM_MIN_IDLE_TIME_MS,
-		request.limit
-	);
-}
-
-async function claimPublished(
-	context: NamespaceRequestContext,
-	repo: Repositories["workflowRunOutbox"],
-	request: Pick<WorkflowRunClaimReadyRequestV1, "workflows" | "shards">,
-	limit: number
-) {
-	const workflows = request.workflows;
-	if (!isNonEmptyArray(workflows)) {
-		return [];
-	}
-
-	return repo.claimPublished(context.namespaceId, { workflows, shards: request.shards }, limit);
-}
-
-async function claimPending(
-	context: NamespaceRequestContext,
-	repo: Repositories["workflowRunOutbox"],
-	request: Pick<WorkflowRunClaimReadyRequestV1, "workflows" | "shards" | "limit">
-) {
-	const workflows = request.workflows;
+	const { workflows } = request;
 	if (!isNonEmptyArray(workflows)) {
 		return [];
 	}

--- a/sdk/server/src/testing/outbox-seed.ts
+++ b/sdk/server/src/testing/outbox-seed.ts
@@ -1,0 +1,97 @@
+import type { DaemonHarnessDeps } from "./daemon-harness";
+import { namespaceRequestContextFactory } from "./middleware/context";
+import { processImminentScheduledRuns } from "../daemons/imminent-scheduled-runs";
+import { publishReadyRuns } from "../daemons/publish-ready-runs";
+import type { Repositories } from "../infra/db/types";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createWorkflowRunService } from "../service/workflow-run";
+import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
+
+export const namespaceContext = namespaceRequestContextFactory.build();
+
+const seededWorkflow = { name: "ship-orders", versionId: "v2" };
+
+const republishBackoff = { baseDelayMs: 5_000, maxDelayMs: 300_000 };
+
+function createServices(repos: Repositories) {
+	const childRunCanceller = createChildRunCanceller();
+	const workflowRunStateMachine = createWorkflowRunStateMachineService({ repos, childRunCanceller });
+	const workflowRun = createWorkflowRunService({
+		repos,
+		childRunCanceller,
+		workflowRunStateMachineService: workflowRunStateMachine,
+	});
+	return { workflowRun, workflowRunStateMachine };
+}
+
+export async function seedQueuedRun(deps: DaemonHarnessDeps) {
+	return _seedQueuedRun(deps, undefined);
+}
+
+export async function seedShardedQueuedRun(deps: DaemonHarnessDeps) {
+	const shard = "warehouse-eu";
+	const seeded = await _seedQueuedRun(deps, shard);
+	return { ...seeded, shard };
+}
+
+async function _seedQueuedRun({ context, repos }: DaemonHarnessDeps, shard: string | undefined) {
+	const services = createServices(repos);
+
+	const runId = await services.workflowRun.createWorkflowRun(namespaceContext, {
+		name: seededWorkflow.name,
+		versionId: seededWorkflow.versionId,
+		input: { orderId: "order-7" },
+		options: shard ? { shard } : undefined,
+	});
+
+	await processImminentScheduledRuns(context, { repos }, { limit: 100, imminenceThresholdMs: 0, republishBackoff });
+
+	const outboxRow = await repos.workflowRunOutbox.getByWorkflowRunId(namespaceContext.namespaceId, runId);
+	if (!outboxRow) {
+		throw new Error(`Outbox row not found for run: ${runId}`);
+	}
+
+	return {
+		runId,
+		outboxRowId: outboxRow.id,
+		workflowName: seededWorkflow.name,
+		workflowVersionId: seededWorkflow.versionId,
+	};
+}
+
+export async function claimRun(repos: Repositories, runId: string) {
+	const services = createServices(repos);
+
+	const run = await repos.workflowRun.getByIdWithState(namespaceContext.namespaceId, runId);
+	if (!run) {
+		throw new Error(`Run not found: ${runId}`);
+	}
+
+	const claim = await services.workflowRunStateMachine.transitionState(namespaceContext, {
+		type: "optimistic",
+		id: runId,
+		state: { status: "running" },
+		expectedRevision: run.revision,
+	});
+
+	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };
+}
+
+export async function seedClaimedRun(deps: DaemonHarnessDeps) {
+	const { context, repos, publisher } = deps;
+	const seeded = await seedQueuedRun(deps);
+
+	await publishReadyRuns(context, { repos, workflowRunPublisher: publisher }, { limit: 100, republishBackoff });
+
+	const claim = await claimRun(repos, seeded.runId);
+	return { ...seeded, ...claim };
+}
+
+export async function seedPublishedRun(deps: DaemonHarnessDeps) {
+	const { context, repos, publisher } = deps;
+	const seeded = await seedQueuedRun(deps);
+
+	await publishReadyRuns(context, { repos, workflowRunPublisher: publisher }, { limit: 100, republishBackoff });
+
+	return seeded;
+}

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -296,11 +296,6 @@ export interface WorkflowRunClaimReadyRequestV1 {
 	workflows: Array<{ name: string; versionId: string }>;
 	shards?: string[];
 	limit: number;
-	/**
-	 * Steal actively executing runs whose last claim refresh was received more than
-	 * previousClaimMinIdleTimeMs milliseconds ago. Defaults to 90 seconds.
-	 */
-	previousClaimMinIdleTimeMs?: number;
 }
 
 export interface WorkflowRunClaimReadyResponseV1 {

--- a/types/src/workflow/run/claim.ts
+++ b/types/src/workflow/run/claim.ts
@@ -1,6 +1,6 @@
 /**
- * Default idle time before a claimed workflow run is considered abandoned and
- * eligible to be reclaimed by another worker.
+ * Default idle time after which the server considers a claimed workflow run
+ * abandoned and makes it claimable again by other workers.
  */
 export const DEFAULT_CLAIM_MIN_IDLE_TIME_MS = 90_000;
 
@@ -8,8 +8,7 @@ export const DEFAULT_CLAIM_MIN_IDLE_TIME_MS = 90_000;
  * Interval at which a worker refreshes its claim on a run it is executing.
  *
  * Derived from {@link DEFAULT_CLAIM_MIN_IDLE_TIME_MS} so the interval stays
- * comfortably below the reclaim threshold (a claim survives two missed
- * refreshes). Any reclaim threshold should remain greater than this interval,
- * otherwise an active claim claim could be stolen too early.
+ * comfortably below the abandonment threshold: an active claim survives a
+ * couple of missed refreshes.
  */
 export const CLAIM_REFRESH_INTERVAL_MS = DEFAULT_CLAIM_MIN_IDLE_TIME_MS / 3;


### PR DESCRIPTION
## Motivation

Every deliverable workflow run has one row in the outbox; the row's status — `pending`, `published`, `claimed` — tracks where delivery stands, and rows are offered in `rank` order (delivery priority). Poll-mode workers fetch work through the claim API (`claimReadyV1`), naming the workflows they serve and optionally the shards they are scoped to. Since #122, the recovery daemon walks in-flight rows on a fast cadence: a `claimed` row whose worker has gone silent past an idle threshold is returned to `pending` and its abandoned run is released back to `queued`; a `published` row whose next publish attempt has come due is returned to `pending` as well.

The claim API still does the pre-recovery three-phase scan: steal stale `claimed` rows, claim `published` rows, then claim `pending` rows, splitting one limit across the phases. With recovery daemon mounted unconditionally, the first two phases duplicate its job — on the hottest path of a poll deployment — and "claimable now" has three meanings instead of one.

## Solution

`pending` is now the single claimable state. Everything a consumer could take either is `pending` already or is returned to `pending` by the recovery daemon, so the claim API runs one scan of one status, and `previousClaimMinIdleTimeMs` leaves the contract. The cost is bounded: a run stuck in `published` or `claimed` is no longer rescued by the next poll; it waits for recovery's next pass (the daemon defaults to a one-second interval).

The remaining scan and its update are fused into one statement:

```sql
UPDATE workflow_run_outbox
SET status = 'claimed', claimed_at = $now
WHERE id IN (SELECT id FROM workflow_run_outbox
             WHERE namespace_id = … AND status = 'pending' AND <workflow/shard filter>
             ORDER BY rank, id LIMIT n)
  AND status = 'pending'
RETURNING workflow_run_id
```

Three renames land with this:

- `refreshClaim` (was `reclaim`): a worker refreshing its claim on a run it is executing, matching the `claimRefreshV1` procedure it backs.
- `listPublishable` (was `listStalePublished`): a `published` row past its `nextPublishAttemptAt` is due for another offer, not stale — only the claimed scan carries an idle-threshold staleness meaning.
- `returnToPending` now takes the status it returns rows from, so each recovery loop's update is guarded to its own kind of row.

## Breaking changes

- `WorkflowRunClaimReadyRequestV1` loses `previousClaimMinIdleTimeMs`.