### PR TITLE
Noun-form run reasons and a single wakeup lexeme

### DIFF
--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -20,7 +20,7 @@ Before writing any test, study the exemplars for its tier and match their idioms
   - **Boundary-value config**: choose knob values that decide the branch by arithmetic, not by
     timing — a `-1` idle threshold makes every claim stale; `Number.MAX_SAFE_INTEGER` makes none
     ever stale; `maxInlineWaitMs: 0` forces the suspend branch.
-  - **Timestamps as authored data**: write sentinel absolutes (`awakeAt: 0`, an epoch constant)
+  - **Timestamps as authored data**: write sentinel absolutes (`wakeupAt: 0`, an epoch constant)
     into rows; a value at the epoch is due/aged for any threshold.
   - **`withFakeClock(seedTimestampMs, fn)`** (`sdk/server/src/testing/clock.ts`): freezes the JS
     clock so aged state is minted through the real code paths. Clock placement follows

--- a/app/dashboard/src/components/run-detail/ExecutionTab.tsx
+++ b/app/dashboard/src/components/run-detail/ExecutionTab.tsx
@@ -513,7 +513,7 @@ function ChildWorkflowResolvedPre({ wait }: { wait: ChildWorkflowRunWaitComplete
 
 function SleepRow({ name, queue }: { name: string; queue: SleepQueue }) {
 	const activeSleep = queue.sleeps.find((s) => s.status === "sleeping");
-	const awakeAt = activeSleep?.status === "sleeping" ? activeSleep.awakeAt : undefined;
+	const wakeupAt = activeSleep?.status === "sleeping" ? activeSleep.wakeupAt : undefined;
 
 	return (
 		<div
@@ -542,17 +542,17 @@ function SleepRow({ name, queue }: { name: string; queue: SleepQueue }) {
 			</svg>
 			<span style={{ fontFamily: "var(--mono)", fontSize: 12, fontWeight: 600, color: "var(--t0)" }}>{name}</span>
 			<span style={{ flex: 1 }} />
-			{awakeAt !== undefined && <SleepCountdown awakeAt={awakeAt} />}
+			{wakeupAt !== undefined && <SleepCountdown wakeupAt={wakeupAt} />}
 		</div>
 	);
 }
 
-function SleepCountdown({ awakeAt }: { awakeAt: number }) {
-	const [remaining, setRemaining] = useState(() => timeUntil(awakeAt));
+function SleepCountdown({ wakeupAt }: { wakeupAt: number }) {
+	const [remaining, setRemaining] = useState(() => timeUntil(wakeupAt));
 	useEffect(() => {
-		const interval = setInterval(() => setRemaining(timeUntil(awakeAt)), 1000);
+		const interval = setInterval(() => setRemaining(timeUntil(wakeupAt)), 1000);
 		return () => clearInterval(interval);
-	}, [awakeAt]);
+	}, [wakeupAt]);
 	return <span style={{ fontFamily: "var(--mono)", fontSize: 11, color: "#818CF8" }}>{remaining}</span>;
 }
 

--- a/app/dashboard/src/components/run-detail/timeline-lookups.ts
+++ b/app/dashboard/src/components/run-detail/timeline-lookups.ts
@@ -52,8 +52,8 @@ export function buildTimelineLookups(
 			const reason = state.reason;
 			const context: ScheduledContext = {};
 
-			// Handle awake/awake_early - look up the previous sleeping transition
-			if (reason === "awake" || reason === "awake_early") {
+			// Handle wakeup/wakeup_early - look up the previous sleeping transition
+			if (reason === "wakeup" || reason === "wakeup_early") {
 				for (let j = i - 1; j >= 0; j--) {
 					const prev = transitions[j];
 					if (prev.type === "workflow_run" && prev.state.status === "sleeping") {

--- a/app/dashboard/src/pages/RunDetail.tsx
+++ b/app/dashboard/src/pages/RunDetail.tsx
@@ -461,7 +461,7 @@ export function RunDetail() {
 					{/* Contextual: sleeping */}
 					{currentRun.state.status === "sleeping" && (
 						<Meta label="Awakes">
-							<span style={{ color: "var(--accent-indigo)" }}>{timeUntil(currentRun.state.awakeAt)}</span>
+							<span style={{ color: "var(--accent-indigo)" }}>{timeUntil(currentRun.state.wakeupAt)}</span>
 						</Meta>
 					)}
 

--- a/app/dashboard/src/pages/RunDetail.tsx
+++ b/app/dashboard/src/pages/RunDetail.tsx
@@ -342,7 +342,7 @@ export function RunDetail() {
 											namespaceAuthedClient.workflowRun.transitionStateV1({
 												type: "pessimistic",
 												id: currentRun.id,
-												state: { status: "scheduled", scheduledInMs: 0, reason: "resume" },
+												state: { status: "scheduled", scheduledInMs: 0, reason: "resumption" },
 											})
 										)
 									}

--- a/app/website/content/docs/core-concepts/sleeps.md
+++ b/app/website/content/docs/core-concepts/sleeps.md
@@ -53,7 +53,7 @@ You can wake a sleeping workflow before its duration elapses using the handle:
 
 ```typescript
 // From outside the workflow
-await handle.awake();
+await handle.wakeup();
 ```
 
 Inside the workflow, check if the sleep was cancelled:

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -217,7 +217,7 @@ The handle returned from `.start()` provides:
 | `cancel(reason?)` | Cancel the workflow run |
 | `pause()` | Pause the workflow |
 | `resume()` | Resume a paused workflow |
-| `awake()` | Wake a sleeping workflow |
+| `wakeup()` | Wake a sleeping workflow |
 
 #### Waiting for Status
 

--- a/sdk/server/src/contract/schema/sleep.ts
+++ b/sdk/server/src/contract/schema/sleep.ts
@@ -2,7 +2,7 @@ import { type } from "arktype";
 
 export const sleepSchema = type({
 	status: "'sleeping'",
-	awakeAt: "number > 0",
+	wakeupAt: "number > 0",
 })
 	.or({
 		status: "'completed'",

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -32,15 +32,15 @@ export const workflowRunStateScheduledSchema = type({
 })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'retry'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'task_retry'" })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'awake'" })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'awake_early'" })
+	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'wakeup'" })
+	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'wakeup_early'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'resumption'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'event'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'child_workflow'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'redelivery'" });
 
 const workflowRunQueuedReasonSchema = type(
-	"'new' | 'retry' | 'task_retry' | 'awake' | 'awake_early' | 'resumption' | 'event' | 'child_workflow' | 'recovery' | 'redelivery'"
+	"'new' | 'retry' | 'task_retry' | 'wakeup' | 'wakeup_early' | 'resumption' | 'event' | 'child_workflow' | 'recovery' | 'redelivery'"
 );
 
 export const workflowRunStateQueuedSchema = type({
@@ -59,7 +59,7 @@ export const workflowRunStatePausedSchema = type({
 export const workflowRunStateSleepingSchema = type({
 	status: "'sleeping'",
 	sleepName: "string > 0",
-	awakeAt: "number > 0",
+	wakeupAt: "number > 0",
 });
 
 export const workflowRunStateAwaitingEventSchema = type({
@@ -191,7 +191,7 @@ export const workflowRunStateScheduledRequestOptimisticSchema = type({
 	reason: "'retry'",
 })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'task_retry'" })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'awake'" })
+	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'wakeup'" })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'event'" })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'child_workflow'" });
 
@@ -200,7 +200,7 @@ export const workflowRunStateScheduledRequestPessimisticSchema = type({
 	scheduledInMs: "number.integer >= 0",
 	reason: "'new'",
 })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'awake_early'" })
+	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'wakeup_early'" })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'resumption'" })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'redelivery'" });
 

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -34,13 +34,13 @@ export const workflowRunStateScheduledSchema = type({
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'task_retry'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'awake'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'awake_early'" })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'resume'" })
+	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'resumption'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'event'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'child_workflow'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'redelivery'" });
 
 const workflowRunQueuedReasonSchema = type(
-	"'new' | 'retry' | 'task_retry' | 'awake' | 'awake_early' | 'resume' | 'event' | 'child_workflow' | 'recovered' | 'redelivery'"
+	"'new' | 'retry' | 'task_retry' | 'awake' | 'awake_early' | 'resumption' | 'event' | 'child_workflow' | 'recovery' | 'redelivery'"
 );
 
 export const workflowRunStateQueuedSchema = type({
@@ -201,7 +201,7 @@ export const workflowRunStateScheduledRequestPessimisticSchema = type({
 	reason: "'new'",
 })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'awake_early'" })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'resume'" })
+	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'resumption'" })
 	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'redelivery'" });
 
 export const workflowRunStateSleepingRequestSchema = type({

--- a/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemons/imminent-sleep-elapsed-runs.ts
@@ -103,7 +103,7 @@ async function processChunk(
 		}
 
 		const stateTransitionId = ulid();
-		const state: WorkflowRunStateQueued = { status: "queued", reason: "awake" };
+		const state: WorkflowRunStateQueued = { status: "queued", reason: "wakeup" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,

--- a/sdk/server/src/daemons/recover-overdue-outbox-entries.integration.test.ts
+++ b/sdk/server/src/daemons/recover-overdue-outbox-entries.integration.test.ts
@@ -95,7 +95,7 @@ describe("recoverOverdueOutboxEntries", () => {
 					expect.objectContaining({
 						id: runId,
 						status: "queued",
-						state: { status: "queued", reason: "recovered" },
+						state: { status: "queued", reason: "recovery" },
 					})
 				);
 			}));

--- a/sdk/server/src/daemons/recover-overdue-outbox-entries.ts
+++ b/sdk/server/src/daemons/recover-overdue-outbox-entries.ts
@@ -66,7 +66,7 @@ export async function recoverOverdueOutboxEntries(
 						type: "workflow_run",
 						status: "queued",
 						attempt: run.attempts,
-						state: { status: "queued", reason: "recovered" } satisfies WorkflowRunStateQueued,
+						state: { status: "queued", reason: "recovery" } satisfies WorkflowRunStateQueued,
 					});
 					stateTransitionUpdates.push({ id: run.id, stateTransitionId });
 				}

--- a/sdk/server/src/infra/db/pg/migration/0013_youthful_payback.sql
+++ b/sdk/server/src/infra/db/pg/migration/0013_youthful_payback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "sleep_queue" RENAME COLUMN "awake_at" TO "wakeup_at";--> statement-breakpoint
+ALTER TABLE "workflow_run" RENAME COLUMN "awake_at" TO "wakeup_at";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_status_awake_at_id";--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_status_wakeup_at_id" ON "workflow_run" USING btree ("status","wakeup_at","id");

--- a/sdk/server/src/infra/db/pg/migration/meta/0013_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0013_snapshot.json
@@ -1,0 +1,1763 @@
+{
+	"id": "0e719f09-0c97-4bc9-974a-2e0c02c344de",
+	"prevId": "dd8daf39-78d3-4023-8725-00bf0bed9ffd",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"shard": {
+					"name": "shard",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_at": {
+					"name": "next_publish_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "shard",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR (\"workflow_run_outbox\".\"first_published_at\" IS NOT NULL AND \"workflow_run_outbox\".\"next_publish_attempt_at\" IS NOT NULL)"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -92,6 +92,13 @@
 			"when": 1785324993217,
 			"tag": "0012_harsh_skaar",
 			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1785581384068,
+			"tag": "0013_youthful_payback",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -23,7 +23,7 @@ export type WorkflowRunRowInsert = typeof workflowRun.$inferInsert;
 type WorkflowRunRowUpdate = Partial<
 	Pick<
 		WorkflowRunRowInsert,
-		"status" | "attempts" | "latestStateTransitionId" | "scheduledAt" | "awakeAt" | "timeoutAt" | "nextAttemptAt"
+		"status" | "attempts" | "latestStateTransitionId" | "scheduledAt" | "wakeupAt" | "timeoutAt" | "nextAttemptAt"
 	>
 >;
 
@@ -350,17 +350,17 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				attempts: workflowRun.attempts,
 				options: workflowRun.options,
 				latestStateTransitionId: workflowRun.latestStateTransitionId,
-				dueAt: sql<TimestampMs>`${workflowRun.awakeAt}`.mapWith(workflowRun.awakeAt),
+				dueAt: sql<TimestampMs>`${workflowRun.wakeupAt}`.mapWith(workflowRun.wakeupAt),
 			})
 			.from(workflowRun)
 			.where(
 				and(
 					eq(workflowRun.status, "sleeping"),
-					lte(workflowRun.awakeAt, before),
-					keysetStreamCursorFilter(workflowRun.awakeAt, workflowRun.id, cursor)
+					lte(workflowRun.wakeupAt, before),
+					keysetStreamCursorFilter(workflowRun.wakeupAt, workflowRun.id, cursor)
 				)
 			)
-			.orderBy(workflowRun.awakeAt, workflowRun.id)
+			.orderBy(workflowRun.wakeupAt, workflowRun.id)
 			.limit(limit);
 	},
 
@@ -470,7 +470,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				revision: sql`${workflowRun.revision} + 1`,
 				attempts: options?.incrementAttempts ? sql`${workflowRun.attempts} + 1` : workflowRun.attempts,
 				scheduledAt: null,
-				awakeAt: null,
+				wakeupAt: null,
 				timeoutAt: null,
 				nextAttemptAt: null,
 				latestStateTransitionId: sql`v.state_transition_id`,
@@ -495,7 +495,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				status: "cancelled",
 				revision: sql`${workflowRun.revision} + 1`,
 				scheduledAt: null,
-				awakeAt: null,
+				wakeupAt: null,
 				timeoutAt: null,
 				nextAttemptAt: null,
 			})
@@ -512,7 +512,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				status: "stalled",
 				revision: sql`${workflowRun.revision} + 1`,
 				scheduledAt: null,
-				awakeAt: null,
+				wakeupAt: null,
 				timeoutAt: null,
 				nextAttemptAt: null,
 			})
@@ -529,7 +529,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				status: "queued",
 				revision: sql`${workflowRun.revision} + 1`,
 				scheduledAt: null,
-				awakeAt: null,
+				wakeupAt: null,
 				timeoutAt: null,
 				nextAttemptAt: null,
 			})

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -144,7 +144,7 @@ export const workflowRun = pgTable(
 
 		latestStateTransitionId: text("latest_state_transition_id").notNull(),
 		scheduledAt: timestampMs("scheduled_at"),
-		awakeAt: timestampMs("awake_at"),
+		wakeupAt: timestampMs("wakeup_at"),
 		timeoutAt: timestampMs("timeout_at"),
 		nextAttemptAt: timestampMs("next_attempt_at"),
 
@@ -182,7 +182,7 @@ export const workflowRun = pgTable(
 		// TODO: will adding an index on input hash make conflict resolution faster?
 
 		index("idx_workflow_run_status_scheduled_at_id").on(table.status, table.scheduledAt, table.id),
-		index("idx_workflow_run_status_awake_at_id").on(table.status, table.awakeAt, table.id),
+		index("idx_workflow_run_status_wakeup_at_id").on(table.status, table.wakeupAt, table.id),
 		index("idx_workflow_run_status_timeout_at_id").on(table.status, table.timeoutAt, table.id),
 		index("idx_workflow_run_status_next_attempt_at_id").on(table.status, table.nextAttemptAt, table.id),
 	]
@@ -264,7 +264,7 @@ export const sleepQueue = pgTable(
 		name: text("name").notNull(),
 		status: sleepStatusEnum("status").notNull(),
 
-		awakeAt: timestampMs("awake_at").notNull(),
+		wakeupAt: timestampMs("wakeup_at").notNull(),
 		completedAt: timestampMs("completed_at"),
 		cancelledAt: timestampMs("cancelled_at"),
 

--- a/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
@@ -74,7 +74,7 @@ describe("WorkflowRunStateMachineService redelivery", () => {
 				stateMachine.transitionState(context, {
 					type: "pessimistic",
 					id: runId,
-					state: { status: "scheduled", scheduledInMs: 0, reason: "resume" },
+					state: { status: "scheduled", scheduledInMs: 0, reason: "resumption" },
 				})
 			).rejects.toThrow(InvalidWorkflowRunStateTransitionError);
 		}));

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -82,11 +82,11 @@ const workflowRunStateTransitionValidator: Record<
 			if (!allowedDestinations.includes(to.status)) {
 				return { allowed: false };
 			}
-			if (to.status === "scheduled" && to.reason !== "awake_early") {
-				return { allowed: false, reason: "Only awake_early run allowed" };
+			if (to.status === "scheduled" && to.reason !== "wakeup_early") {
+				return { allowed: false, reason: "Only wakeup_early run allowed" };
 			}
-			if (to.status === "queued" && to.reason !== "awake") {
-				return { allowed: false, reason: "Only awake run allowed" };
+			if (to.status === "queued" && to.reason !== "wakeup") {
+				return { allowed: false, reason: "Only wakeup run allowed" };
 			}
 			return { allowed: true };
 		};
@@ -255,7 +255,7 @@ async function transitionStateInTx(
 			workflowRunId: runId,
 			name: toState.sleepName,
 			status: "sleeping",
-			awakeAt: toState.awakeAt as TimestampMs,
+			wakeupAt: toState.wakeupAt as TimestampMs,
 		});
 	}
 
@@ -272,8 +272,8 @@ async function transitionStateInTx(
 				toState.reason satisfies
 					| "new"
 					| "task_retry"
-					| "awake"
-					| "awake_early"
+					| "wakeup"
+					| "wakeup_early"
 					| "resumption"
 					| "event"
 					| "child_workflow"
@@ -345,7 +345,7 @@ async function finalizeSleep(
 		return;
 	}
 
-	if (toState.reason === "awake") {
+	if (toState.reason === "wakeup") {
 		await txRepos.sleepQueue.update(activeSleep.id, {
 			status: "completed",
 			completedAt: now as TimestampMs,
@@ -407,14 +407,14 @@ async function updateWorkflowRun(
 		attempts,
 		latestStateTransitionId: stateTransitionId,
 		scheduledAt: null,
-		awakeAt: null,
+		wakeupAt: null,
 		timeoutAt: null,
 		nextAttemptAt: null,
 	};
 	if (toState.status === "scheduled") {
 		updates.scheduledAt = toState.scheduledAt as TimestampMs;
 	} else if (toState.status === "sleeping") {
-		updates.awakeAt = toState.awakeAt as TimestampMs;
+		updates.wakeupAt = toState.wakeupAt as TimestampMs;
 	} else if (
 		(toState.status === "awaiting_event" || toState.status === "awaiting_child_workflow") &&
 		toState.timeoutAt !== undefined
@@ -512,7 +512,7 @@ function convertDurationsToTimestamps(request: WorkflowRunStateRequest, now: num
 		return {
 			status: request.status,
 			sleepName: request.sleepName,
-			awakeAt: now + request.durationMs,
+			wakeupAt: now + request.durationMs,
 		};
 	}
 

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -69,8 +69,8 @@ const workflowRunStateTransitionValidator: Record<
 			if (!allowedDestinations.includes(to.status)) {
 				return { allowed: false };
 			}
-			if (to.status === "scheduled" && to.reason !== "resume") {
-				return { allowed: false, reason: "Only resume run allowed" };
+			if (to.status === "scheduled" && to.reason !== "resumption") {
+				return { allowed: false, reason: "Only resumption run allowed" };
 			}
 			return { allowed: true };
 		};
@@ -274,10 +274,10 @@ async function transitionStateInTx(
 					| "task_retry"
 					| "awake"
 					| "awake_early"
-					| "resume"
+					| "resumption"
 					| "event"
 					| "child_workflow"
-					| "recovered"
+					| "recovery"
 					| "redelivery";
 		}
 	}

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -721,7 +721,7 @@ function buildSleepQueuesByNameRecord(sleepQueueRows: SleepQueueRow[]): Record<s
 
 		switch (row.status) {
 			case "sleeping":
-				queue.sleeps.push({ status: row.status, awakeAt: row.awakeAt });
+				queue.sleeps.push({ status: row.status, wakeupAt: row.wakeupAt });
 				break;
 			case "completed": {
 				const { completedAt } = row;

--- a/sdk/workflow/src/run/handle-child.ts
+++ b/sdk/workflow/src/run/handle-child.ts
@@ -38,7 +38,7 @@ export function childWorkflowRunHandle<Input, Output, Context, TEvents extends E
 		cancel: handle.cancel.bind(handle),
 		pause: handle.pause.bind(handle),
 		resume: handle.resume.bind(handle),
-		awake: handle.awake.bind(handle),
+		wakeup: handle.wakeup.bind(handle),
 		[INTERNAL]: handle[INTERNAL],
 	};
 }

--- a/sdk/workflow/src/run/handle.test.ts
+++ b/sdk/workflow/src/run/handle.test.ts
@@ -246,7 +246,7 @@ describe("workflowRunHandle", () => {
 				await handle.resume();
 			}));
 
-		test("awake schedules the run immediately with reason 'awake_early'", () =>
+		test("wakeup schedules the run immediately with reason 'wakeup_early'", () =>
 			withFakeClient(async (client) => {
 				const record = runningWorkflowRunRecordFactory.build();
 				const handle = workflowRunHandle(client, record);
@@ -255,7 +255,7 @@ describe("workflowRunHandle", () => {
 					{
 						type: "pessimistic",
 						id: record.id,
-						state: { status: "scheduled", scheduledInMs: 0, reason: "awake_early" },
+						state: { status: "scheduled", scheduledInMs: 0, reason: "wakeup_early" },
 					},
 					{
 						revision: record.revision + 1,
@@ -264,7 +264,7 @@ describe("workflowRunHandle", () => {
 					}
 				);
 
-				await handle.awake();
+				await handle.wakeup();
 			}));
 	});
 

--- a/sdk/workflow/src/run/handle.test.ts
+++ b/sdk/workflow/src/run/handle.test.ts
@@ -231,10 +231,14 @@ describe("workflowRunHandle", () => {
 				const handle = workflowRunHandle(client, record);
 
 				client.api.workflowRun.transitionStateV1.once(
-					{ type: "pessimistic", id: record.id, state: { status: "scheduled", scheduledInMs: 0, reason: "resume" } },
+					{
+						type: "pessimistic",
+						id: record.id,
+						state: { status: "scheduled", scheduledInMs: 0, reason: "resumption" },
+					},
 					{
 						revision: record.revision + 1,
-						state: { status: "scheduled", scheduledAt: 0, reason: "resume" },
+						state: { status: "scheduled", scheduledAt: 0, reason: "resumption" },
 						attempts: record.attempts,
 					}
 				);

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -149,7 +149,7 @@ export interface WorkflowRunHandle<Input, Output, Context, TEvents extends Event
 
 	resume: () => Promise<void>;
 
-	awake: () => Promise<void>;
+	wakeup: () => Promise<void>;
 
 	[INTERNAL]: {
 		client: Client<Context>;
@@ -324,9 +324,9 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 		this.logger.info("Workflow resumed");
 	}
 
-	public async awake(): Promise<void> {
-		await this.transitionState({ status: "scheduled", scheduledInMs: 0, reason: "awake_early" });
-		this.logger.info("Workflow awoken");
+	public async wakeup(): Promise<void> {
+		await this.transitionState({ status: "scheduled", scheduledInMs: 0, reason: "wakeup_early" });
+		this.logger.info("Workflow woken up");
 	}
 
 	private async transitionState(targetState: WorkflowRunStateRequest): Promise<void> {
@@ -336,7 +336,7 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 				(targetState.status === "scheduled" &&
 					(targetState.reason === "new" ||
 						targetState.reason === "resumption" ||
-						targetState.reason === "awake_early" ||
+						targetState.reason === "wakeup_early" ||
 						targetState.reason === "redelivery")) ||
 				targetState.status === "paused" ||
 				targetState.status === "cancelled"

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -320,7 +320,7 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 	}
 
 	public async resume(): Promise<void> {
-		await this.transitionState({ status: "scheduled", scheduledInMs: 0, reason: "resume" });
+		await this.transitionState({ status: "scheduled", scheduledInMs: 0, reason: "resumption" });
 		this.logger.info("Workflow resumed");
 	}
 
@@ -335,7 +335,7 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 			if (
 				(targetState.status === "scheduled" &&
 					(targetState.reason === "new" ||
-						targetState.reason === "resume" ||
+						targetState.reason === "resumption" ||
 						targetState.reason === "awake_early" ||
 						targetState.reason === "redelivery")) ||
 				targetState.status === "paused" ||

--- a/sdk/workflow/src/run/sleeper.test.ts
+++ b/sdk/workflow/src/run/sleeper.test.ts
@@ -26,7 +26,7 @@ describe("createSleeper", () => {
 						state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
 						expectedRevision: 0,
 					},
-					{ revision: 1, state: { status: "sleeping", sleepName: "nap", awakeAt: 0 }, attempts: 1 }
+					{ revision: 1, state: { status: "sleeping", sleepName: "nap", wakeupAt: 0 }, attempts: 1 }
 				);
 
 				expect(sleep("nap", { seconds: 60 })).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
@@ -74,7 +74,7 @@ describe("createSleeper", () => {
 		test("suspends again without a transition when the recorded sleep is still sleeping", () =>
 			withFakeClient((client) => {
 				const record = runningWorkflowRunRecordFactory.build({
-					sleepQueues: { nap: { sleeps: [{ status: "sleeping", awakeAt: 0 }] } },
+					sleepQueues: { nap: { sleeps: [{ status: "sleeping", wakeupAt: 0 }] } },
 				});
 				const sleep = createTestSleeper(client, record);
 
@@ -126,7 +126,7 @@ describe("createSleeper", () => {
 						state: { status: "sleeping", sleepName: "nap", durationMs: 30_000 },
 						expectedRevision: 4,
 					},
-					{ revision: 5, state: { status: "sleeping", sleepName: "nap", awakeAt: 0 }, attempts: 1 }
+					{ revision: 5, state: { status: "sleeping", sleepName: "nap", wakeupAt: 0 }, attempts: 1 }
 				);
 
 				expect(sleep("nap", { seconds: 90 })).rejects.toBeInstanceOf(WorkflowRunSuspendedError);

--- a/sdk/workflow/src/run/sleeper.ts
+++ b/sdk/workflow/src/run/sleeper.ts
@@ -46,7 +46,7 @@ export function createSleeper(handle: WorkflowRunHandle<unknown, unknown, unknow
 		if (existingSleep.status === "sleeping") {
 			logger.debug("Already sleeping", {
 				"aiki.sleepName": sleepName,
-				"aiki.awakeAt": existingSleep.awakeAt,
+				"aiki.wakeupAt": existingSleep.wakeupAt,
 			});
 			throw new WorkflowRunSuspendedError(handle.run.id as WorkflowRunId);
 		}

--- a/testing/src/workflow/run.ts
+++ b/testing/src/workflow/run.ts
@@ -15,7 +15,7 @@ export const workflowRunStateByStatus: {
 	queued: { status: "queued", reason: "new" },
 	running: { status: "running" },
 	paused: { status: "paused" },
-	sleeping: { status: "sleeping", sleepName: "nap", awakeAt: 0 },
+	sleeping: { status: "sleeping", sleepName: "nap", wakeupAt: 0 },
 	awaiting_event: { status: "awaiting_event", eventName: "order-shipped" },
 	awaiting_retry: {
 		status: "awaiting_retry",

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -183,7 +183,7 @@ export type WorkflowRunStateScheduledRequestOptimistic = Extract<
 
 export type WorkflowRunStateScheduledRequestPessimistic = Extract<
 	WorkflowRunStateScheduledRequest,
-	{ reason: "new" | "awake_early" | "resume" | "redelivery" }
+	{ reason: "new" | "awake_early" | "resumption" | "redelivery" }
 >;
 
 export interface WorkflowRunTransitionStateRequestOptimistic extends WorkflowRunTransitionStateRequestBase {

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -129,7 +129,7 @@ export type WorkflowRunStateScheduledRequest = DistributiveOmit<WorkflowRunState
 	scheduledInMs: number;
 };
 
-export type WorkflowRunStateSleepingRequest = DistributiveOmit<WorkflowRunStateSleeping, "awakeAt"> & {
+export type WorkflowRunStateSleepingRequest = DistributiveOmit<WorkflowRunStateSleeping, "wakeupAt"> & {
 	durationMs: number;
 };
 
@@ -178,12 +178,12 @@ interface WorkflowRunTransitionStateRequestBase {
 
 export type WorkflowRunStateScheduledRequestOptimistic = Extract<
 	WorkflowRunStateScheduledRequest,
-	{ reason: "retry" | "task_retry" | "awake" | "event" | "child_workflow" }
+	{ reason: "retry" | "task_retry" | "wakeup" | "event" | "child_workflow" }
 >;
 
 export type WorkflowRunStateScheduledRequestPessimistic = Extract<
 	WorkflowRunStateScheduledRequest,
-	{ reason: "new" | "awake_early" | "resumption" | "redelivery" }
+	{ reason: "new" | "wakeup_early" | "resumption" | "redelivery" }
 >;
 
 export interface WorkflowRunTransitionStateRequestOptimistic extends WorkflowRunTransitionStateRequestBase {

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -68,8 +68,8 @@ export const WORKFLOW_RUN_SCHEDULED_REASON = [
 	"new",
 	"retry",
 	"task_retry",
-	"awake",
-	"awake_early",
+	"wakeup",
+	"wakeup_early",
 	"resumption",
 	"event",
 	"child_workflow",
@@ -95,12 +95,12 @@ export interface WorkflowRunStateScheduledByTaskRetry extends WorkflowRunStateSc
 	reason: "task_retry";
 }
 
-export interface WorkflowRunStateScheduledByAwake extends WorkflowRunStateScheduledBase {
-	reason: "awake";
+export interface WorkflowRunStateScheduledByWakeup extends WorkflowRunStateScheduledBase {
+	reason: "wakeup";
 }
 
-export interface WorkflowRunStateScheduledByAwakeEarly extends WorkflowRunStateScheduledBase {
-	reason: "awake_early";
+export interface WorkflowRunStateScheduledByWakeupEarly extends WorkflowRunStateScheduledBase {
+	reason: "wakeup_early";
 }
 
 export interface WorkflowRunStateScheduledByResume extends WorkflowRunStateScheduledBase {
@@ -123,8 +123,8 @@ export type WorkflowRunStateScheduled =
 	| WorkflowRunStateScheduledByNew
 	| WorkflowRunStateScheduledByRetry
 	| WorkflowRunStateScheduledByTaskRetry
-	| WorkflowRunStateScheduledByAwake
-	| WorkflowRunStateScheduledByAwakeEarly
+	| WorkflowRunStateScheduledByWakeup
+	| WorkflowRunStateScheduledByWakeupEarly
 	| WorkflowRunStateScheduledByResume
 	| WorkflowRunStateScheduledByEvent
 	| WorkflowRunStateScheduledByChildWorkflow
@@ -134,8 +134,8 @@ export const WORKFLOW_RUN_QUEUED_REASON = [
 	"new",
 	"retry",
 	"task_retry",
-	"awake",
-	"awake_early",
+	"wakeup",
+	"wakeup_early",
 	"resumption",
 	"event",
 	"child_workflow",
@@ -160,7 +160,7 @@ export interface WorkflowRunStatePaused extends WorkflowRunStateBase {
 export interface WorkflowRunStateSleeping extends WorkflowRunStateBase {
 	status: "sleeping";
 	sleepName: string;
-	awakeAt: number;
+	wakeupAt: number;
 }
 
 export interface WorkflowRunStateAwaitingEvent extends WorkflowRunStateBase {

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -70,7 +70,7 @@ export const WORKFLOW_RUN_SCHEDULED_REASON = [
 	"task_retry",
 	"awake",
 	"awake_early",
-	"resume",
+	"resumption",
 	"event",
 	"child_workflow",
 	"redelivery",
@@ -104,7 +104,7 @@ export interface WorkflowRunStateScheduledByAwakeEarly extends WorkflowRunStateS
 }
 
 export interface WorkflowRunStateScheduledByResume extends WorkflowRunStateScheduledBase {
-	reason: "resume";
+	reason: "resumption";
 }
 
 export interface WorkflowRunStateScheduledByEvent extends WorkflowRunStateScheduledBase {
@@ -136,10 +136,10 @@ export const WORKFLOW_RUN_QUEUED_REASON = [
 	"task_retry",
 	"awake",
 	"awake_early",
-	"resume",
+	"resumption",
 	"event",
 	"child_workflow",
-	"recovered",
+	"recovery",
 	"redelivery",
 ] as const;
 export type WorkflowRunQueuedReason = (typeof WORKFLOW_RUN_QUEUED_REASON)[number];

--- a/types/src/workflow/run/sleep.ts
+++ b/types/src/workflow/run/sleep.ts
@@ -9,7 +9,7 @@ interface SleepBase {
 
 export interface SleepSleeping extends SleepBase {
 	status: "sleeping";
-	awakeAt: number;
+	wakeupAt: number;
 }
 
 export interface SleepCompleted extends SleepBase {


### PR DESCRIPTION
Two vocabulary fixes. The scheduled/queued `reason` union mixed grammars — `retry` and `event` are nouns, `resume` a verb, `awake` an adjective, `recovered` a past participle. A reason answers "why is this run here," so all reasons are now nouns: `recovered` → `recovery`, `awake` → `wakeup`, `awake_early` → `wakeup_early`, `resume` → `resumption`. `new` stays — too idiomatic to trade for consistency.

`awake` has no workable noun form, so its noun is `wakeup` — a different lexeme from the rest of the sleep vocabulary (`handle.awake()`, the sleeping state's `awakeAt`, the `awake_at` columns). Renaming only the reason would leave one concept spelled two ways, so the whole sleep vocabulary moves with it: `handle.wakeup()`, `wakeupAt`, and migration 0013 renaming the two columns and the index — pure renames, no data movement.

Reasons already persisted in run histories are not migrated: they live inside stored state-transition JSON and nothing at runtime branches on a stored reason, so old runs keep the old tokens as history. One consequence: the dashboard timeline matches sleep-wake events on the new tokens, so pre-rename runs lose that correlation in their timeline; they age out.

## Breaking changes

- SDK: `handle.awake()` is now `handle.wakeup()`; the sleeping state's `awakeAt` is `wakeupAt` in API payloads.
- Transition API: the old reason tokens are rejected; clients send `resumption`, `wakeup`, `wakeup_early`.
- Migration 0013 renames `awake_at` to `wakeup_at` on `workflow_run` and `sleep_queue`.
