### PR TITLE
Namespace-scope the bulk run cancel

### DIFF
--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -128,3 +128,8 @@ Before writing any test, study the exemplars for its tier and match their idioms
   cell is the illegal case, `{}` is legal-unguarded, and `NonEmptyArray` forbids the empty guard
   list a plain `string[]` would accept — `{ reasons: [] }` would generate zero accepts tests and
   silently decline every reason.
+- A case-table cell is data only while every case is exercised identically. When cases differ
+  in how the action is performed (a different transition variant, a different seed), the cell
+  is a function that performs the action and the loop just calls it — the refreshClaim guard
+  table's cells are the seed functions themselves. A data cell that forces the loop to branch
+  on the case puts per-case knowledge in the wrong place.

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -403,7 +403,7 @@ async function processOverlapCancelPreviousSchedules(
 
 		// Step 1: Cancel active runs (without setting latestStateTransitionId)
 		const cancelledRunIds = isNonEmptyArray(runIdsToCancel)
-			? await txRepos.workflowRun.bulkTransitionToCancelled(runIdsToCancel)
+			? await txRepos.workflowRun.bulkTransitionToCancelledGlobal(context, runIdsToCancel)
 			: [];
 
 		// Step 2: Discard in-flight tasks and outbox entries for the cancelled runs, then insert

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -488,7 +488,30 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result.map((row) => row.id);
 	},
 
-	async bulkTransitionToCancelled(runIds: NonEmptyArray<string>): Promise<string[]> {
+	async bulkTransitionToCancelled(namespaceId: NamespaceId, runIds: NonEmptyArray<string>): Promise<string[]> {
+		const result = await db
+			.update(workflowRun)
+			.set({
+				status: "cancelled",
+				revision: sql`${workflowRun.revision} + 1`,
+				scheduledAt: null,
+				wakeupAt: null,
+				timeoutAt: null,
+				nextAttemptAt: null,
+			})
+			.where(
+				and(
+					eq(workflowRun.namespaceId, namespaceId),
+					inArray(workflowRun.id, runIds),
+					inArray(workflowRun.status, NON_TERMINAL_WORKFLOW_RUN_STATUSES)
+				)
+			)
+			.returning({ id: workflowRun.id });
+
+		return result.map((row) => row.id);
+	},
+
+	async bulkTransitionToCancelledGlobal(_context: DaemonContext, runIds: NonEmptyArray<string>): Promise<string[]> {
 		const result = await db
 			.update(workflowRun)
 			.set({

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -1,9 +1,19 @@
+import type { WorkflowRunTransitionStateResponseV1 } from "@aikirun/types/api/workflow-run";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
+
 import { describe, expect, test } from "bun:test";
 import type { Repositories } from "../infra/db/types";
+import type { NamespaceRequestContext } from "../middleware/context";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createTaskStateMachineService } from "../service/task-state-machine";
 import { createWorkflowRunService } from "../service/workflow-run";
-import { createWorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
+import {
+	createWorkflowRunStateMachineService,
+	type WorkflowRunStateMachineService,
+} from "../service/workflow-run-state-machine";
 import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
 import { seedClaimedRun } from "../testing/run-seed";
 
@@ -19,6 +29,59 @@ function createService(repos: Repositories) {
 }
 
 describe("WorkflowRunService cancelByIds", () => {
+	test("cancels a claimed run with reason Cancelled", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const { service } = createService(repos);
+			const result = await service.cancelByIds(context, { ids: [runId] });
+			expect(result).toEqual({ cancelledIds: [runId] });
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(
+				expect.objectContaining({
+					id: runId,
+					status: "cancelled",
+					revision: revisionWhenClaimed + 1,
+					attempts: attemptsWhenClaimed,
+					state: { status: "cancelled", reason: "Cancelled" },
+				})
+			);
+		}));
+
+	test("cancelling a claimed run deletes its outbox row", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+
+			expect(await repos.workflowRunOutbox.getByWorkflowRunId(context.namespaceId, runId)).toEqual(
+				expect.objectContaining({ workflowRunId: runId })
+			);
+
+			const { service } = createService(repos);
+			await service.cancelByIds(context, { ids: [runId] });
+
+			expect(await repos.workflowRunOutbox.getByWorkflowRunId(context.namespaceId, runId)).toBeNull();
+		}));
+
+	test("an empty ids request cancels nothing", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const { service } = createService(repos);
+			expect(await service.cancelByIds(context, { ids: [] })).toEqual({ cancelledIds: [] });
+
+			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			expect(run).toEqual(expect.objectContaining({ id: runId, status: "running", revision: revisionWhenClaimed }));
+		}));
+
 	test("cancelling a sleeping run cancels its active sleep", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const { runId, revisionWhenClaimed } = await seedClaimedRun({
@@ -50,5 +113,153 @@ describe("WorkflowRunService cancelByIds", () => {
 
 			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
 			expect(sleeps).toEqual([expect.objectContaining({ name: "nap", status: "cancelled", cancelledAt })]);
+		}));
+
+	Object.entries({
+		cancelled: (context, stateMachine, seed) =>
+			stateMachine.transitionState(context, {
+				type: "pessimistic",
+				id: seed.runId,
+				state: { status: "cancelled" },
+			}),
+		completed: (context, stateMachine, seed) =>
+			stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: seed.runId,
+				state: { status: "completed", output: "receipt-9" },
+				expectedRevision: seed.revisionWhenClaimed,
+			}),
+		failed: (context, stateMachine, seed) =>
+			stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: seed.runId,
+				state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+				expectedRevision: seed.revisionWhenClaimed,
+			}),
+	} satisfies Record<
+		TerminalWorkflowRunStatus,
+		(
+			context: NamespaceRequestContext,
+			stateMachine: WorkflowRunStateMachineService,
+			seed: { runId: string; revisionWhenClaimed: number }
+		) => Promise<WorkflowRunTransitionStateResponseV1>
+	>).forEach(([status, reachTerminalStatus]) => {
+		test(`does not cancel a ${status} run`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const terminalRunSeed = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+				const { service, stateMachine } = createService(repos);
+				const terminal = await reachTerminalStatus(context, stateMachine, terminalRunSeed);
+
+				const { runId: cancellableRunId } = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+
+				const result = await service.cancelByIds(context, { ids: [terminalRunSeed.runId, cancellableRunId] });
+				expect(result).toEqual({ cancelledIds: [cancellableRunId] });
+
+				const terminalRun = await repos.workflowRun.getByIdWithState(context.namespaceId, terminalRunSeed.runId);
+				expect(terminalRun).toEqual(
+					expect.objectContaining({
+						id: terminalRunSeed.runId,
+						status,
+						revision: terminal.revision,
+						state: terminal.state,
+					})
+				);
+			}));
+	});
+
+	test("does not cancel a run from another namespace", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const otherNamespaceContext = namespaceRequestContextFactory.build({ namespaceId: "other-ns" as NamespaceId });
+			const foreignRunSeed = await seedClaimedRun({
+				namespaceRequestContext: otherNamespaceContext,
+				repos,
+				publisher,
+			});
+
+			const { service } = createService(repos);
+			expect(await service.cancelByIds(context, { ids: [foreignRunSeed.runId] })).toEqual({ cancelledIds: [] });
+
+			const foreignRun = await repos.workflowRun.getByIdWithState(
+				otherNamespaceContext.namespaceId,
+				foreignRunSeed.runId
+			);
+			expect(foreignRun).toEqual(
+				expect.objectContaining({
+					id: foreignRunSeed.runId,
+					status: "running",
+					revision: foreignRunSeed.revisionWhenClaimed,
+				})
+			);
+		}));
+
+	test("cancelling a run discards its running task", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const taskStateMachine = createTaskStateMachineService({ repos });
+			const taskInfo = await taskStateMachine.transitionState(context, {
+				type: "create",
+				id: runId,
+				expectedWorkflowRunRevision: revisionWhenClaimed,
+				taskName: "charge-card",
+				taskState: { status: "running", attempts: 1, input: { amountCents: 1250 } },
+			});
+
+			expect(await repos.task.listByWorkflowRunIdsAndStatuses(runId, ["discarded"])).toBeEmpty();
+			const runningTasks = await repos.task.listByWorkflowRunIdsAndStatuses(runId, ["running"]);
+			expect(runningTasks).toEqual([expect.objectContaining({ id: taskInfo.id, workflowRunId: runId })]);
+
+			const { service } = createService(repos);
+			await service.cancelByIds(context, { ids: [runId] });
+
+			expect(await repos.task.listByWorkflowRunIdsAndStatuses(runId, ["running"])).toBeEmpty();
+			const discardedTasks = await repos.task.listByWorkflowRunIdsAndStatuses(runId, ["discarded"]);
+			expect(discardedTasks).toEqual([expect.objectContaining({ id: taskInfo.id, workflowRunId: runId })]);
+		}));
+
+	test("cancelling a parent with a live child schedules the cancel-child-runs workflow", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+
+			const { service } = createService(repos);
+			const childRunId = await service.createWorkflowRun(context, {
+				name: parent.workflowName,
+				versionId: parent.workflowVersionId,
+				input: { orderId: "order-9" },
+				parentWorkflowRunId: parent.runId,
+			});
+
+			await service.cancelByIds(context, { ids: [parent.runId] });
+
+			// The child is not cancelled inline: a system workflow run is scheduled to cascade the
+			// cancellation, and the child stays untouched until that run executes.
+			const scheduledRuns = await repos.workflowRun.listByFilters(
+				context.namespaceId,
+				{ status: ["scheduled"] },
+				10,
+				0,
+				{
+					order: "asc",
+				}
+			);
+			expect(scheduledRuns).toEqual({
+				rows: [
+					expect.objectContaining({ id: childRunId, status: "scheduled", name: parent.workflowName }),
+					expect.objectContaining({ status: "scheduled", name: "aiki:cancel-child-runs" }),
+				],
+				total: 2,
+			});
 		}));
 });

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -477,7 +477,7 @@ export const createWorkflowRunService = ({
 		}
 
 		return repos.transaction(async (txRepos) => {
-			const cancelledRunIds = await txRepos.workflowRun.bulkTransitionToCancelled(ids);
+			const cancelledRunIds = await txRepos.workflowRun.bulkTransitionToCancelled(namespaceId, ids);
 			if (!isNonEmptyArray(cancelledRunIds)) {
 				return { cancelledIds: [] };
 			}


### PR DESCRIPTION
Cancelling runs by id fed the request's ids into a namespace-blind bulk update: any non-terminal run whose id appeared was cancelled, whichever namespace it belonged to. The read that then appends the cancel state transition is namespace-scoped, so a foreign run ended up cancelled with its latest recorded transition still describing the old state.

The bulk update now carries the caller's namespace in its predicate, so foreign ids cancel nothing. The schedule-overlap daemon, whose ids come from its own schedule query rather than a request, uses a global variant. The cancel-by-ids suite now covers the whole contract: response and final state, outbox-row deletion, empty ids, a does-not-cancel case for every terminal status, foreign-namespace ids, running-task discard, and the scheduled cascade run for a parent with a live child.