### PR TITLE
Wrap publisher result buckets in objects

### DIFF
--- a/sdk/adapter/memory/src/queue/in-memory-queue.test.ts
+++ b/sdk/adapter/memory/src/queue/in-memory-queue.test.ts
@@ -126,7 +126,7 @@ describe("inMemoryQueue publish/subscribe", () => {
 		const [readyRun1, readyRun2] = [readyWorkflowRunFactory.build(), readyWorkflowRunFactory.build()];
 		const result = await publisher.publishRuns([readyRun1, readyRun2]);
 
-		expect(result.published).toEqual([{ run: readyRun1 }, { run: readyRun2 }]);
+		expect(result.published).toEqual({ runs: [{ run: readyRun1 }, { run: readyRun2 }] });
 	});
 });
 

--- a/sdk/adapter/memory/src/queue/publisher.ts
+++ b/sdk/adapter/memory/src/queue/publisher.ts
@@ -27,7 +27,7 @@ export function createInMemoryPublisher(store: Store): CreatePublisher {
 				}
 			}
 
-			return { published: runs.map((run) => ({ run })) };
+			return { published: { runs: runs.map((run) => ({ run })) } };
 		},
 	});
 }

--- a/sdk/adapter/redis/src/queue/publisher.ts
+++ b/sdk/adapter/redis/src/queue/publisher.ts
@@ -23,7 +23,7 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 		return {
 			async publishRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishRunsResult> {
 				if (!redisTracker.isAvailable()) {
-					return { failed: runs.map((run) => ({ run })) };
+					return { failed: { runs: runs.map((run) => ({ run })) } };
 				}
 
 				const dataByQueueName = new Map<string, QueueData>();
@@ -50,11 +50,11 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 					logger.warn("Publish pipeline returned no results, treating runs as failed", {
 						"aiki.count": runs.length,
 					});
-					return { failed: runs.map((run) => ({ run })) };
+					return { failed: { runs: runs.map((run) => ({ run })) } };
 				}
 
-				const published: PublishRunsResultBucket = [];
-				const failed: PublishRunsResultBucket = [];
+				const published: PublishRunsResultBucket = { runs: [] };
+				const failed: PublishRunsResultBucket = { runs: [] };
 				let err: Error | undefined;
 				for (const [i, queueData] of queueDataBatch.entries()) {
 					const result = results[i];
@@ -62,11 +62,11 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 					if (commandError !== null) {
 						err ??= commandError;
 						for (const run of queueData.runs) {
-							failed.push({ run });
+							failed.runs.push({ run });
 						}
 					} else {
 						for (const run of queueData.runs) {
-							published.push({ run });
+							published.runs.push({ run });
 						}
 					}
 				}
@@ -74,15 +74,15 @@ export function redisPublisher(redis: Redis): CreatePublisher {
 				if (err) {
 					logger.warn("Publish command failed, treating its runs as failed", {
 						err,
-						"aiki.count": failed.length,
+						"aiki.count": failed.runs.length,
 					});
 				}
 
 				const result: PublishRunsResult = {};
-				if (published.length > 0) {
+				if (published.runs.length > 0) {
 					result.published = published;
 				}
-				if (failed.length > 0) {
+				if (failed.runs.length > 0) {
 					result.failed = failed;
 				}
 				return result;

--- a/sdk/server/src/daemon/publish-pending-outbox-entries.ts
+++ b/sdk/server/src/daemon/publish-pending-outbox-entries.ts
@@ -100,15 +100,15 @@ async function publish(
 	const publishedEntryIds: string[] = [];
 
 	for (const outcome of PUBLISH_OUTCOMES) {
-		const bucket = result[outcome];
-		if (!isNonEmptyArray(bucket)) {
+		const runsBucket = result[outcome]?.runs;
+		if (!isNonEmptyArray(runsBucket)) {
 			continue;
 		}
 
 		switch (outcome) {
 			case "published":
-				logger.debug("Published ready workflow runs", { "aiki.count": bucket.length });
-				for (const { run } of bucket) {
+				logger.debug("Published ready workflow runs", { "aiki.count": runsBucket.length });
+				for (const { run } of runsBucket) {
 					const entry = entryByRunId.get(run.id);
 					if (entry) {
 						publishedEntryIds.push(entry.id);
@@ -116,13 +116,13 @@ async function publish(
 				}
 				break;
 			case "deferred":
-				logger.debug("Deferred publishing workflow runs", { "aiki.count": bucket.length });
+				logger.debug("Deferred publishing workflow runs", { "aiki.count": runsBucket.length });
 				break;
 			case "failed":
-				logger.debug("Failed to publish workflow runs", { "aiki.count": bucket.length });
+				logger.debug("Failed to publish workflow runs", { "aiki.count": runsBucket.length });
 				break;
 			case "declined":
-				logger.warn("Declined to publish workflow runs", { "aiki.count": bucket.length });
+				logger.warn("Declined to publish workflow runs", { "aiki.count": runsBucket.length });
 				break;
 			default:
 				outcome satisfies never;

--- a/testing/src/infra/queue/publisher.test.ts
+++ b/testing/src/infra/queue/publisher.test.ts
@@ -11,7 +11,7 @@ describe("fakePublisher", () => {
 
 		const result = await publisher.publishRuns([readyRun1, readyRun2]);
 
-		expect(result).toEqual({ published: [{ run: readyRun1 }, { run: readyRun2 }] });
+		expect(result).toEqual({ published: { runs: [{ run: readyRun1 }, { run: readyRun2 }] } });
 	});
 
 	test("rejectsOnce throws on the next call, then heals", async () => {
@@ -22,7 +22,7 @@ describe("fakePublisher", () => {
 
 		expect(publisher.publishRuns([readyRun1])).rejects.toThrow("broker down");
 		expect(await publisher.publishRuns([readyRun2])).toEqual({
-			published: [{ run: readyRun2 }],
+			published: { runs: [{ run: readyRun2 }] },
 		});
 	});
 
@@ -30,7 +30,7 @@ describe("fakePublisher", () => {
 		const publisher = fakePublisher();
 		const readyRun1 = readyWorkflowRunFactory.build();
 
-		const degraded: PublishRunsResult = { failed: [{ run: readyRun1 }] };
+		const degraded: PublishRunsResult = { failed: { runs: [{ run: readyRun1 }] } };
 		publisher.publishRuns.once(expect.anything(), degraded);
 
 		expect(await publisher.publishRuns([readyRun1])).toEqual(degraded);
@@ -40,17 +40,17 @@ describe("fakePublisher", () => {
 		const publisher = fakePublisher();
 		const [readyRun1, readyRun2] = [readyWorkflowRunFactory.build(), readyWorkflowRunFactory.build()];
 
-		publisher.publishRuns.once(expect.anything(), (runs) => ({ failed: runs.map((run) => ({ run })) }));
+		publisher.publishRuns.once(expect.anything(), (runs) => ({ failed: { runs: runs.map((run) => ({ run })) } }));
 
 		const result = await publisher.publishRuns([readyRun1, readyRun2]);
 
-		expect(result).toEqual({ failed: [{ run: readyRun1 }, { run: readyRun2 }] });
+		expect(result).toEqual({ failed: { runs: [{ run: readyRun1 }, { run: readyRun2 }] } });
 	});
 
 	test("asserts the request against the matcher", async () => {
 		const publisher = fakePublisher();
 
-		publisher.publishRuns.once([readyWorkflowRunFactory.build({ id: "expected" })], { published: [] });
+		publisher.publishRuns.once([readyWorkflowRunFactory.build({ id: "expected" })], { published: { runs: [] } });
 
 		expect(publisher.publishRuns([readyWorkflowRunFactory.build({ id: "actual" })])).rejects.toThrow();
 	});
@@ -63,18 +63,20 @@ describe("fakePublisher", () => {
 			readyWorkflowRunFactory.build(),
 		];
 
-		publisher.publishRuns.rejectsOnce(expect.anything(), new Error("first")).once(expect.anything(), { published: [] });
+		publisher.publishRuns
+			.rejectsOnce(expect.anything(), new Error("first"))
+			.once(expect.anything(), { published: { runs: [] } });
 
 		expect(publisher.publishRuns([readyRun1])).rejects.toThrow("first");
-		expect(await publisher.publishRuns([readyRun2])).toEqual({ published: [] });
+		expect(await publisher.publishRuns([readyRun2])).toEqual({ published: { runs: [] } });
 		expect(await publisher.publishRuns([readyRun3])).toEqual({
-			published: [{ run: readyRun3 }],
+			published: { runs: [{ run: readyRun3 }] },
 		});
 	});
 
 	test("verify passes once every scripted call has been made", async () => {
 		const publisher = fakePublisher();
-		publisher.publishRuns.once(expect.anything(), { published: [] });
+		publisher.publishRuns.once(expect.anything(), { published: { runs: [] } });
 
 		await publisher.publishRuns([readyWorkflowRunFactory.build()]);
 
@@ -83,7 +85,7 @@ describe("fakePublisher", () => {
 
 	test("verify throws when a scripted call was never made", () => {
 		const publisher = fakePublisher();
-		publisher.publishRuns.once(expect.anything(), { published: [] });
+		publisher.publishRuns.once(expect.anything(), { published: { runs: [] } });
 
 		expect(() => publisher.verify()).toThrow();
 	});

--- a/testing/src/infra/queue/publisher.ts
+++ b/testing/src/infra/queue/publisher.ts
@@ -73,7 +73,7 @@ export function fakePublisher(): FakePublisher {
 		const expectedCalls = expectations.getCalls(publishRunsFn.name);
 		const expectedCall = expectedCalls.shift();
 		if (expectedCall === undefined) {
-			return { published: actualRequest.map((run) => ({ run })) };
+			return { published: { runs: actualRequest.map((run) => ({ run })) } };
 		}
 		expect(actualRequest).toEqual(expectedCall.request as PublishRunsRequest);
 

--- a/types/src/infra/queue/publisher.ts
+++ b/types/src/infra/queue/publisher.ts
@@ -10,8 +10,12 @@ export interface ReadyWorkflowRun {
 	pool?: string;
 }
 
-export type PublishRunsResultBucket = Array<{ run: ReadyWorkflowRun }>;
-export type TimedPublishRunsResultBucket = Array<{ run: ReadyWorkflowRun; nextPublishAttemptAt: number }>;
+export interface PublishRunsResultBucket {
+	runs: Array<{ run: ReadyWorkflowRun }>;
+}
+export interface TimedPublishRunsResultBucket {
+	runs: Array<{ run: ReadyWorkflowRun; nextPublishAttemptAt: number }>;
+}
 
 export interface PublishRunsResult {
 	/** Handoff to broker confirmed. */


### PR DESCRIPTION
## Problem

`Publisher` is the public contract a queue adapter implements to deliver ready workflow runs. `publishRuns` returns a `PublishRunsResult` that sorts each run into an outcome bucket: `published`, `deferred`, `failed`, or `declined`. Each bucket was a bare array of `{ run }` entries.

The entry objects already allow non-breaking per-run additions; `deferred` entries carry a per-run `nextPublishAttemptAt` this way. A bare array, however, has no place for a fact about the bucket as a whole. Adding one later would mean changing the bucket from an array to an object, which breaks every adapter implementation.

## Solution

Each bucket is now an object wrapping its `runs` array:

```typescript
// Before
type PublishRunsResultBucket = Array<{ run: ReadyWorkflowRun }>;
type TimedPublishRunsResultBucket = Array<{ run: ReadyWorkflowRun; nextPublishAttemptAt: number }>;

// After
interface PublishRunsResultBucket {
	runs: Array<{ run: ReadyWorkflowRun }>;
}
interface TimedPublishRunsResultBucket {
	runs: Array<{ run: ReadyWorkflowRun; nextPublishAttemptAt: number }>;
}
```

Both extension axes are now non-breaking: an entry can gain an optional per-run field, and a bucket can gain an optional bucket-level field. Possible future additions, not in this PR: a reason on `declined` entries, or an error on `failed` so the daemon can log the underlying delivery failure instead of the adapter logging it locally.

## Breaking changes

`PublishRunsResult` buckets changed shape from `Array<{ run, ... }>` to `{ runs: Array<{ run, ... }> }`. This affects custom `Publisher` implementations.