### PR TITLE
Retire orphaned scheduled reasons, split wait-timeout reasons

### DIFF
--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -11,6 +11,8 @@ Before writing any test, study the exemplars for its tier and match their idioms
   seeding, fake clock, assertion shapes.
 - `sdk/workflow/src/run/sleeper.test.ts` — timestamps as authored data.
 - `sdk/workflow/src/task.test.ts` — boundary-value config knobs, file-local helpers.
+- `sdk/server/src/service/workflow-run-state-machine.test.ts` — exhaustive legality matrix driven
+  from a typed case table.
 
 ## Determinism
 
@@ -96,3 +98,8 @@ Before writing any test, study the exemplars for its tier and match their idioms
   `satisfies Record<Exclude<StatusUnion, "claimed">, unknown>`, then `Object.entries(...)` into
   a test per key. The `Record` over `Exclude` makes the table complete by construction: a new
   union member fails the build until it gets an entry, and a typo'd key never compiles.
+- When a case table's cells carry a payload, type the payload so a degenerate entry cannot
+  compile. The legality-matrix cell shape is `{ reasons?: NonEmptyArray<string> }`: an absent
+  cell is the illegal case, `{}` is legal-unguarded, and `NonEmptyArray` forbids the empty guard
+  list a plain `string[]` would accept — `{ reasons: [] }` would generate zero accepts tests and
+  silently decline every reason.

--- a/app/dashboard/src/components/run-detail/timeline-lookups.ts
+++ b/app/dashboard/src/components/run-detail/timeline-lookups.ts
@@ -78,12 +78,18 @@ export function buildTimelineLookups(
 			}
 
 			// Handle event - look up the previous awaiting_event transition
-			if (reason === "event") {
+			if (reason === "event" || reason === "event_wait_timeout") {
 				for (let j = i - 1; j >= 0; j--) {
 					const prev = transitions[j];
 					if (prev.type === "workflow_run" && prev.state.status === "awaiting_event") {
 						const eventName = prev.state.eventName;
 						context.eventDataName = eventName;
+						if (reason === "event_wait_timeout") {
+							context.eventTimedOut = true;
+							break;
+						}
+						// The wait row carries the event data; it also classifies rows written before the
+						// reason split, whose timed-out waits are labelled "event".
 						const queue = eventWaitQueues[eventName];
 						if (queue?.eventWaits.length > 0) {
 							let eventIndex = 0;
@@ -110,13 +116,19 @@ export function buildTimelineLookups(
 			}
 
 			// Handle child_workflow - look up the previous awaiting_child_workflow transition
-			if (reason === "child_workflow") {
+			if (reason === "child_workflow" || reason === "child_workflow_wait_timeout") {
 				for (let j = i - 1; j >= 0; j--) {
 					const prev = transitions[j];
 					if (prev.type === "workflow_run" && prev.state.status === "awaiting_child_workflow") {
 						const childId = prev.state.childWorkflowRunId;
 						const waitForStatus = prev.state.childWorkflowRunStatus;
 						context.scheduledByChildWorkflowRunId = childId;
+						if (reason === "child_workflow_wait_timeout") {
+							context.childWorkflowTimedOut = true;
+							break;
+						}
+						// The wait row carries the child's terminal status; it also classifies rows written
+						// before the reason split, whose timed-out waits are labelled "child_workflow".
 						const childInfo = childWorkflowById.get(childId);
 						const waitQueue = childInfo?.childWorkflowRunWaitQueues[waitForStatus];
 						const waits = waitQueue?.childWorkflowRunWaits;

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -30,9 +30,6 @@ export const workflowRunStateScheduledSchema = type({
 	scheduledAt: "number > 0",
 	reason: "'new'",
 })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'retry'" })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'task_retry'" })
-	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'wakeup'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'wakeup_early'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'resumption'" })
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'event'" })
@@ -40,7 +37,7 @@ export const workflowRunStateScheduledSchema = type({
 	.or({ status: "'scheduled'", scheduledAt: "number > 0", reason: "'redelivery'" });
 
 const workflowRunQueuedReasonSchema = type(
-	"'new' | 'retry' | 'task_retry' | 'wakeup' | 'wakeup_early' | 'resumption' | 'event' | 'child_workflow' | 'recovery' | 'redelivery'"
+	"'new' | 'retry' | 'task_retry' | 'wakeup' | 'wakeup_early' | 'resumption' | 'event' | 'event_wait_timeout' | 'child_workflow' | 'child_workflow_wait_timeout' | 'recovery' | 'redelivery'"
 );
 
 export const workflowRunStateQueuedSchema = type({
@@ -188,12 +185,8 @@ export const workflowRunSchema = type({
 export const workflowRunStateScheduledRequestOptimisticSchema = type({
 	status: "'scheduled'",
 	scheduledInMs: "number.integer >= 0",
-	reason: "'retry'",
-})
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'task_retry'" })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'wakeup'" })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'event'" })
-	.or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'child_workflow'" });
+	reason: "'event'",
+}).or({ status: "'scheduled'", scheduledInMs: "number.integer >= 0", reason: "'child_workflow'" });
 
 export const workflowRunStateScheduledRequestPessimisticSchema = type({
 	status: "'scheduled'",

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -136,7 +136,7 @@ async function processChunk(
 		});
 
 		const stateTransitionId = ulid();
-		const toState: WorkflowRunStateQueued = { status: "queued", reason: "child_workflow" };
+		const toState: WorkflowRunStateQueued = { status: "queued", reason: "child_workflow_wait_timeout" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -135,7 +135,7 @@ async function processChunk(
 		});
 
 		const stateTransitionId = ulid();
-		const toState: WorkflowRunStateQueued = { status: "queued", reason: "event" };
+		const toState: WorkflowRunStateQueued = { status: "queued", reason: "event_wait_timeout" };
 		stateTransitionEntries.push({
 			id: stateTransitionId,
 			workflowRunId: run.id,

--- a/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
@@ -8,7 +8,7 @@ import { createChildRunCanceller } from "../service/cancel-child-runs";
 import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
 import { daemonContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
-import { seedClaimedRun, seedStalledRun } from "../testing/run-seed";
+import { seedClaimedRun, seedScheduledRun, seedStalledRun } from "../testing/run-seed";
 
 const withHarness = createServiceHarness();
 
@@ -154,6 +154,164 @@ describe("WorkflowRunStateMachineService transition preconditions", () => {
 					status: "running",
 					revision: revisionWhenClaimed,
 					attempts: attemptsWhenClaimed,
+				})
+			);
+		}));
+});
+
+describe("WorkflowRunStateMachineService attempt counting", () => {
+	test("entering awaiting_retry charges no attempt", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const result = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: {
+					status: "awaiting_retry",
+					cause: "self",
+					error: { name: "Error", message: "boom" },
+					nextAttemptInMs: 0,
+				},
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			expect(result).toEqual({
+				revision: revisionWhenClaimed + 1,
+				state: {
+					status: "awaiting_retry",
+					cause: "self",
+					error: { name: "Error", message: "boom" },
+					nextAttemptAt: expect.any(Number),
+				},
+				attempts: attemptsWhenClaimed,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "awaiting_retry",
+					revision: result.revision,
+					attempts: result.attempts,
+				})
+			);
+		}));
+
+	test("re-queueing a retry from awaiting_retry charges exactly one attempt", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const awaitingRetryRun = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: {
+					status: "awaiting_retry",
+					cause: "self",
+					error: { name: "Error", message: "boom" },
+					nextAttemptInMs: 0,
+				},
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			const result = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "queued", reason: "retry" },
+				expectedRevision: awaitingRetryRun.revision,
+			});
+
+			expect(result).toEqual({
+				revision: awaitingRetryRun.revision + 1,
+				state: { status: "queued", reason: "retry" },
+				attempts: attemptsWhenClaimed + 1,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "queued",
+					revision: result.revision,
+					attempts: result.attempts,
+					state: { status: "queued", reason: "retry" },
+				})
+			);
+		}));
+
+	test("a task_retry re-queue charges no attempt", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const result = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "queued", reason: "task_retry" },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			expect(result).toEqual({
+				revision: revisionWhenClaimed + 1,
+				state: { status: "queued", reason: "task_retry" },
+				attempts: attemptsWhenClaimed,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "queued",
+					revision: result.revision,
+					attempts: result.attempts,
+					state: { status: "queued", reason: "task_retry" },
+				})
+			);
+		}));
+
+	test("a non-retry promotion from scheduled charges no attempt", () =>
+		withHarness(async ({ context, repos }) => {
+			const { runId, revisionWhenScheduled, attemptsWhenScheduled } = await seedScheduledRun({
+				namespaceRequestContext: context,
+				repos,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const result = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "queued", reason: "new" },
+				expectedRevision: revisionWhenScheduled,
+			});
+
+			expect(result).toEqual({
+				revision: revisionWhenScheduled + 1,
+				state: { status: "queued", reason: "new" },
+				attempts: attemptsWhenScheduled,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "queued",
+					revision: result.revision,
+					attempts: result.attempts,
+					state: { status: "queued", reason: "new" },
 				})
 			);
 		}));

--- a/sdk/server/src/service/workflow-run-state-machine.test.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.test.ts
@@ -1,3 +1,4 @@
+import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import { workflowRunStateByStatus } from "@aikirun/testing/data-factory/workflow/run";
 import type { WorkflowRunStateRequest } from "@aikirun/types/api/workflow-run";
 import {
@@ -21,34 +22,41 @@ describe("assertIsValidWorkflowRunStateTransition", () => {
 		);
 	}
 
-	const validTransitions: Record<WorkflowRunStatus, Partial<Record<WorkflowRunStatus, { reason: string } | null>>> = {
-		scheduled: { queued: null, paused: null, cancelled: null },
-		queued: { running: null, paused: null, cancelled: null, failed: null, stalled: null },
+	const validTransitions: Record<
+		WorkflowRunStatus,
+		Partial<Record<WorkflowRunStatus, { reasons?: NonEmptyArray<string> }>>
+	> = {
+		scheduled: {
+			queued: { reasons: ["new", "wakeup_early", "resumption", "event", "child_workflow", "redelivery"] },
+			paused: {},
+			cancelled: {},
+		},
+		queued: { running: {}, paused: {}, cancelled: {}, failed: {}, stalled: {} },
 		running: {
-			queued: { reason: "task_retry" },
-			running: null,
-			paused: null,
-			sleeping: null,
-			awaiting_event: null,
-			awaiting_retry: null,
-			awaiting_child_workflow: null,
-			cancelled: null,
-			completed: null,
-			failed: null,
+			queued: { reasons: ["task_retry"] },
+			running: {},
+			paused: {},
+			sleeping: {},
+			awaiting_event: {},
+			awaiting_retry: {},
+			awaiting_child_workflow: {},
+			cancelled: {},
+			completed: {},
+			failed: {},
 		},
-		paused: { scheduled: { reason: "resumption" }, cancelled: null },
-		sleeping: { scheduled: { reason: "wakeup_early" }, queued: { reason: "wakeup" }, cancelled: null },
-		awaiting_event: { scheduled: { reason: "event" }, queued: { reason: "event" }, cancelled: null },
-		awaiting_retry: { queued: { reason: "retry" }, cancelled: null },
+		paused: { scheduled: { reasons: ["resumption"] }, cancelled: {} },
+		sleeping: { scheduled: { reasons: ["wakeup_early"] }, queued: { reasons: ["wakeup"] }, cancelled: {} },
+		awaiting_event: { scheduled: { reasons: ["event"] }, queued: { reasons: ["event_wait_timeout"] }, cancelled: {} },
+		awaiting_retry: { queued: { reasons: ["retry"] }, cancelled: {} },
 		awaiting_child_workflow: {
-			scheduled: { reason: "child_workflow" },
-			queued: { reason: "child_workflow" },
-			cancelled: null,
+			scheduled: { reasons: ["child_workflow"] },
+			queued: { reasons: ["child_workflow_wait_timeout"] },
+			cancelled: {},
 		},
-		stalled: { scheduled: { reason: "redelivery" }, cancelled: null },
+		stalled: { scheduled: { reasons: ["redelivery"] }, cancelled: {} },
 		cancelled: {},
 		completed: {},
-		failed: { awaiting_retry: null },
+		failed: { awaiting_retry: {} },
 	};
 
 	const possibleReasons = Array.from(new Set([...WORKFLOW_RUN_SCHEDULED_REASON, ...WORKFLOW_RUN_QUEUED_REASON]));
@@ -69,17 +77,21 @@ describe("assertIsValidWorkflowRunStateTransition", () => {
 					continue;
 				}
 
-				const validReason = validDestination?.reason;
-
-				test(`accepts to ${toStatus} ${validReason ? `(${validReason})` : ""}`, () => {
-					expect(() => attemptTransition(fromStatus, { status: toStatus, reason: validReason })).not.toThrow();
-				});
-
-				if (!validReason) {
+				const validReasons = validDestination?.reasons;
+				if (validReasons === undefined) {
+					test(`accepts to ${toStatus}`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus })).not.toThrow();
+					});
 					continue;
 				}
+
+				for (const reason of validReasons) {
+					test(`accepts to ${toStatus} (${reason})`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus, reason })).not.toThrow();
+					});
+				}
 				for (const reason of possibleReasons) {
-					if (reason === validReason) {
+					if (validReasons.includes(reason)) {
 						continue;
 					}
 					test(`declines to ${toStatus} (${reason})`, () => {
@@ -97,9 +109,9 @@ describe("convertDurationToTimestamp", () => {
 	const now = 1_000;
 
 	test("scheduled: scheduledInMs becomes an absolute scheduledAt", () => {
-		expect(convertDurationToTimestamp({ status: "scheduled", reason: "wakeup", scheduledInMs: 500 }, now)).toEqual({
+		expect(convertDurationToTimestamp({ status: "scheduled", reason: "event", scheduledInMs: 500 }, now)).toEqual({
 			status: "scheduled",
-			reason: "wakeup",
+			reason: "event",
 			scheduledAt: 1_500,
 		});
 	});

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -11,10 +11,9 @@ import type {
 	WorkflowRunId,
 	WorkflowRunState,
 	WorkflowRunStateAwaitingChildWorkflow,
-	WorkflowRunStateScheduled,
 	WorkflowRunStatus,
 } from "@aikirun/types/workflow/run";
-import { isTerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
+import { isTerminalWorkflowRunStatus, isWorkflowRunScheduledReason } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../errors";
@@ -31,7 +30,15 @@ const workflowRunStateTransitionValidator: Record<
 > = {
 	scheduled: (() => {
 		const allowedDestinations: WorkflowRunStatus[] = ["queued", "paused", "cancelled"];
-		return (to) => ({ allowed: allowedDestinations.includes(to.status) });
+		return (to) => {
+			if (!allowedDestinations.includes(to.status)) {
+				return { allowed: false };
+			}
+			if (to.status === "queued" && !isWorkflowRunScheduledReason(to.reason)) {
+				return { allowed: false, reason: "Only scheduled reasons allowed" };
+			}
+			return { allowed: true };
+		};
 	})(),
 
 	queued: (() => {
@@ -101,8 +108,8 @@ const workflowRunStateTransitionValidator: Record<
 			if (to.status === "scheduled" && to.reason !== "event") {
 				return { allowed: false, reason: "Only event received run allowed" };
 			}
-			if (to.status === "queued" && to.reason !== "event") {
-				return { allowed: false, reason: "Only event received run allowed" };
+			if (to.status === "queued" && to.reason !== "event_wait_timeout") {
+				return { allowed: false, reason: "Only event_wait_timeout run allowed" };
 			}
 			return { allowed: true };
 		};
@@ -130,8 +137,8 @@ const workflowRunStateTransitionValidator: Record<
 			if (to.status === "scheduled" && to.reason !== "child_workflow") {
 				return { allowed: false, reason: "Only child workflow triggered run allowed" };
 			}
-			if (to.status === "queued" && to.reason !== "child_workflow") {
-				return { allowed: false, reason: "Only child workflow triggered run allowed" };
+			if (to.status === "queued" && to.reason !== "child_workflow_wait_timeout") {
+				return { allowed: false, reason: "Only child_workflow_wait_timeout run allowed" };
 			}
 			return { allowed: true };
 		};
@@ -202,12 +209,17 @@ export const createWorkflowRunStateMachineService = ({
 		request: WorkflowRunTransitionStateRequestV1,
 		txRepos?: TxRepos
 	): Promise<WorkflowRunTransitionStateResponseV1> {
-		if (txRepos) {
-			return transitionStateInTx(context, request, childRunCanceller, txRepos);
-		}
-		return repos.transaction(async (transactionRepos) =>
-			transitionStateInTx(context, request, childRunCanceller, transactionRepos)
-		);
+		const response = txRepos
+			? await transitionStateInTx(context, request, childRunCanceller, txRepos)
+			: await repos.transaction(async (newTxRepos) =>
+					transitionStateInTx(context, request, childRunCanceller, newTxRepos)
+				);
+		context.logger.info("Workflow state transition", {
+			"aiki.runId": request.id,
+			"aiki.state": response.state,
+			"aiki.attempts": response.attempts,
+		});
+		return response;
 	},
 });
 
@@ -239,14 +251,8 @@ async function transitionStateInTx(
 	const now = Date.now();
 	let toState = convertDurationToTimestamp(request.state, now);
 
-	context.logger.info("Workflow state transition", {
-		"aiki.runId": runId,
-		"aiki.state": toState,
-		"aiki.attempts": run.attempts,
-	});
-
 	if (fromState.status === "sleeping" && toState.status === "scheduled") {
-		await finalizeSleep(runId, fromState.sleepName, toState, now, txRepos);
+		await cancelSleep(runId, fromState.sleepName, now, txRepos);
 	}
 
 	if (toState.status === "sleeping") {
@@ -263,10 +269,7 @@ async function transitionStateInTx(
 	if (toState.status === "scheduled" || toState.status === "queued") {
 		switch (toState.reason) {
 			case "retry":
-				// fromState guard prevents double-count across scheduled(retry) -> queued(retry).
-				if (fromState.status !== "scheduled" && fromState.status !== "queued") {
-					attempts++;
-				}
+				attempts++;
 				break;
 			default:
 				toState.reason satisfies
@@ -276,7 +279,9 @@ async function transitionStateInTx(
 					| "wakeup_early"
 					| "resumption"
 					| "event"
+					| "event_wait_timeout"
 					| "child_workflow"
+					| "child_workflow_wait_timeout"
 					| "recovery"
 					| "redelivery";
 		}
@@ -286,10 +291,6 @@ async function transitionStateInTx(
 		await txRepos.workflowRunOutbox.markClaimed(namespaceId, runId);
 	} else if (toState.status !== "queued") {
 		await txRepos.workflowRunOutbox.deleteByWorkflowRunId(namespaceId, runId);
-	}
-
-	if (toState.status === "scheduled" && toState.reason === "retry") {
-		await discardStaleTasks(runId, ["running", "awaiting_retry", "failed"], txRepos);
 	}
 
 	if (toState.status === "awaiting_child_workflow") {
@@ -333,29 +334,16 @@ async function transitionStateInTx(
 	return { revision: newRevision, state: toState, attempts };
 }
 
-async function finalizeSleep(
-	runId: WorkflowRunId,
-	sleepName: string,
-	toState: WorkflowRunStateScheduled,
-	now: number,
-	txRepos: TxRepos
-) {
+async function cancelSleep(runId: WorkflowRunId, sleepName: string, now: number, txRepos: TxRepos) {
 	const activeSleep = await txRepos.sleepQueue.getActiveByWorkflowRunIdAndName(runId, sleepName);
 	if (!activeSleep) {
 		return;
 	}
 
-	if (toState.reason === "wakeup") {
-		await txRepos.sleepQueue.update(activeSleep.id, {
-			status: "completed",
-			completedAt: now as TimestampMs,
-		});
-	} else {
-		await txRepos.sleepQueue.update(activeSleep.id, {
-			status: "cancelled",
-			cancelledAt: now as TimestampMs,
-		});
-	}
+	await txRepos.sleepQueue.update(activeSleep.id, {
+		status: "cancelled",
+		cancelledAt: now as TimestampMs,
+	});
 }
 
 async function childWorkflowRunWaitNotNeeded(

--- a/sdk/server/src/testing/run-seed.ts
+++ b/sdk/server/src/testing/run-seed.ts
@@ -27,25 +27,27 @@ function createServices(repos: Repositories) {
 	return { workflowRun, workflowRunStateMachine };
 }
 
-interface SeedQueuedRunDeps {
+interface SeedRunDeps {
 	repos: Repositories;
 	daemonContext?: DaemonContext;
 	namespaceRequestContext?: NamespaceRequestContext;
 }
 
-export async function seedQueuedRun(deps: SeedQueuedRunDeps) {
-	return _seedQueuedRun(deps, undefined);
+export async function seedScheduledRun(deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">) {
+	return _seedScheduledRun(deps, undefined);
 }
 
-export async function seedPooledQueuedRun(deps: SeedQueuedRunDeps) {
+export async function seedPooledScheduledRun(deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">) {
 	const pool = "warehouse-eu";
-	const seeded = await _seedQueuedRun(deps, pool);
+	const seeded = await _seedScheduledRun(deps, pool);
 	return { ...seeded, pool };
 }
 
-async function _seedQueuedRun(deps: SeedQueuedRunDeps, pool: string | undefined) {
+async function _seedScheduledRun(
+	deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">,
+	pool: string | undefined
+) {
 	const { repos } = deps;
-	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
 	const services = createServices(repos);
 
@@ -55,6 +57,27 @@ async function _seedQueuedRun(deps: SeedQueuedRunDeps, pool: string | undefined)
 		input: { orderId: "order-7" },
 		options: pool ? { pool } : undefined,
 	});
+
+	return { runId, revisionWhenScheduled: 0, attemptsWhenScheduled: 1 };
+}
+
+export async function seedQueuedRun(deps: SeedRunDeps) {
+	return _seedQueuedRun(deps, undefined);
+}
+
+export async function seedPooledQueuedRun(deps: SeedRunDeps) {
+	const pool = "warehouse-eu";
+	const seeded = await _seedQueuedRun(deps, pool);
+	return { ...seeded, pool };
+}
+
+async function _seedQueuedRun(deps: SeedRunDeps, pool: string | undefined) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+
+	const { runId } = await _seedScheduledRun({ repos, namespaceRequestContext }, pool);
+
+	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 
 	await processImminentScheduledRuns(daemonContext, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });
 
@@ -90,7 +113,7 @@ export async function claimRun(deps: { context: NamespaceRequestContext; repos: 
 	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };
 }
 
-export async function seedClaimedRun(deps: SeedQueuedRunDeps & { publisher: FakePublisher }) {
+export async function seedClaimedRun(deps: SeedRunDeps & { publisher: FakePublisher }) {
 	const { repos, publisher } = deps;
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
@@ -102,7 +125,7 @@ export async function seedClaimedRun(deps: SeedQueuedRunDeps & { publisher: Fake
 	return { ...seeded, ...claim };
 }
 
-export async function seedPublishedRun(deps: SeedQueuedRunDeps & { publisher: FakePublisher }) {
+export async function seedPublishedRun(deps: SeedRunDeps & { publisher: FakePublisher }) {
 	const { repos, publisher } = deps;
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const seeded = await seedQueuedRun(deps);
@@ -112,7 +135,7 @@ export async function seedPublishedRun(deps: SeedQueuedRunDeps & { publisher: Fa
 	return seeded;
 }
 
-export async function seedStalledRun(deps: SeedQueuedRunDeps) {
+export async function seedStalledRun(deps: SeedRunDeps) {
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const seeded = await withFakeClock(1 as TimestampMs, () => seedQueuedRun(deps));
 

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -178,7 +178,7 @@ interface WorkflowRunTransitionStateRequestBase {
 
 export type WorkflowRunStateScheduledRequestOptimistic = Extract<
 	WorkflowRunStateScheduledRequest,
-	{ reason: "retry" | "task_retry" | "wakeup" | "event" | "child_workflow" }
+	{ reason: "event" | "child_workflow" }
 >;
 
 export type WorkflowRunStateScheduledRequestPessimistic = Extract<

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -66,9 +66,6 @@ interface WorkflowRunStateBase {
 
 export const WORKFLOW_RUN_SCHEDULED_REASON = [
 	"new",
-	"retry",
-	"task_retry",
-	"wakeup",
 	"wakeup_early",
 	"resumption",
 	"event",
@@ -76,6 +73,15 @@ export const WORKFLOW_RUN_SCHEDULED_REASON = [
 	"redelivery",
 ] as const;
 export type WorkflowRunScheduledReason = (typeof WORKFLOW_RUN_SCHEDULED_REASON)[number];
+
+export function isWorkflowRunScheduledReason(reason: string): reason is WorkflowRunScheduledReason {
+	for (const scheduledReason of WORKFLOW_RUN_SCHEDULED_REASON) {
+		if (reason === scheduledReason) {
+			return true;
+		}
+	}
+	return false;
+}
 
 export interface WorkflowRunStateScheduledBase extends WorkflowRunStateBase {
 	status: "scheduled";
@@ -85,18 +91,6 @@ export interface WorkflowRunStateScheduledBase extends WorkflowRunStateBase {
 
 export interface WorkflowRunStateScheduledByNew extends WorkflowRunStateScheduledBase {
 	reason: "new";
-}
-
-export interface WorkflowRunStateScheduledByRetry extends WorkflowRunStateScheduledBase {
-	reason: "retry";
-}
-
-export interface WorkflowRunStateScheduledByTaskRetry extends WorkflowRunStateScheduledBase {
-	reason: "task_retry";
-}
-
-export interface WorkflowRunStateScheduledByWakeup extends WorkflowRunStateScheduledBase {
-	reason: "wakeup";
 }
 
 export interface WorkflowRunStateScheduledByWakeupEarly extends WorkflowRunStateScheduledBase {
@@ -121,9 +115,6 @@ export interface WorkflowRunStateScheduledByRedelivery extends WorkflowRunStateS
 
 export type WorkflowRunStateScheduled =
 	| WorkflowRunStateScheduledByNew
-	| WorkflowRunStateScheduledByRetry
-	| WorkflowRunStateScheduledByTaskRetry
-	| WorkflowRunStateScheduledByWakeup
 	| WorkflowRunStateScheduledByWakeupEarly
 	| WorkflowRunStateScheduledByResume
 	| WorkflowRunStateScheduledByEvent
@@ -138,7 +129,9 @@ export const WORKFLOW_RUN_QUEUED_REASON = [
 	"wakeup_early",
 	"resumption",
 	"event",
+	"event_wait_timeout",
 	"child_workflow",
+	"child_workflow_wait_timeout",
 	"recovery",
 	"redelivery",
 ] as const;


### PR DESCRIPTION
## Problem

`scheduled` and `queued` run states carry a `reason` that records why the run entered the state. The two states have different writers. Request handlers (create, resume, redeliver, event send, child-wait resolution) put runs in `scheduled`, and `processImminentScheduledRuns` daemon moves them to `queued` when their time arrives. The timer daemons skip `scheduled`: they write `queued` directly and publish immediately. The direct path dates to the timer-latency change (dd8f9e21). Before that change, every waiting state exited through `scheduled`.

Three scheduled reasons — `retry`, `task_retry`, `wakeup` — are left over from before that change. Nothing produces them, and the transition validator rejects them from every origin. They exist only in the type system. Some code still handles them:

- the attempt counter guards against double-charging across a `scheduled(retry) → queued(retry)` sequence that can no longer happen;
- a stale-task discard branch runs only on `scheduled(retry)`, so it never runs — the retry daemon does that discard itself when it requeues;
- sleep finalization still checks for a `wakeup` exit that no longer goes through the state machine.

Separately, the timeout exits of the two wait states reuse their arrival reasons. An event wait that times out requeues as `queued(event)` — which claims an event arrived when none did. Sleeping already names its two exits differently: `wakeup` when the sleep timer fires, `wakeup_early` when the user wakes the run early. Event and child-workflow waits are the inconsistent ones. Because the reason is ambiguous, the dashboard timeline has to join each wait's queue record just to tell arrival from timeout.

## Solution

The idea behind all of it: a reason is stamped once, at the moment something decides the run should move — an event arrives, a user resumes, a wait times out. Moving the run along afterwards is not a new decision, so the reason travels with the run unchanged.

**The scheduled reason list shrinks to the six reasons that are actually produced**: `new`, `wakeup_early`, `resumption`, `event`, `child_workflow`, `redelivery`. The three dead reasons and their state interfaces are removed from the types, the contract schemas, and the optimistic transition-request union.

**Wait timeouts get their own reasons.** It is the wait that times out, not the event or the child workflow — so the event-wait timeout daemon now writes `queued(event_wait_timeout)`, and the child-workflow-wait timeout daemon writes `queued(child_workflow_wait_timeout)`. The union change is additive, so rows written before the split still parse.

**A run moving from `scheduled` to `queued` keeps the reason it entered `scheduled` with.** Moving the run is not a new decision, so there is nothing new to record. The validator now rejects the move when the reason is not one a scheduled run can hold.

**The attempt counter reads the reason alone.** `attempts` counts the tries a run has been granted: one at creation, one more each time a failed run wins another try. The only transition that grants a new try is `queued(retry)` — a failed run re-entering the queue — so that is the only transition that charges. The old origin check and the unreachable `scheduled(retry)` discard branch are deleted.

**Sleep finalization only cancels.** The only `scheduled` exit from sleeping is the user waking the run early, and an early wakeup abandons the sleep — so the finalizer is renamed `cancelSleep` and always cancels. Normal wakeups complete their sleep rows in the sleep daemon.

## Breaking changes

`WorkflowRunScheduledReason` loses `retry`, `task_retry`, and `wakeup`, and their state interfaces are deleted. `WorkflowRunQueuedReason` gains `event_wait_timeout` and `child_workflow_wait_timeout`. The optimistic scheduled transition request narrows to reasons `event | child_workflow`.
