### PR TITLE
Ready-handshake gate for blocking Redis connections

### DIFF
--- a/sdk/adapter/redis/src/connection.test.ts
+++ b/sdk/adapter/redis/src/connection.test.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "node:events";
+import type { Redis } from "ioredis";
+
+import { untilReadyHandshake } from "./connection";
+import { describe, expect, test } from "bun:test";
+
+function fakeRedis(status: "connecting" | "ready") {
+	return Object.assign(new EventEmitter(), { status }) as unknown as Redis;
+}
+
+describe("untilReadyHandshake", () => {
+	test("resolves immediately when the connection is already ready", async () => {
+		await untilReadyHandshake(fakeRedis("ready"));
+	});
+
+	test("resolves when the connection becomes ready", async () => {
+		const redis = fakeRedis("connecting");
+		const handshakeReadyPromise = untilReadyHandshake(redis);
+
+		redis.emit("ready");
+
+		await handshakeReadyPromise;
+	});
+
+	test("rejects when the connection closes before becoming ready", () => {
+		const redis = fakeRedis("connecting");
+		const handshakeReadyPromise = untilReadyHandshake(redis);
+
+		redis.emit("close");
+
+		expect(handshakeReadyPromise).rejects.toThrow("closed before completing the ready handshake");
+	});
+
+	test("removes both listeners after resolving", async () => {
+		const redis = fakeRedis("connecting");
+		const handshakeReadyPromise = untilReadyHandshake(redis);
+
+		redis.emit("ready");
+		await handshakeReadyPromise;
+
+		expect(redis.listenerCount("ready")).toBe(0);
+		expect(redis.listenerCount("close")).toBe(0);
+	});
+
+	test("removes both listeners after rejecting", async () => {
+		const redis = fakeRedis("connecting");
+		const handshakeReadyPromise = untilReadyHandshake(redis);
+
+		redis.emit("close");
+		expect(handshakeReadyPromise).rejects.toThrow();
+
+		expect(redis.listenerCount("ready")).toBe(0);
+		expect(redis.listenerCount("close")).toBe(0);
+	});
+});

--- a/sdk/adapter/redis/src/connection.ts
+++ b/sdk/adapter/redis/src/connection.ts
@@ -74,6 +74,29 @@ export const connectionTracker = (() => {
 })();
 
 /**
+ * Resolves when the connection's connect → ready handshake completes, rejecting
+ * if the connection closes first.
+ */
+export function untilReadyHandshake(redis: Redis): Promise<void> {
+	if (redis.status === "ready") {
+		return Promise.resolve();
+	}
+
+	return new Promise((resolve, reject) => {
+		const onReady = () => {
+			redis.off("close", onClose);
+			resolve();
+		};
+		const onClose = () => {
+			redis.off("ready", onReady);
+			reject(new Error("Redis connection closed before completing the ready handshake"));
+		};
+		redis.once("ready", onReady);
+		redis.once("close", onClose);
+	});
+}
+
+/**
  * Attaches connection-lifecycle supervision to an existing Redis client: a
  * watchdog over the "connect → ready" handshake that forces a reconnect if the
  * handshake stalls. ioredis's connectTimeout only covers the TCP connect; a

--- a/sdk/adapter/redis/src/queue/subscriber.ts
+++ b/sdk/adapter/redis/src/queue/subscriber.ts
@@ -10,7 +10,7 @@ import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 import { Redis } from "ioredis";
 
 import { getWorkflowQueueNames } from "./key";
-import { attachConnectionSupervisor, type RedisConnectionParams } from "../connection";
+import { attachConnectionSupervisor, type RedisConnectionParams, untilReadyHandshake } from "../connection";
 
 export interface RedisSubscriberOptions {
 	maxRetryIntervalMs?: number;
@@ -116,12 +116,18 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 			{ once: true }
 		);
 
+		let completedReadyHandshake = false;
 		const queueNames = getWorkflowQueueNames(workflows, pools);
 
 		return {
 			getNextDelay,
 
 			async getReadyRuns(limit: number): Promise<WorkflowRunMessage[]> {
+				if (!completedReadyHandshake) {
+					await untilReadyHandshake(redis);
+					completedReadyHandshake = true;
+				}
+
 				const shuffledQueueNames = shuffleArray(queueNames);
 				const firstItem = (await redis.bzpopmin(...shuffledQueueNames, 0)) as
 					| [key: string, member: WorkflowRunId, score: string]

--- a/sdk/adapter/redis/src/timer/priority-queue.ts
+++ b/sdk/adapter/redis/src/timer/priority-queue.ts
@@ -10,7 +10,7 @@ import type {
 } from "@aikirun/types/infra/timer";
 import type { Redis } from "ioredis";
 
-import { attachConnectionSupervisor, connectionTracker } from "../connection";
+import { attachConnectionSupervisor, connectionTracker, untilReadyHandshake } from "../connection";
 
 function encodeMember(type: TimerType, id: string): string {
 	return `${type}:${id}`;
@@ -132,6 +132,8 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 					maxRetriesPerRequest: 0,
 					enableOfflineQueue: false,
 				});
+
+				let completedReadyHandshake = false;
 				const connectionSupervisor = attachConnectionSupervisor(redisDuplicate, { logger });
 				let closed = false;
 
@@ -143,6 +145,11 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 					 * peek-after-pop will rediscover them.
 					 */
 					async wait(timeoutSeconds: number): Promise<number> {
+						if (!completedReadyHandshake) {
+							await untilReadyHandshake(redisDuplicate);
+							completedReadyHandshake = true;
+						}
+
 						const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
 						if (result === null) {
 							await redisDuplicate.del(signalKey);


### PR DESCRIPTION
The due-timers consumer's signal waiter (BRPOP) and the worker's Redis subscriber (BZPOPMIN) hold blocking connections with ioredis's offline queue disabled, so connection failures surface to their retry loops instead of buffering inside the client. The cost: both send their first command while the connect → ready handshake is still in flight, and without an offline queue that command fails instantly. Every server boot logs one transient "Due timers consumer failed, will retry"; the subscriber hits the same race silently.

`untilReadyHandshake` resolves on a connection's first ready event and rejects if it closes first. Each consumer awaits it before its first command only, so nothing changes after startup — a mid-run drop still fails fast into the retry loop, and an unreachable Redis at boot still warns and paces, since each failed connect attempt fires close. Enabling the offline queue instead would silence outage failures entirely, not just the boot race.
