### PR TITLE
Rename `shard` to `pool`

### DIFF
--- a/app/dashboard/src/pages/SchedulesList.tsx
+++ b/app/dashboard/src/pages/SchedulesList.tsx
@@ -675,7 +675,7 @@ function ScheduleRow({
 						{schedule.workflowRunOptions?.retry && (
 							<Meta label="Retry" value={retrySummary(schedule.workflowRunOptions.retry)} />
 						)}
-						{schedule.workflowRunOptions?.shard && <Meta label="Shard" value={schedule.workflowRunOptions.shard} />}
+						{schedule.workflowRunOptions?.pool && <Meta label="Pool" value={schedule.workflowRunOptions.pool} />}
 						<Meta label="Total Runs" value={runCount.toLocaleString()} />
 						<Meta label="Created" value={fmtDate(schedule.createdAt)} />
 					</div>

--- a/app/website/content/docs/architecture/subscribers.md
+++ b/app/website/content/docs/architecture/subscribers.md
@@ -57,11 +57,11 @@ aiki:workflow:order-processing:1.0.0
 aiki:workflow:user-onboarding:1.0.0
 ```
 
-With sharding enabled:
+With worker pools in use:
 
 ```
-aiki:workflow:order-processing:1.0.0:us-east
-aiki:workflow:order-processing:1.0.0:eu-west
+aiki:workflow:order-processing:1.0.0:tenant-acme
+aiki:workflow:order-processing:1.0.0:tenant-globex
 ```
 
 ### Work Distribution

--- a/app/website/content/docs/core-concepts/schedules.md
+++ b/app/website/content/docs/core-concepts/schedules.md
@@ -115,11 +115,11 @@ const hourlySync = schedule({
 await hourlySync
 	.with()
 	.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
-	.opt("workflowRun.shard", "eu")
+	.opt("workflowRun.pool", "foo-bar")
 	.activate(client, inventorySyncV1);
 ```
 
-Only `retry` and `shard` can be set: a scheduled run's reference ID and trigger are the schedule's to control, not the caller's. Run options are part of a schedule's identity, so changing them is a different schedule — or, with a [reference ID](#reference-ids), a conflict.
+Only `retry` and `pool` can be set: a scheduled run's reference ID and trigger are the schedule's to control, not the caller's. Run options are part of a schedule's identity, so changing them is a different schedule — or, with a [reference ID](#reference-ids), a conflict.
 
 ## Idempotent Activation
 

--- a/app/website/content/docs/core-concepts/workers.md
+++ b/app/website/content/docs/core-concepts/workers.md
@@ -52,7 +52,7 @@ const handle2 = worker2.start(aikiClient);
 
 **Specialize workers** by registering different workflows on different workers. Each worker only handles the workflows it knows about.
 
-**Shard by region or tenant** using `shards`. A worker with `shards: ["us-east"]` only processes workflow runs routed to that shard.
+**Split fleets by capability, tenant, or region** using `pools`. A worker with `pools: ["gpu"]` only processes workflow runs routed to that pool.
 
 ## Graceful Shutdown
 
@@ -85,7 +85,7 @@ Worker configuration is split between **params** (identity) and **options** (tun
 | `maxConcurrentWorkflowRuns` | 1 | Max parallel executions |
 | `gracefulShutdownTimeoutMs` | 5,000 | Shutdown wait time (ms) |
 | `workflowRun.claimRefreshIntervalMs` | 30,000 | How often the worker refreshes its run claim (ms) |
-| `shards` | — | Shards to process |
+| `pools` | — | Worker pools to process |
 
 ## Pluggable Subscribers
 

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -136,18 +136,18 @@ Schemas work with any validation library that implements [Standard Schema](https
 
 **Why use output schemas?** For child workflows, cached outputs are validated against the schema. If the cached shape doesn't match, the parent workflow fails immediately. See [Refactoring Workflows](../guides/refactoring-workflows.md#changing-task-or-child-workflow-output-shapes).
 
-## Sharding
+## Worker Pools
 
-Route workflows to specific shards for distributed processing, multi-region deployments, or tenant isolation:
+Route workflows to a named worker pool when only part of your fleet should execute them — a fleet with special hardware, a fleet dedicated to one tenant, or a regional deployment:
 
 ```typescript
 const handle = await orderWorkflowV1
 	.with()
-	.opt("shard", "us-east")
+	.opt("pool", "gpu")
 	.start(client, { orderId: "123" });
 ```
 
-Workers must be configured to listen to the same shard. A workflow routed to `"us-east"` will only be picked up by workers with `shards: ["us-east"]` in their configuration. See **[Workers](./workers.md)** for worker-side setup.
+Workers must be configured to serve the same pool. A workflow routed to `"gpu"` will only be picked up by workers with `pools: ["gpu"]` in their configuration. See **[Workers](./workers.md)** for worker-side setup.
 
 ## Starting Workflows
 

--- a/examples/src/scenarios/scheduled-notify.ts
+++ b/examples/src/scenarios/scheduled-notify.ts
@@ -15,7 +15,7 @@ await runWithWorker([notify], async (client) => {
 		.with()
 		.opt("reference.id", "my-correlation-xxx")
 		.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-		.opt("workflowRun.shard", "eu")
+		.opt("workflowRun.pool", "heavy-duty")
 		.activate(client, notify, "This is a reminder");
 	await delay(20_000);
 	await scheduleHandle.pause();

--- a/sdk/adapter/http/src/queue/subscriber.ts
+++ b/sdk/adapter/http/src/queue/subscriber.ts
@@ -44,14 +44,14 @@ export function httpSubscriber(params: HttpSubscriberParams): CreateSubscriber {
 		}
 	};
 
-	return ({ workflows, shards, signal }): Subscriber => {
+	return ({ workflows, pools, signal }): Subscriber => {
 		return {
 			getNextDelay,
 			async getReadyRuns(size: number): Promise<WorkflowRunMessage[]> {
 				const response = await api.workflowRun.claimReadyV1(
 					{
 						workflows: workflows.map((workflow) => ({ name: workflow.name, versionId: workflow.versionId })),
-						shards,
+						pools,
 						limit: size,
 					},
 					{ signal }

--- a/sdk/adapter/memory/src/queue/key.ts
+++ b/sdk/adapter/memory/src/queue/key.ts
@@ -1,15 +1,15 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { WorkflowMeta } from "@aikirun/types/workflow";
 
-export function getWorkflowQueueName(name: string, versionId: string, shard?: string): string {
-	return shard ? `${name}:${versionId}:${shard}` : `${name}:${versionId}`;
+export function getWorkflowQueueName(name: string, versionId: string, pool?: string): string {
+	return pool ? `${name}:${versionId}:${pool}` : `${name}:${versionId}`;
 }
 
-export function getWorkflowQueueNames(workflows: WorkflowMeta[], shards?: string[]): string[] {
-	if (!isNonEmptyArray(shards)) {
+export function getWorkflowQueueNames(workflows: WorkflowMeta[], pools?: string[]): string[] {
+	if (!isNonEmptyArray(pools)) {
 		return workflows.map((workflow) => getWorkflowQueueName(workflow.name, workflow.versionId));
 	}
 	return workflows.flatMap((workflow) =>
-		shards.map((shard) => getWorkflowQueueName(workflow.name, workflow.versionId, shard))
+		pools.map((pool) => getWorkflowQueueName(workflow.name, workflow.versionId, pool))
 	);
 }

--- a/sdk/adapter/memory/src/queue/publisher.ts
+++ b/sdk/adapter/memory/src/queue/publisher.ts
@@ -14,8 +14,8 @@ export function createInMemoryPublisher(store: Store): CreatePublisher {
 	return (_context: PublisherContext): Publisher => ({
 		async publishRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishRunsResult> {
 			const touchedQueues = new Map<string, Queue>();
-			for (const { id, name, versionId, rank, shard } of runs) {
-				const queueName = getWorkflowQueueName(name, versionId, shard);
+			for (const { id, name, versionId, rank, pool } of runs) {
+				const queueName = getWorkflowQueueName(name, versionId, pool);
 				const queue = store.getOrCreateQueue(queueName);
 				queue.push({ rank, id });
 				touchedQueues.set(queueName, queue);

--- a/sdk/adapter/memory/src/queue/subscriber.ts
+++ b/sdk/adapter/memory/src/queue/subscriber.ts
@@ -21,8 +21,8 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 		}
 	};
 
-	return ({ workflows, shards, signal }): Subscriber => {
-		const queueNames = getWorkflowQueueNames(workflows, shards) as NonEmptyArray<string>;
+	return ({ workflows, pools, signal }): Subscriber => {
+		const queueNames = getWorkflowQueueNames(workflows, pools) as NonEmptyArray<string>;
 		const queueNamesByIndex = new Map<string, number>();
 		for (const [queueIndex, queueName] of queueNames.entries()) {
 			queueNamesByIndex.set(queueName, queueIndex);

--- a/sdk/adapter/redis/src/queue/key.ts
+++ b/sdk/adapter/redis/src/queue/key.ts
@@ -1,16 +1,16 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { WorkflowMeta } from "@aikirun/types/workflow/workflow";
 
-export function getWorkflowQueueName(name: string, versionId: string, shard?: string): string {
-	return shard ? `aiki:workflow:${name}:${versionId}:${shard}` : `aiki:workflow:${name}:${versionId}`;
+export function getWorkflowQueueName(name: string, versionId: string, pool?: string): string {
+	return pool ? `aiki:workflow:${name}:${versionId}:${pool}` : `aiki:workflow:${name}:${versionId}`;
 }
 
-export function getWorkflowQueueNames(workflows: WorkflowMeta[], shards?: string[]): string[] {
-	if (!isNonEmptyArray(shards)) {
+export function getWorkflowQueueNames(workflows: WorkflowMeta[], pools?: string[]): string[] {
+	if (!isNonEmptyArray(pools)) {
 		return workflows.map((workflow) => getWorkflowQueueName(workflow.name, workflow.versionId));
 	}
 
 	return workflows.flatMap((workflow) =>
-		shards.map((shard) => getWorkflowQueueName(workflow.name, workflow.versionId, shard))
+		pools.map((pool) => getWorkflowQueueName(workflow.name, workflow.versionId, pool))
 	);
 }

--- a/sdk/adapter/redis/src/queue/publisher.ts
+++ b/sdk/adapter/redis/src/queue/publisher.ts
@@ -28,7 +28,7 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 
 				const dataByQueueName = new Map<string, QueueData>();
 				for (const run of runs) {
-					const queueName = getWorkflowQueueName(run.name, run.versionId, run.shard);
+					const queueName = getWorkflowQueueName(run.name, run.versionId, run.pool);
 					const queueData = dataByQueueName.get(queueName);
 					if (!queueData) {
 						dataByQueueName.set(queueName, { runs: [run], args: [run.rank, run.id] });

--- a/sdk/adapter/redis/src/queue/subscriber.ts
+++ b/sdk/adapter/redis/src/queue/subscriber.ts
@@ -92,7 +92,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 		}
 	};
 
-	return ({ workflows, shards, logger, signal }): Subscriber => {
+	return ({ workflows, pools, logger, signal }): Subscriber => {
 		const connectTimeoutMs = params.connectTimeoutMs ?? 5_000;
 
 		const redis = new Redis({
@@ -116,7 +116,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 			{ once: true }
 		);
 
-		const queueNames = getWorkflowQueueNames(workflows, shards);
+		const queueNames = getWorkflowQueueNames(workflows, pools);
 
 		return {
 			getNextDelay,

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -341,7 +341,7 @@ const claimReadyV1: ContractProcedure<WorkflowRunClaimReadyRequestV1, WorkflowRu
 			})
 				.array()
 				.atLeastLength(1),
-			"shards?": type("string > 0").array().or("undefined"),
+			"pools?": type("string > 0").array().or("undefined"),
 			limit: "number.integer > 0",
 		})
 	)

--- a/sdk/server/src/contract/schema/schedule.ts
+++ b/sdk/server/src/contract/schema/schedule.ts
@@ -31,7 +31,7 @@ export const scheduleActivateOptionsSchema = type({
 	"reference?": scheduleReferenceSchema.or("undefined"),
 });
 
-export const scheduledWorkflowStartOptionsSchema = workflowOptionsSchema.pick("retry", "shard");
+export const scheduledWorkflowStartOptionsSchema = workflowOptionsSchema.pick("retry", "pool");
 
 export const scheduleWorkflowFilterSchema = type({
 	name: "string > 0",

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -21,7 +21,7 @@ const workflowReferenceSchema = type({
 export const workflowOptionsSchema = type({
 	"reference?": workflowReferenceSchema,
 	"trigger?": triggerStrategySchema,
-	"shard?": "string | undefined",
+	"pool?": "string | undefined",
 	"retry?": retryStrategySchema,
 });
 
@@ -256,7 +256,7 @@ export const listChildRunsResponseSchema = type({
 	runs: type({
 		id: "string > 0",
 		"options?": type({
-			"shard?": "string | undefined",
+			"pool?": "string | undefined",
 		}).or("undefined"),
 	}).array(),
 });

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -160,7 +160,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			rank: run.rank,
 			status: "pending",
 		});

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -160,7 +160,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			rank: run.rank,
 			status: "pending",
 		});

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -187,7 +187,7 @@ async function processOverlapAllowSchedules(
 				workflowName: schedule.workflowName,
 				workflowVersionId: schedule.workflowVersionId,
 				rank: computeRank(occurrence),
-				shard: schedule.workflowRunOptions?.shard ?? null,
+				pool: schedule.workflowRunOptions?.pool ?? null,
 				status: "pending",
 			});
 		}
@@ -283,7 +283,7 @@ async function processOverlapSkipSchedules(
 			workflowName: schedule.workflowName,
 			workflowVersionId: schedule.workflowVersionId,
 			rank: computeRank(occurrence),
-			shard: schedule.workflowRunOptions?.shard ?? null,
+			pool: schedule.workflowRunOptions?.pool ?? null,
 			status: "pending",
 		});
 		scheduleUpdates.push({
@@ -325,7 +325,7 @@ async function processOverlapCancelPreviousSchedules(
 	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(deps.repos, schedules);
 
 	const runIdsToCancel: string[] = [];
-	const runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; shard?: string }> = [];
+	const runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string }> = [];
 
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
 	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
@@ -379,7 +379,7 @@ async function processOverlapCancelPreviousSchedules(
 			workflowName: schedule.workflowName,
 			workflowVersionId: schedule.workflowVersionId,
 			rank: computeRank(occurrence),
-			shard: schedule.workflowRunOptions?.shard ?? null,
+			pool: schedule.workflowRunOptions?.pool ?? null,
 			status: "pending",
 		});
 		scheduleUpdates.push({
@@ -431,7 +431,7 @@ async function processOverlapCancelPreviousSchedules(
 					state: { status: "cancelled", reason: "Schedule overlap policy" } satisfies WorkflowRunStateCancelled,
 				});
 				cancelledRunStateTransitionIdUpdates.push({ id: run.id, stateTransitionId });
-				cancelledRuns.push({ namespaceId: run.namespaceId, runId: run.id, shard: run.shard });
+				cancelledRuns.push({ namespaceId: run.namespaceId, runId: run.id, pool: run.pool });
 			}
 
 			if (isNonEmptyArray(cancelStateTransitionEntries) && isNonEmptyArray(cancelledRunStateTransitionIdUpdates)) {
@@ -466,7 +466,7 @@ function scheduledRunOptions(
 	return {
 		reference: { id: referenceId },
 		retry: schedule.workflowRunOptions?.retry,
-		shard: schedule.workflowRunOptions?.shard,
+		pool: schedule.workflowRunOptions?.pool,
 	};
 }
 
@@ -492,7 +492,7 @@ async function fetchActiveRunsBySchedule(
 		schedulesByReferenceId.set(referenceId, schedule);
 	}
 
-	const activeRunsByScheduleId = new Map<string, { id: string; attempts: number; shard?: string }>();
+	const activeRunsByScheduleId = new Map<string, { id: string; attempts: number; pool?: string }>();
 
 	if (isNonEmptyArray(workflowAndReferenceIdPairs) && isNonEmptyArray(NON_TERMINAL_WORKFLOW_RUN_STATUSES)) {
 		const activeRuns = await repos.workflowRun.listByWorkflowAndReferenceIdPairs({
@@ -504,8 +504,8 @@ async function fetchActiveRunsBySchedule(
 			if (run.referenceId) {
 				const schedule = schedulesByWorkflowAndReferenceId.get(run.workflowId)?.get(run.referenceId);
 				if (schedule) {
-					const shard = run.options?.shard;
-					activeRunsByScheduleId.set(schedule.id, { id: run.id, attempts: run.attempts, shard });
+					const pool = run.options?.pool;
+					activeRunsByScheduleId.set(schedule.id, { id: run.id, attempts: run.attempts, pool });
 				}
 			}
 		}

--- a/sdk/server/src/daemon/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-runs.ts
@@ -128,7 +128,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			status: "pending",
 			rank: run.rank,
 		});

--- a/sdk/server/src/daemon/imminent-retryable-task-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-task-runs.ts
@@ -160,7 +160,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			rank: run.rank,
 			status: "pending",
 		});

--- a/sdk/server/src/daemon/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.ts
@@ -144,7 +144,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			rank: run.rank,
 			status: "pending",
 		});

--- a/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
@@ -127,7 +127,7 @@ async function processChunk(
 			workflowRunId: run.id,
 			workflowName: workflow.name,
 			workflowVersionId: workflow.versionId,
-			shard: run.options?.shard,
+			pool: run.options?.pool,
 			rank: run.rank,
 			status: "pending",
 		});

--- a/sdk/server/src/daemon/publish-pending-outbox-entries.ts
+++ b/sdk/server/src/daemon/publish-pending-outbox-entries.ts
@@ -91,7 +91,7 @@ async function publish(
 			name: entry.workflowName,
 			versionId: entry.workflowVersionId,
 			rank: entry.rank,
-			shard: entry.shard ?? undefined,
+			pool: entry.pool ?? undefined,
 		});
 	}
 

--- a/sdk/server/src/infra/db/pg/migration/0014_acoustic_baron_zemo.sql
+++ b/sdk/server/src/infra/db/pg/migration/0014_acoustic_baron_zemo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "workflow_run_outbox" RENAME COLUMN "shard" TO "pool";--> statement-breakpoint
+DROP INDEX "idx_workflow_run_outbox_claim_pending";--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_outbox_claim_pending" ON "workflow_run_outbox" USING btree ("namespace_id","workflow_name","workflow_version_id","pool","rank","id") WHERE "workflow_run_outbox"."status" = 'pending';--> statement-breakpoint
+UPDATE "workflow_run" SET "options" = ("options" - 'shard') || jsonb_build_object('pool', "options" -> 'shard') WHERE "options" ? 'shard';--> statement-breakpoint
+UPDATE "schedule" SET "workflow_run_options" = ("workflow_run_options" - 'shard') || jsonb_build_object('pool', "workflow_run_options" -> 'shard') WHERE "workflow_run_options" ? 'shard';

--- a/sdk/server/src/infra/db/pg/migration/meta/0014_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0014_snapshot.json
@@ -1,0 +1,1763 @@
+{
+	"id": "c212ab1b-2a25-40d7-bfca-722a72e9291a",
+	"prevId": "0e719f09-0c97-4bc9-974a-2e0c02c344de",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait_queue": {
+			"name": "child_workflow_run_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_queue_parent_id": {
+					"name": "idx_child_workflow_run_wait_queue_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_queue_parent": {
+					"name": "fk_child_workflow_run_wait_queue_parent",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_child": {
+					"name": "fk_child_workflow_run_wait_queue_child",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_queue_state_transition": {
+					"name": "fk_child_workflow_run_wait_queue_state_transition",
+					"tableFrom": "child_workflow_run_wait_queue",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'completed' OR (\"child_workflow_run_wait_queue\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait_queue\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait_queue\".\"status\" != 'timeout' OR \"child_workflow_run_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait_queue": {
+			"name": "event_wait_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_queue_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_queue_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_queue_workflow_run_id": {
+					"name": "idx_event_wait_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_queue_workflow_run": {
+					"name": "fk_event_wait_queue_workflow_run",
+					"tableFrom": "event_wait_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_queue_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_queue_timeout_requires_timed_out_at",
+					"value": "\"event_wait_queue\".\"status\" != 'timeout' OR \"event_wait_queue\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "schedule_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sleep_queue": {
+			"name": "sleep_queue",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_queue_one_active_per_run": {
+					"name": "uqidx_sleep_queue_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep_queue\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_queue_workflow_run_id": {
+					"name": "idx_sleep_queue_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_queue_workflow_run": {
+					"name": "fk_sleep_queue_workflow_run",
+					"tableFrom": "sleep_queue",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_queue_completed_requires_completed_at": {
+					"name": "chk_sleep_queue_completed_requires_completed_at",
+					"value": "\"sleep_queue\".\"status\" != 'completed' OR \"sleep_queue\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_queue_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_queue_cancelled_requires_cancelled_at",
+					"value": "\"sleep_queue\".\"status\" != 'cancelled' OR \"sleep_queue\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"conflict_policy": {
+					"name": "conflict_policy",
+					"type": "workflow_run_conflict_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_at": {
+					"name": "next_publish_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR (\"workflow_run_outbox\".\"first_published_at\" IS NOT NULL AND \"workflow_run_outbox\".\"next_publish_attempt_at\" IS NOT NULL)"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_conflict_policy": {
+			"name": "schedule_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_conflict_policy": {
+			"name": "workflow_run_conflict_policy",
+			"schema": "public",
+			"values": ["error", "return_existing"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -99,6 +99,13 @@
 			"when": 1785581384068,
 			"tag": "0013_youthful_payback",
 			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1785598153377,
+			"tag": "0014_acoustic_baron_zemo",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
@@ -24,7 +24,7 @@ export type WorkflowRunOutboxRowClaimed = WorkflowRunOutboxRow & { status: "clai
 
 interface ClaimFilter {
 	workflows: NonEmptyArray<{ name: string; versionId: string }>;
-	shards?: string[];
+	pools?: string[];
 }
 
 export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
@@ -200,9 +200,9 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 							)
 						)
 					),
-					isNonEmptyArray(filters.shards)
-						? inArray(workflowRunOutbox.shard, filters.shards)
-						: isNull(workflowRunOutbox.shard)
+					isNonEmptyArray(filters.pools)
+						? inArray(workflowRunOutbox.pool, filters.pools)
+						: isNull(workflowRunOutbox.pool)
 				)
 			)
 			.orderBy(workflowRunOutbox.rank, workflowRunOutbox.id)

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -378,7 +378,7 @@ export const workflowRunOutbox = pgTable(
 		workflowRunId: text("workflow_run_id").notNull(),
 		workflowName: text("workflow_name").notNull(),
 		workflowVersionId: text("workflow_version_id").notNull(),
-		shard: text("shard"),
+		pool: text("pool"),
 		rank: doublePrecision("rank").notNull(),
 
 		status: workflowRunOutboxStatusEnum("status").notNull(),
@@ -396,9 +396,9 @@ export const workflowRunOutbox = pgTable(
 	(table) => [
 		uniqueIndex("uqidx_workflow_run_outbox_workflow_run_id").on(table.workflowRunId),
 
-		// Claim path: worker claims rank ordered pending rows by workflow identity and shard.
+		// Claim path: worker claims rank ordered pending rows by workflow identity and pool.
 		index("idx_workflow_run_outbox_claim_pending")
-			.on(table.namespaceId, table.workflowName, table.workflowVersionId, table.shard, table.rank, table.id)
+			.on(table.namespaceId, table.workflowName, table.workflowVersionId, table.pool, table.rank, table.id)
 			.where(sql`${table.status} = 'pending'`),
 
 		// Daemon list paths: broad scans over one status to feed broker.

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -20,7 +20,7 @@ import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
 export interface CancelledParentRun {
 	namespaceId: NamespaceId;
 	runId: string;
-	shard: string | undefined;
+	pool: string | undefined;
 }
 
 export const createChildRunCanceller = () => ({
@@ -96,7 +96,7 @@ export const createChildRunCanceller = () => ({
 				input: parentRun.runId,
 				inputHash,
 				options: {
-					shard: parentRun.shard,
+					pool: parentRun.pool,
 					retry: {
 						type: "exponential",
 						maxAttempts: Number.MAX_SAFE_INTEGER,

--- a/sdk/server/src/service/workflow-run-outbox.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-outbox.integration.test.ts
@@ -7,7 +7,7 @@ import { createWorkflowRunOutboxService } from "../service/workflow-run-outbox";
 import { withFakeClock } from "../testing/clock";
 import { daemonContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
-import { claimRun, seedClaimedRun, seedPublishedRun, seedQueuedRun, seedShardedQueuedRun } from "../testing/run-seed";
+import { claimRun, seedClaimedRun, seedPooledQueuedRun, seedPublishedRun, seedQueuedRun } from "../testing/run-seed";
 
 const withHarness = createServiceHarness();
 
@@ -56,9 +56,9 @@ describe("WorkflowRunOutboxService.claimReady", () => {
 			expect(result).toHaveLength(0);
 		}));
 
-	test("does not return a pending row outside the requested shards", () =>
+	test("does not return a pending row outside the requested pools", () =>
 		withHarness(async ({ context, repos }) => {
-			// The seeded run has no shard; requesting a specific shard excludes it.
+			// The seeded run has no pool; requesting a specific pool excludes it.
 			const { workflowName, workflowVersionId } = await seedQueuedRun({
 				namespaceRequestContext: context,
 				repos,
@@ -67,16 +67,16 @@ describe("WorkflowRunOutboxService.claimReady", () => {
 			const outboxService = createWorkflowRunOutboxService({ repos });
 			const result = await outboxService.claimReady(context, {
 				workflows: [{ name: workflowName, versionId: workflowVersionId }],
-				shards: ["eu-east"],
+				pools: ["eu-east"],
 				limit: 10,
 			});
 
 			expect(result).toHaveLength(0);
 		}));
 
-	test("claims a pending row in the requested shard", () =>
+	test("claims a pending row in the requested pool", () =>
 		withHarness(async ({ context, repos }) => {
-			const { runId, workflowName, workflowVersionId, shard } = await seedShardedQueuedRun({
+			const { runId, workflowName, workflowVersionId, pool } = await seedPooledQueuedRun({
 				namespaceRequestContext: context,
 				repos,
 			});
@@ -84,16 +84,16 @@ describe("WorkflowRunOutboxService.claimReady", () => {
 			const outboxService = createWorkflowRunOutboxService({ repos });
 			const result = await outboxService.claimReady(context, {
 				workflows: [{ name: workflowName, versionId: workflowVersionId }],
-				shards: [shard],
+				pools: [pool],
 				limit: 10,
 			});
 
 			expect(result).toEqual([expect.objectContaining({ id: runId })]);
 		}));
 
-	test("does not return a sharded row when the request has no shards", () =>
+	test("does not return a pooled row when the request has no pools", () =>
 		withHarness(async ({ context, repos }) => {
-			const { workflowName, workflowVersionId } = await seedShardedQueuedRun({
+			const { workflowName, workflowVersionId } = await seedPooledQueuedRun({
 				namespaceRequestContext: context,
 				repos,
 			});

--- a/sdk/server/src/service/workflow-run-outbox.ts
+++ b/sdk/server/src/service/workflow-run-outbox.ts
@@ -32,5 +32,5 @@ async function claimPending(
 		return [];
 	}
 
-	return repo.claimPending(context.namespaceId, { workflows, shards: request.shards }, request.limit);
+	return repo.claimPending(context.namespaceId, { workflows, pools: request.pools }, request.limit);
 }

--- a/sdk/server/src/service/workflow-run-state-machine.test.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.test.ts
@@ -1,0 +1,221 @@
+import { workflowRunStateByStatus } from "@aikirun/testing/data-factory/workflow/run";
+import type { WorkflowRunStateRequest } from "@aikirun/types/api/workflow-run";
+import {
+	WORKFLOW_RUN_QUEUED_REASON,
+	WORKFLOW_RUN_SCHEDULED_REASON,
+	WORKFLOW_RUN_STATUSES,
+	type WorkflowRunId,
+	type WorkflowRunStatus,
+} from "@aikirun/types/workflow/run";
+
+import { assertIsValidWorkflowRunStateTransition, convertDurationToTimestamp } from "./workflow-run-state-machine";
+import { describe, expect, test } from "bun:test";
+import { InvalidWorkflowRunStateTransitionError } from "../errors";
+
+describe("assertIsValidWorkflowRunStateTransition", () => {
+	function attemptTransition(fromStatus: WorkflowRunStatus, to: { status: WorkflowRunStatus; reason?: string }): void {
+		assertIsValidWorkflowRunStateTransition(
+			"run-1" as WorkflowRunId,
+			workflowRunStateByStatus[fromStatus],
+			to as WorkflowRunStateRequest
+		);
+	}
+
+	const validTransitions: Record<WorkflowRunStatus, Partial<Record<WorkflowRunStatus, { reason: string } | null>>> = {
+		scheduled: { queued: null, paused: null, cancelled: null },
+		queued: { running: null, paused: null, cancelled: null, failed: null, stalled: null },
+		running: {
+			queued: { reason: "task_retry" },
+			running: null,
+			paused: null,
+			sleeping: null,
+			awaiting_event: null,
+			awaiting_retry: null,
+			awaiting_child_workflow: null,
+			cancelled: null,
+			completed: null,
+			failed: null,
+		},
+		paused: { scheduled: { reason: "resumption" }, cancelled: null },
+		sleeping: { scheduled: { reason: "wakeup_early" }, queued: { reason: "wakeup" }, cancelled: null },
+		awaiting_event: { scheduled: { reason: "event" }, queued: { reason: "event" }, cancelled: null },
+		awaiting_retry: { queued: { reason: "retry" }, cancelled: null },
+		awaiting_child_workflow: {
+			scheduled: { reason: "child_workflow" },
+			queued: { reason: "child_workflow" },
+			cancelled: null,
+		},
+		stalled: { scheduled: { reason: "redelivery" }, cancelled: null },
+		cancelled: {},
+		completed: {},
+		failed: { awaiting_retry: null },
+	};
+
+	const possibleReasons = Array.from(new Set([...WORKFLOW_RUN_SCHEDULED_REASON, ...WORKFLOW_RUN_QUEUED_REASON]));
+
+	for (const fromStatus of WORKFLOW_RUN_STATUSES) {
+		describe(`from ${fromStatus}`, () => {
+			const validDestinations = validTransitions[fromStatus];
+
+			for (const toStatus of WORKFLOW_RUN_STATUSES) {
+				const validDestination = validDestinations[toStatus];
+
+				if (validDestination === undefined) {
+					test(`declines to ${toStatus}`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus })).toThrow(
+							InvalidWorkflowRunStateTransitionError
+						);
+					});
+					continue;
+				}
+
+				const validReason = validDestination?.reason;
+
+				test(`accepts to ${toStatus} ${validReason ? `(${validReason})` : ""}`, () => {
+					expect(() => attemptTransition(fromStatus, { status: toStatus, reason: validReason })).not.toThrow();
+				});
+
+				if (!validReason) {
+					continue;
+				}
+				for (const reason of possibleReasons) {
+					if (reason === validReason) {
+						continue;
+					}
+					test(`declines to ${toStatus} (${reason})`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus, reason })).toThrow(
+							InvalidWorkflowRunStateTransitionError
+						);
+					});
+				}
+			}
+		});
+	}
+});
+
+describe("convertDurationToTimestamp", () => {
+	const now = 1_000;
+
+	test("scheduled: scheduledInMs becomes an absolute scheduledAt", () => {
+		expect(convertDurationToTimestamp({ status: "scheduled", reason: "wakeup", scheduledInMs: 500 }, now)).toEqual({
+			status: "scheduled",
+			reason: "wakeup",
+			scheduledAt: 1_500,
+		});
+	});
+
+	test("sleeping: durationMs becomes an absolute wakeupAt", () => {
+		expect(convertDurationToTimestamp({ status: "sleeping", sleepName: "nap", durationMs: 500 }, now)).toEqual({
+			status: "sleeping",
+			sleepName: "nap",
+			wakeupAt: 1_500,
+		});
+	});
+
+	test("awaiting_event with a timeout: timeoutInMs becomes an absolute timeoutAt", () => {
+		expect(
+			convertDurationToTimestamp({ status: "awaiting_event", eventName: "order-shipped", timeoutInMs: 500 }, now)
+		).toEqual({ status: "awaiting_event", eventName: "order-shipped", timeoutAt: 1_500 });
+	});
+
+	test("awaiting_event without a timeout: passes through with no timeoutAt", () => {
+		expect(convertDurationToTimestamp({ status: "awaiting_event", eventName: "order-shipped" }, now)).toEqual({
+			status: "awaiting_event",
+			eventName: "order-shipped",
+		});
+	});
+
+	test("awaiting_retry caused by a task: nextAttemptInMs becomes nextAttemptAt", () => {
+		expect(
+			convertDurationToTimestamp(
+				{ status: "awaiting_retry", cause: "task", taskId: "task-1", nextAttemptInMs: 500 },
+				now
+			)
+		).toEqual({ status: "awaiting_retry", cause: "task", taskId: "task-1", nextAttemptAt: 1_500 });
+	});
+
+	test("awaiting_retry caused by a child workflow: nextAttemptInMs becomes nextAttemptAt", () => {
+		expect(
+			convertDurationToTimestamp(
+				{ status: "awaiting_retry", cause: "child_workflow", childWorkflowRunId: "child-1", nextAttemptInMs: 500 },
+				now
+			)
+		).toEqual({
+			status: "awaiting_retry",
+			cause: "child_workflow",
+			childWorkflowRunId: "child-1",
+			nextAttemptAt: 1_500,
+		});
+	});
+
+	test("awaiting_retry caused by self: nextAttemptInMs becomes nextAttemptAt", () => {
+		const error = { name: "Error", message: "boom" };
+		expect(
+			convertDurationToTimestamp({ status: "awaiting_retry", cause: "self", error, nextAttemptInMs: 500 }, now)
+		).toEqual({ status: "awaiting_retry", cause: "self", error, nextAttemptAt: 1_500 });
+	});
+
+	test("awaiting_child_workflow with a timeout: timeoutInMs becomes an absolute timeoutAt", () => {
+		expect(
+			convertDurationToTimestamp(
+				{
+					status: "awaiting_child_workflow",
+					childWorkflowRunId: "child-1",
+					childWorkflowRunStatus: "completed",
+					timeoutInMs: 500,
+				},
+				now
+			)
+		).toEqual({
+			status: "awaiting_child_workflow",
+			childWorkflowRunId: "child-1",
+			childWorkflowRunStatus: "completed",
+			timeoutAt: 1_500,
+		});
+	});
+
+	test("awaiting_child_workflow without a timeout: passes through with no timeoutAt", () => {
+		expect(
+			convertDurationToTimestamp(
+				{ status: "awaiting_child_workflow", childWorkflowRunId: "child-1", childWorkflowRunStatus: "completed" },
+				now
+			)
+		).toEqual({
+			status: "awaiting_child_workflow",
+			childWorkflowRunId: "child-1",
+			childWorkflowRunStatus: "completed",
+		});
+	});
+
+	test("completed with an output: keeps the output", () => {
+		expect(convertDurationToTimestamp({ status: "completed", output: { orderId: "order-7" } }, now)).toEqual({
+			status: "completed",
+			output: { orderId: "order-7" },
+		});
+	});
+
+	test("completed without an output: normalizes output to undefined", () => {
+		expect(convertDurationToTimestamp({ status: "completed" }, now)).toEqual({
+			status: "completed",
+			output: undefined,
+		});
+	});
+
+	Object.entries({
+		queued: { status: "queued", reason: "new" },
+		running: { status: "running" },
+		paused: { status: "paused" },
+		stalled: { status: "stalled" },
+		cancelled: { status: "cancelled" },
+		failed: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+	} satisfies {
+		[Status in Exclude<
+			WorkflowRunStatus,
+			"scheduled" | "sleeping" | "awaiting_event" | "awaiting_retry" | "awaiting_child_workflow" | "completed"
+		>]: Extract<WorkflowRunStateRequest, { status: Status }>;
+	}).forEach(([status, request]) => {
+		test(`${status}: carries no duration and passes through unchanged`, () => {
+			expect(convertDurationToTimestamp(request, now)).toEqual(request);
+		});
+	});
+});

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -237,7 +237,7 @@ async function transitionStateInTx(
 	}
 
 	const now = Date.now();
-	let toState = convertDurationsToTimestamps(request.state, now);
+	let toState = convertDurationToTimestamp(request.state, now);
 
 	context.logger.info("Workflow state transition", {
 		"aiki.runId": runId,
@@ -499,7 +499,7 @@ async function notifyParentOfStateChangeIfNecessary(
 	}
 }
 
-function convertDurationsToTimestamps(request: WorkflowRunStateRequest, now: number): WorkflowRunState {
+export function convertDurationToTimestamp(request: WorkflowRunStateRequest, now: number): WorkflowRunState {
 	if (request.status === "scheduled") {
 		return {
 			status: "scheduled",

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -312,7 +312,7 @@ async function transitionStateInTx(
 
 	if (toState.status === "cancelled") {
 		await discardStaleTasks(runId, ["running", "awaiting_retry"], txRepos);
-		await childRunCanceller.cancel([{ namespaceId, runId, shard: run.options?.shard }], txRepos, context.logger);
+		await childRunCanceller.cancel([{ namespaceId, runId, pool: run.options?.pool }], txRepos, context.logger);
 	}
 
 	if (isTerminalWorkflowRunStatus(toState.status) && propsRequiredNonNull(run, "parentWorkflowRunId")) {

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -461,10 +461,10 @@ export const createWorkflowRunService = ({
 		});
 		return {
 			runs: childRuns.map((child) => {
-				const shard = child.options?.shard;
+				const pool = child.options?.pool;
 				return {
 					id: child.id,
-					options: shard ? { shard } : undefined,
+					options: pool ? { pool } : undefined,
 				};
 			}),
 		};
@@ -505,7 +505,7 @@ export const createWorkflowRunService = ({
 				cancelledRunsMeta.push({
 					namespaceId,
 					runId: run.id,
-					shard: run.options?.shard,
+					pool: run.options?.pool,
 				});
 			}
 

--- a/sdk/server/src/testing/run-seed.ts
+++ b/sdk/server/src/testing/run-seed.ts
@@ -37,13 +37,13 @@ export async function seedQueuedRun(deps: SeedQueuedRunDeps) {
 	return _seedQueuedRun(deps, undefined);
 }
 
-export async function seedShardedQueuedRun(deps: SeedQueuedRunDeps) {
-	const shard = "warehouse-eu";
-	const seeded = await _seedQueuedRun(deps, shard);
-	return { ...seeded, shard };
+export async function seedPooledQueuedRun(deps: SeedQueuedRunDeps) {
+	const pool = "warehouse-eu";
+	const seeded = await _seedQueuedRun(deps, pool);
+	return { ...seeded, pool };
 }
 
-async function _seedQueuedRun(deps: SeedQueuedRunDeps, shard: string | undefined) {
+async function _seedQueuedRun(deps: SeedQueuedRunDeps, pool: string | undefined) {
 	const { repos } = deps;
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
@@ -53,7 +53,7 @@ async function _seedQueuedRun(deps: SeedQueuedRunDeps, shard: string | undefined
 		name: seededWorkflow.name,
 		versionId: seededWorkflow.versionId,
 		input: { orderId: "order-7" },
-		options: shard ? { shard } : undefined,
+		options: pool ? { pool } : undefined,
 	});
 
 	await processImminentScheduledRuns(daemonContext, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -65,11 +65,11 @@ export interface WorkerParams {
 
 export interface WorkerStartOptions {
 	/**
-	 * Optional array of shards this worker should process.
-	 * When provided, the worker will only subscribe to registered workflows within that shard.
-	 * When omitted, the worker subscribes to unsharded registered workflows.
+	 * Optional array of pools this worker should process.
+	 * When provided, the worker will only subscribe to registered workflows within those pools.
+	 * When omitted, the worker subscribes to registered workflows not assigned to a pool.
 	 */
-	shards?: string[];
+	pools?: string[];
 	/**
 	 * Optional reference for external correlation.
 	 * Use this to associate the worker with external identifiers.
@@ -162,7 +162,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 		this.primarySubscriber = createPrimarySubscriber({
 			workerId: this.id,
 			workflows,
-			shards: this.startOptions.shards,
+			pools: this.startOptions.pools,
 			logger: this.logger.child({ "aiki.subscriber": "primary" }),
 			signal,
 		});
@@ -175,7 +175,7 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			this.backupSubscriber = createBackupSubscriber({
 				workerId: this.id,
 				workflows,
-				shards: this.startOptions.shards,
+				pools: this.startOptions.pools,
 				logger: this.logger.child({ "aiki.subscriber": "backup" }),
 				signal,
 			});

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -98,13 +98,13 @@ describe("schedule", () => {
 			retry: { type: "fixed", maxAttempts: 5, delayMs: 300 },
 		});
 
-		test("opt carries retry and shard to every fired run", () =>
+		test("opt carries retry and pool to every fired run", () =>
 			withFakeClient(async (client) => {
 				client.api.schedule.activateV1.once(
 					intervalScheduleActivateRequest.build({
 						workflowRunOptions: {
 							retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 },
-							shard: "eu",
+							pool: "eu",
 						},
 					}),
 					{ schedule: intervalScheduleFactory.build() }
@@ -113,7 +113,7 @@ describe("schedule", () => {
 				await schedule({ type: "interval", every: { seconds: 1 } })
 					.with()
 					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-					.opt("workflowRun.shard", "eu")
+					.opt("workflowRun.pool", "eu")
 					.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
 			}));
 
@@ -137,7 +137,7 @@ describe("schedule", () => {
 					intervalScheduleActivateRequest.build({
 						workflowRunOptions: {
 							retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 },
-							shard: "eu",
+							pool: "eu",
 						},
 					}),
 					{ schedule: intervalScheduleFactory.build() }
@@ -146,7 +146,7 @@ describe("schedule", () => {
 				await schedule({ type: "interval", every: { seconds: 1 } })
 					.with()
 					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-					.opt("workflowRun.shard", "eu")
+					.opt("workflowRun.pool", "eu")
 					.activate(client, retryingSyncInventoryWorkflow, { warehouseId: "wh-1" });
 			}));
 	});

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -696,13 +696,13 @@ describe("creating a workflow run", () => {
 						name: "greet",
 						versionId: "1.0.0",
 						input: "world",
-						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 }, shard: "eu-west" },
+						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 }, pool: "eu-west" },
 					},
 					{ id: newRunRecord.id }
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
 
-				const handle = await workflowVersion.with().opt("shard", "eu-west").start(client, "world");
+				const handle = await workflowVersion.with().opt("pool", "eu-west").start(client, "world");
 
 				expect(handle.run.id).toBe(newRunRecord.id);
 			}));
@@ -737,14 +737,14 @@ describe("creating a workflow run", () => {
 				expect(childHandle.run.id).toBe(childRunRecord.id);
 			}));
 
-		test("propagates the parent's shard to the child run", () =>
+		test("propagates the parent's pool to the child run", () =>
 			withFakeClient(async (client) => {
 				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
 					async handler(_run, payload: string) {
 						return payload;
 					},
 				});
-				const parentRunRecord = runningWorkflowRunRecordFactory.build({ options: { shard: "eu-west" } });
+				const parentRunRecord = runningWorkflowRunRecordFactory.build({ options: { pool: "eu-west" } });
 				const parentRun = createTestWorkflowRun(client, parentRunRecord);
 				const childRunRecord = runningWorkflowRunRecordFactory.build();
 
@@ -754,7 +754,7 @@ describe("creating a workflow run", () => {
 						versionId: "1.0.0",
 						input: "payload",
 						parentWorkflowRunId: parentRunRecord.id,
-						options: { shard: "eu-west" },
+						options: { pool: "eu-west" },
 					},
 					{ id: childRunRecord.id }
 				);

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -209,13 +209,13 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			await this.throwNonDeterminismError(parentRun, parentRunHandle, inputHash, referenceId, replayManifest);
 		}
 
-		const shard = parentRun.options.shard;
+		const pool = parentRun.options.pool;
 		const { id: newRunId } = await client.api.workflowRun.createV1({
 			name: this.name,
 			versionId: this.versionId,
 			input,
 			parentWorkflowRunId: parentRun.id,
-			options: shard === undefined ? startOptions : { ...startOptions, shard },
+			options: pool === undefined ? startOptions : { ...startOptions, pool },
 		});
 		const { run: newRun } = await client.api.workflowRun.getByIdV1({ id: newRunId });
 

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -281,7 +281,7 @@ export interface WorkflowRunListChildRunsRequestV1 {
 }
 
 export interface WorkflowRunListChildRunsResponseV1 {
-	runs: Array<{ id: string; options?: { shard?: string } }>;
+	runs: Array<{ id: string; options?: { pool?: string } }>;
 }
 
 export interface WorkflowRunCancelByIdsRequestV1 {
@@ -294,7 +294,7 @@ export interface WorkflowRunCancelByIdsResponseV1 {
 
 export interface WorkflowRunClaimReadyRequestV1 {
 	workflows: Array<{ name: string; versionId: string }>;
-	shards?: string[];
+	pools?: string[];
 	limit: number;
 }
 

--- a/types/src/infra/queue/publisher.ts
+++ b/types/src/infra/queue/publisher.ts
@@ -7,7 +7,7 @@ export interface ReadyWorkflowRun {
 	name: string;
 	versionId: string;
 	rank: number;
-	shard?: string;
+	pool?: string;
 }
 
 export type PublishRunsResultBucket = Array<{ run: ReadyWorkflowRun }>;

--- a/types/src/infra/queue/subscriber.ts
+++ b/types/src/infra/queue/subscriber.ts
@@ -23,7 +23,7 @@ export interface Subscriber {
 export interface SubscriberContext {
 	workerId: string;
 	workflows: NonEmptyArray<WorkflowMeta>;
-	shards?: string[];
+	pools?: string[];
 	logger: Logger;
 	signal: AbortSignal;
 }

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -37,7 +37,7 @@ export interface ScheduleReference {
 	conflictPolicy?: ScheduleConflictPolicy;
 }
 
-export type ScheduledWorkflowStartOptions = Pick<WorkflowStartOptions, "retry" | "shard">;
+export type ScheduledWorkflowStartOptions = Pick<WorkflowStartOptions, "retry" | "pool">;
 
 export interface ScheduleActivateOptions {
 	reference?: ScheduleReference;

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -55,7 +55,7 @@ export interface WorkflowStartOptions {
 	retry?: RetryStrategy;
 	trigger?: TriggerStrategy;
 	reference?: WorkflowReference;
-	shard?: string;
+	pool?: string;
 }
 
 export type WorkflowDefinitionStartOptions = Pick<WorkflowStartOptions, "retry">;


### PR DESCRIPTION
## Problem

A run can carry an optional routing label: only workers that declare the label claim the run, and workers that declare none see only unlabeled runs. The label was called `shard`, but shards are system-assigned, exhaustive, single-owner scaling units — none of which applies here. What Aiki has is what CI and infra systems call a pool: name a group of workers, route work at the group. The old name invites expectations of balancing and exclusivity that don't exist, and takes the word a real partitioning mechanism would deserve.

## Solution

A pure rename across every surface the label touches: start options, schedules, worker options, the claim filter, the transport contracts, the outbox column, dashboard, docs. Migration 0014 renames the outbox column and converts the key inside stored run and schedule options JSON — schedules stamp their stored options onto every run they fire, so without the conversion existing schedules would silently stop routing to their pool.

## Breaking changes

- `WorkflowStartOptions.shard` → `pool`; builder keys `.opt("shard", …)` → `.opt("pool", …)` and `.opt("workflowRun.shard", …)` → `.opt("workflowRun.pool", …)`.
- `WorkerStartOptions.shards` → `pools`.
- Claim request field `shards` → `pools`.
- Custom transport contracts: `ReadyWorkflowRun.shard` → `pool`, `SubscriberContext.shards` → `pools`.
- List-child-runs response: `options.shard` → `options.pool`.
- Migration 0014 renames `workflow_run_outbox.shard` to `pool` and converts the key in stored run and schedule options JSON.
