### PR TITLE
Finalize active sleeps when runs are cancelled

### DIFF
--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -31,8 +31,9 @@ Before writing any test, study the exemplars for its tier and match their idioms
     Integration-only (test files run sequentially in one process).
 - Use these tools only where the test's semantics need them. The fake clock earns its place
   where state must look stale or aged (a recovery threshold, an age cap keyed on a row id's
-  mint time), not where mere status suffices. Derive each piece of harness machinery from what
-  the test asserts; don't inherit it from the neighboring test.
+  mint time) or where an expectation pins an exact written timestamp, not where mere status
+  suffices. Derive each piece of harness machinery from what the test asserts; don't inherit
+  it from the neighboring test.
 - Waits ride event-signaled promises (see `lib/src/async/latch.ts`), never polling loops or
   sized sleeps. The one legitimate fixed wait is an absence check: wait a window, assert nothing
   changed.
@@ -67,11 +68,29 @@ Before writing any test, study the exemplars for its tier and match their idioms
 - Expectations compare whole arrays with matchers —
   `expect(rows).toEqual([expect.objectContaining({ ... })])` — never `rows[0]?.field` inside an
   `expect`. This pins count and content together.
-- Captures (probes, helper lookups) may index only after the count is pinned:
-  `expect(rows).toHaveLength(1)` then `rows[0]`. `rows[0]!` with a
-  `biome-ignore ...: the length has already been asserted` comment is the accepted narrowing.
+- Captures (indexing a row out to reuse a value) are a last resort, not an idiom: authored
+  instants let the whole-array assertion carry every field, and asserting row order replaces
+  reading out an id to filter by. Where a later step genuinely needs a value that cannot be
+  authored, index only after `expect(rows).toHaveLength(n)`; `rows[0]!` with a
+  `biome-ignore ...: the length has already been asserted` comment is the tolerated narrowing,
+  and its presence is a prompt to ask whether the value could have been authored instead.
 - Merge related equality fields into one `objectContaining` (include ids). An ordered comparison
   (`toBeGreaterThan`) gets its own assertion line — no asymmetric ordering matcher exists.
+- Timestamps in expectations are exact values, never `expect.any(Number)` — presence-only
+  survives a dropped duration or a seconds/ms mix-up. Capture an instant, freeze the clock
+  around the one mutating call, and assert the arithmetic
+  (`const sleepStartedAt = Date.now()`, then `wakeupAt: sleepStartedAt + durationMs`).
+  Seeding the freeze from `Date.now()` is not the real-time smell: nothing depends on the
+  value, and a current-time seed keeps the frozen instant after earlier real-time steps so
+  ulids stay causally ordered. Scope the freeze to the call under assertion. Timestamps minted
+  in one transaction share its single `now` — asserting them against the same instant pins
+  that property too. Where the clock cannot be frozen, bracket from both sides
+  (`before + duration <= t <= after + duration`); a one-sided bound still passes a doubled
+  duration.
+- A captured row pins stability, not exactness: comparing against an earlier read proves the
+  row didn't change, while its timestamps stay unfrozen wall-clock values. When exactness is
+  the point, freeze the instant that minted the row and assert the authored value — the
+  whole-array form then needs no capture at all.
 - An absence assertion must be a read that would have shown the row if it existed.
 - When a test claims "X prevents Y", first prove Y was actually going to happen: assert the
   seeded state is one Y would hit (the claim is old enough to be recovered), then do X, then
@@ -92,6 +111,12 @@ Before writing any test, study the exemplars for its tier and match their idioms
 - Mutation-test your assertions: if the behavior under test were deleted, would this test fail?
   Baselines captured before an intermediate step, or comparisons that hold vacuously (0 === 0),
   are the common failure.
+- When the claim is "X leaves Y untouched", mint Y in a state X cannot write: a bystander
+  sleep finalized `completed` (a `durationMs: 0` sleep is due for the elapsed-runs daemon
+  immediately) against an X that writes `cancelled`. A same-status bystander forces the
+  assertion to lean on incidental values; a distinguishable status turns any violation into a
+  visible flip. Assert the bystander's outcome columns with their null complements
+  (`completedAt` set, `cancelledAt: null`) so finalization is pinned to exactly one outcome.
 - When a behavior applies only to one status (a guard like `status = 'claimed'`), test every
   excluded status, not one representative. Build the case table as an object keyed by the
   excluded statuses and pin it with

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -410,6 +410,7 @@ async function processOverlapCancelPreviousSchedules(
 		// cancel state transitions only for actually cancelled runs and set latestStateTransitionId
 		if (isNonEmptyArray(cancelledRunIds)) {
 			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
+			await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now as TimestampMs);
 			await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
 			const cancelledRunIdsSet = new Set(cancelledRunIds);

--- a/sdk/server/src/infra/db/pg/repository/sleep.ts
+++ b/sdk/server/src/infra/db/pg/repository/sleep.ts
@@ -33,6 +33,13 @@ export const createSleepRepository = (db: PgDb) => ({
 			.where(and(inArray(sleep.workflowRunId, workflowRunIds), eq(sleep.status, "sleeping")));
 	},
 
+	async bulkCancelByWorkflowRunIds(workflowRunIds: NonEmptyArray<string>, cancelledAt: TimestampMs): Promise<void> {
+		await db
+			.update(sleep)
+			.set({ status: "cancelled", cancelledAt })
+			.where(and(inArray(sleep.workflowRunId, workflowRunIds), eq(sleep.status, "sleeping")));
+	},
+
 	async getActiveByWorkflowRunIdAndName(workflowRunId: WorkflowRunId, name: string): Promise<SleepRow | null> {
 		const result = await db
 			.select()

--- a/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.integration.test.ts
@@ -2,13 +2,15 @@ import { NotFoundError } from "@aikirun/lib/error";
 
 import { describe, expect, test } from "bun:test";
 import { processImminentScheduledRuns } from "../daemon/imminent-scheduled-runs";
+import { processImminentSleepElapsedRuns } from "../daemon/imminent-sleep-elapsed-runs";
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
 import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
+import { withFakeClock } from "../testing/clock";
 import { daemonContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
-import { seedClaimedRun, seedScheduledRun, seedStalledRun } from "../testing/run-seed";
+import { claimRun, seedClaimedRun, seedScheduledRun, seedStalledRun } from "../testing/run-seed";
 
 const withHarness = createServiceHarness();
 
@@ -169,17 +171,20 @@ describe("WorkflowRunStateMachineService attempt counting", () => {
 			});
 
 			const stateMachine = createStateMachine(repos);
-			const result = await stateMachine.transitionState(context, {
-				type: "optimistic",
-				id: runId,
-				state: {
-					status: "awaiting_retry",
-					cause: "self",
-					error: { name: "Error", message: "boom" },
-					nextAttemptInMs: 0,
-				},
-				expectedRevision: revisionWhenClaimed,
-			});
+			const failedAt = Date.now();
+			const result = await withFakeClock(failedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: {
+						status: "awaiting_retry",
+						cause: "self",
+						error: { name: "Error", message: "boom" },
+						nextAttemptInMs: 10_000,
+					},
+					expectedRevision: revisionWhenClaimed,
+				})
+			);
 
 			expect(result).toEqual({
 				revision: revisionWhenClaimed + 1,
@@ -187,7 +192,7 @@ describe("WorkflowRunStateMachineService attempt counting", () => {
 					status: "awaiting_retry",
 					cause: "self",
 					error: { name: "Error", message: "boom" },
-					nextAttemptAt: expect.any(Number),
+					nextAttemptAt: failedAt + 10_000,
 				},
 				attempts: attemptsWhenClaimed,
 			});
@@ -314,6 +319,175 @@ describe("WorkflowRunStateMachineService attempt counting", () => {
 					state: { status: "queued", reason: "new" },
 				})
 			);
+		}));
+});
+
+describe("WorkflowRunStateMachineService sleep lifecycle", () => {
+	test("entering sleeping state creates an active sleep row", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const sleepStartedAt = Date.now();
+			const result = await withFakeClock(sleepStartedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+					expectedRevision: revisionWhenClaimed,
+				})
+			);
+
+			expect(result).toEqual({
+				revision: revisionWhenClaimed + 1,
+				state: { status: "sleeping", sleepName: "nap", wakeupAt: sleepStartedAt + 60_000 },
+				attempts: attemptsWhenClaimed,
+			});
+
+			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
+			expect(sleeps).toEqual([expect.objectContaining({ workflowRunId: runId, name: "nap", status: "sleeping" })]);
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "sleeping",
+					revision: result.revision,
+					attempts: result.attempts,
+					state: { status: "sleeping", sleepName: "nap", wakeupAt: sleepStartedAt + 60_000 },
+				})
+			);
+		}));
+
+	test("an early wakeup cancels the active sleep", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const sleeping = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			const earlyWakeupAt = Date.now();
+			const result = await withFakeClock(earlyWakeupAt, () =>
+				stateMachine.transitionState(context, {
+					type: "pessimistic",
+					id: runId,
+					state: { status: "scheduled", scheduledInMs: 0, reason: "wakeup_early" },
+				})
+			);
+
+			expect(result).toEqual({
+				revision: sleeping.revision + 1,
+				state: { status: "scheduled", reason: "wakeup_early", scheduledAt: earlyWakeupAt },
+				attempts: sleeping.attempts,
+			});
+
+			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
+			expect(sleeps).toEqual([
+				expect.objectContaining({ name: "nap", status: "cancelled", cancelledAt: earlyWakeupAt }),
+			]);
+		}));
+
+	test("an early wakeup cancels only the active sleep, not prior finalized sleeps", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "sleeping", sleepName: "nap", durationMs: 0 },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			const firstSleepCompletedAt = Date.now();
+			await withFakeClock(firstSleepCompletedAt, () =>
+				processImminentSleepElapsedRuns(
+					daemonContext,
+					{ repos },
+					{ limit: 100, lookaheadWindowMs: 0, republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000 } }
+				)
+			);
+			const reclaimed = await claimRun({ context, repos, runId });
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+				expectedRevision: reclaimed.revisionWhenClaimed,
+			});
+
+			const secondEarlyWakeupAt = Date.now();
+			await withFakeClock(secondEarlyWakeupAt, () =>
+				stateMachine.transitionState(context, {
+					type: "pessimistic",
+					id: runId,
+					state: { status: "scheduled", scheduledInMs: 0, reason: "wakeup_early" },
+				})
+			);
+
+			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
+			expect(sleeps).toEqual([
+				expect.objectContaining({
+					name: "nap",
+					status: "completed",
+					completedAt: firstSleepCompletedAt,
+					cancelledAt: null,
+				}),
+				expect.objectContaining({
+					name: "nap",
+					status: "cancelled",
+					completedAt: null,
+					cancelledAt: secondEarlyWakeupAt,
+				}),
+			]);
+		}));
+
+	test("cancelling a sleeping run cancels its active sleep", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			const cancelledAt = Date.now();
+			await withFakeClock(cancelledAt, () =>
+				stateMachine.transitionState(context, {
+					type: "pessimistic",
+					id: runId,
+					state: { status: "cancelled" },
+				})
+			);
+
+			// The sleep daemon finds due sleeps by scanning runs with status sleeping. A cancelled run
+			// leaves that scan, so nothing ever revisits its sleep row: the cancel must finalize the
+			// sleep here, or the row stays active forever.
+			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
+			expect(sleeps).toEqual([expect.objectContaining({ name: "nap", status: "cancelled", cancelledAt: cancelledAt })]);
 		}));
 });
 

--- a/sdk/server/src/service/workflow-run-state-machine.ts
+++ b/sdk/server/src/service/workflow-run-state-machine.ts
@@ -245,7 +245,7 @@ async function transitionStateInTx(
 	const now = Date.now();
 	let toState = convertDurationToTimestamp(request.state, now);
 
-	if (fromState.status === "sleeping" && toState.status === "scheduled") {
+	if (fromState.status === "sleeping" && (toState.status === "scheduled" || toState.status === "cancelled")) {
 		await cancelSleep(runId, fromState.sleepName, now, txRepos);
 	}
 

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { Repositories } from "../infra/db/types";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createWorkflowRunService } from "../service/workflow-run";
+import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
+import { withFakeClock } from "../testing/clock";
+import { createServiceHarness } from "../testing/harness";
+import { seedClaimedRun } from "../testing/run-seed";
+
+const withHarness = createServiceHarness();
+
+function createService(repos: Repositories) {
+	const childRunCanceller = createChildRunCanceller();
+	const workflowRunStateMachineService = createWorkflowRunStateMachineService({ repos, childRunCanceller });
+	return {
+		service: createWorkflowRunService({ repos, childRunCanceller, workflowRunStateMachineService }),
+		stateMachine: workflowRunStateMachineService,
+	};
+}
+
+describe("WorkflowRunService cancelByIds", () => {
+	test("cancelling a sleeping run cancels its active sleep", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const { service, stateMachine } = createService(repos);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			const cancelledAt = Date.now();
+			const result = await withFakeClock(cancelledAt, () => service.cancelByIds(context, { ids: [runId] }));
+			expect(result).toEqual({ cancelledIds: [runId] });
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "cancelled",
+					state: { status: "cancelled", reason: "Cancelled" },
+				})
+			);
+
+			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
+			expect(sleeps).toEqual([expect.objectContaining({ name: "nap", status: "cancelled", cancelledAt })]);
+		}));
+});

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -483,6 +483,7 @@ export const createWorkflowRunService = ({
 			}
 
 			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
+			await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, Date.now() as TimestampMs);
 			await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
 			const cancelledRuns = await txRepos.workflowRun.getByIds(namespaceId, cancelledRunIds);


### PR DESCRIPTION
Entering `sleeping` writes an active row to the `sleep` table, finalized when the sleep ends: `completed` by the wakeup daemon, `cancelled` by an early wakeup. Cancelling the run did neither — the single-run transition and both bulk cancel paths all left the row at `sleeping` forever, so a cancelled run shows an eternally active sleep in the run detail view.

Every cancel path now finalizes the run's still-active sleep as `cancelled` in the same transaction. Integration tests pin the sleep lifecycle: the row is created on entry, each exit finalizes it exactly one way, and finalized rows stay untouched by later exits. The same pass replaced `expect.any(Number)` timestamp assertions with exact values under a frozen clock and recorded the rule in the testing guide.
