### PR TITLE
Rank-only timer queue that wakes only on a new earliest

### DIFF
--- a/.agents/skills/TESTING.md
+++ b/.agents/skills/TESTING.md
@@ -15,6 +15,8 @@ Before writing any test, study the exemplars for its tier and match their idioms
   from a typed case table.
 - `sdk/server/src/infra/db/workflow-run-outbox.integration.test.ts` — provider-contract suite,
   two-connection concurrency choreography.
+- `sdk/server/src/infra/timer/priority-queue.integration.test.ts` — infra contract suite,
+  provider-selected via the harness, wake and absence checks.
 
 ## Determinism
 
@@ -47,6 +49,26 @@ Before writing any test, study the exemplars for its tier and match their idioms
 - Waits ride event-signaled promises (see `lib/src/async/latch.ts`), never polling loops or
   sized sleeps. The one legitimate fixed wait is an absence check: wait a window, assert nothing
   changed.
+- To catch the moment the code under test reaches a blocking call, wrap the dependency it
+  blocks on: an object that fires a latch on entry, then forwards to the real thing. This turns
+  "has it parked yet?" into an event instead of sleeping for a while and hoping:
+
+  ```ts
+  const waitReached = createBinaryLatch();
+  const timerPriorityQueue: TimerPriorityQueue = {
+  	...realTimerPriorityQueue,
+  	createWaiter: () => {
+  		const realWaiter = realTimerPriorityQueue.createWaiter();
+  		return {
+  			...realWaiter,
+  			wait: (timeoutSeconds: number) => {
+  				waitReached.signal();
+  				return realWaiter.wait(timeoutSeconds);
+  			},
+  		};
+  	},
+  };
+  ```
 - Assert async rejections with a floating `expect(promise).rejects.toThrow(...)` — do not await
   it and do not rewrite it as try/catch.
 
@@ -121,13 +143,32 @@ Before writing any test, study the exemplars for its tier and match their idioms
   doesn't assert.
 - Test a behavior in the suite of the component that owns it: what a service writes is the
   service suite's contract; how a daemon reads it belongs to the daemon's suite. Don't place a
-  test by where you happen to be working.
-- Repository behavior is a provider contract. Test it once, at the provider-neutral level
-  (`sdk/server/src/infra/db/*.integration.test.ts`), never inside a provider directory. The
-  harness goes through the same `Database` seam as production, and `DATABASE_PROVIDER` in
-  `.env.test` picks the implementation — a new provider adds an env matrix row, not test
-  files. Assert outcomes, not locking mechanics; that is what keeps one suite valid for
-  every provider.
+  test by where you happen to be working. A loop or wiring test stops at the seam where it
+  hands work off — proving a popped timer reached the run lookup is the loop's claim; what
+  processing then writes belongs to the processing suite, driven directly at its own seam.
+- Observe the code under test through a dependency it calls on purpose — a repos lookup, a
+  queue pop — never through a side effect like the names bound via `logger.child`. A
+  logger-based observation only holds while the logging sits at a particular line inside the
+  function; move that line and the test starts passing before the behavior it claims to check
+  has happened.
+- Name tests and write their comments in the vocabulary of the interface under test. A
+  timer-queue consumer waits and wakes; "signal" is one adapter's way of waking it, and
+  another adapter may wake it differently. A word that only makes sense inside one
+  implementation doesn't belong in tests of the interface.
+- Pluggable infra is a provider contract — the database, the timer priority queue. Test the
+  contract once, at the provider-neutral level (`sdk/server/src/infra/db/`,
+  `sdk/server/src/infra/timer/`), never inside an adapter's directory. An env variable picks
+  the implementation (`DATABASE_PROVIDER`, `TIMER_PRIORITY_QUEUE_PROVIDER` in `.env.test`)
+  and CI supplies the matrix — a new provider adds a matrix row, not test files. Integration
+  tests get the instance from the harness (`withTimerPriorityQueue`, a scoped combinator like
+  `withRepos`). Assert outcomes, not locking or notification mechanics; that is what keeps
+  one suite valid for every provider.
+- Code that uses a contract may assume any conforming implementation, so its tests can run
+  against the cheapest one: the consumer's unit tests hardcode the in-memory queue as a
+  stand-in for "anything the contract suite has proven". The other half of that bargain:
+  every behavior a consumer leans on must actually be a contract test. The consumer's
+  shutdown always relied on close resolving a parked wait — nothing proved it, and when the
+  contract test was finally written, one adapter turned out to get it wrong.
 - Pick fixture data semantically orthogonal to the subject: don't give a time-based test
   time-shaped input.
 - Capture baselines from operation responses (a transition's returned revision, attempts) rather

--- a/.env.test.example
+++ b/.env.test.example
@@ -9,3 +9,8 @@
 DATABASE_PROVIDER=pg
 DATABASE_URL=postgresql://user:password@localhost:5432/aiki_test
 DATABASE_MAX_CONNECTIONS=1
+
+# memory or redis
+TIMER_PRIORITY_QUEUE_PROVIDER=memory
+# Set if TIMER_PRIORITY_QUEUE_PROVIDER is redis
+# REDIS_URL=redis://localhost:6379

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7
+        image: ${{ matrix.timer-priority-queue-provider == 'redis' && 'redis:7' || '' }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,14 +1,18 @@
 name: Integration Test
 
-# Stands up a throwaway Postgres and runs integration tests against it
+# Stands up throwaway backing services and runs integration tests against them.
 on:
   workflow_call:
 
 jobs:
   integration-test:
-    name: Integration Test
+    name: Integration Test (${{ matrix.timer-priority-queue-provider }} timers)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        timer-priority-queue-provider: [memory, redis]
     services:
       postgres:
         image: postgres:16
@@ -23,9 +27,20 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       DATABASE_PROVIDER: pg
       DATABASE_URL: postgresql://user:password@localhost:5432/aiki_test
+      TIMER_PRIORITY_QUEUE_PROVIDER: ${{ matrix.timer-priority-queue-provider }}
+      REDIS_URL: redis://localhost:6379
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,20 @@ bun run test:db:migrate:apply    # apply the server + iam migrations to it
 bun run test:integration
 ```
 
-CI runs these automatically against a throwaway Postgres, so opening a PR does not
-require a local test database — but run them locally when your change touches the
-database layer.
+Tests that use the timer priority queue are provider-selected: by default they run
+against the in-memory adapter, which needs no service. To run them against Redis:
+
+```bash
+docker run --name aiki-redis -p 6379:6379 -d redis:7
+TIMER_PRIORITY_QUEUE_PROVIDER=redis bun run test:integration
+```
+
+`REDIS_URL` overrides the default `redis://localhost:6379`.
+
+CI runs all of this automatically against throwaway Postgres and Redis services,
+matrixed over the timer-queue provider, so opening a PR does not require local
+services — but run the tests locally when your change touches the database layer
+or a timer-queue adapter.
 
 ## Before you open a PR
 

--- a/bun.lock
+++ b/bun.lock
@@ -229,9 +229,11 @@
       "devDependencies": {
         "@aikirun/lib": "workspace:*",
         "@aikirun/memory": "workspace:*",
+        "@aikirun/redis": "workspace:*",
         "@aikirun/testing": "workspace:*",
         "drizzle-kit": "^0.31.8",
         "fishery": "^2.4.0",
+        "ioredis": "^5.4.1",
         "postgres": "^3.4.8",
       },
       "peerDependencies": {

--- a/sdk/adapter/memory/src/timer/priority-queue.ts
+++ b/sdk/adapter/memory/src/timer/priority-queue.ts
@@ -7,7 +7,7 @@ import type {
 	TimerEntry,
 	TimerPriorityQueue,
 	TimerPriorityQueueContext,
-	TimerSignalWaiter,
+	TimerPriorityQueueWaiter,
 	TimerType,
 } from "@aikirun/types/infra/timer";
 
@@ -40,9 +40,9 @@ function compareTimerItems(a: TimerHeapItem, b: TimerHeapItem): number {
  * Returns a factory for creating the sorted set.
  *
  * State is allocated once per call to `inMemoryTimerPriorityQueue()` and persists
- * for the lifetime of the returned factory. That factory returns the
- * same underlying instance on every invocation, so a server can be stopped
- * and restarted (which re-invokes the factory) without losing queued timers.
+ * for the lifetime of the returned factory. Every factory invocation returns a
+ * queue over that same state, so a server can be stopped and restarted (which
+ * re-invokes the factory) without losing queued timers.
  */
 export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 	const heap = createMinHeap<TimerHeapItem>(compareTimerItems);
@@ -50,7 +50,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 
 	const waiterHandles = new Set<{ wake: () => void }>();
 
-	function drainSignals(): number {
+	function drainSignals(): { rank: number } | null {
 		let min: number | undefined;
 		for (const signal of signals) {
 			if (min === undefined || signal < min) {
@@ -58,24 +58,33 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 			}
 		}
 		signals.length = 0;
-		return min ?? 0;
+		return min === undefined ? null : { rank: min };
 	}
 
-	const timerPriorityQueue: TimerPriorityQueue = {
+	return (_context: TimerPriorityQueueContext): TimerPriorityQueue => ({
 		async add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult> {
-			let minDueAt = timers[0].dueAt;
+			const minRank = heap.peek()?.rank;
+
+			let proposedMinRank = timers[0].rank;
 			for (const timer of timers) {
-				if (timer.dueAt < minDueAt) {
-					minDueAt = timer.dueAt;
+				if (timer.rank < proposedMinRank) {
+					proposedMinRank = timer.rank;
 				}
 				heap.push({ rank: timer.rank, type: timer.type, id: timer.id });
 			}
-			signals.push(minDueAt);
-			waiterHandles.values().next().value?.wake();
+
+			// A signal exists to shorten the waiter's sleep. A timer that is not the
+			// new earliest is already covered by the wake the waiter has scheduled
+			// for the current earliest, so only a new front-of-queue sends one.
+			if (minRank === undefined || proposedMinRank < minRank) {
+				signals.push(proposedMinRank);
+				waiterHandles.values().next().value?.wake();
+			}
+
 			return { status: "added" };
 		},
 
-		async popDue(maxRank: number, limit: number): Promise<DueTimer[]> {
+		async popDue({ maxRank, limit }: { maxRank: number; limit: number }): Promise<DueTimer[]> {
 			const result: DueTimer[] = [];
 			while (result.length < limit) {
 				const next = heap.peek();
@@ -88,12 +97,12 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 			return result;
 		},
 
-		async peekNextRank(): Promise<number | null> {
+		async peekNext(): Promise<{ rank: number } | null> {
 			const next = heap.peek();
-			return next === undefined ? null : next.rank;
+			return next === undefined ? null : { rank: next.rank };
 		},
 
-		createSignalWaiter(): TimerSignalWaiter {
+		createWaiter(): TimerPriorityQueueWaiter {
 			let waiterHandle:
 				| {
 						timeout: ReturnType<typeof setTimeout> | undefined;
@@ -104,9 +113,9 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 			let closed = false;
 
 			return {
-				async wait(timeoutSeconds: number): Promise<number> {
+				async wait(timeoutSeconds: number): Promise<{ rank: number } | null> {
 					if (closed) {
-						return 0;
+						return null;
 					}
 					if (signals.length > 0) {
 						// Do not block if there are items in the set.
@@ -114,7 +123,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 						return drainSignals();
 					}
 
-					return new Promise<number>((resolve) => {
+					return new Promise<{ rank: number } | null>((resolve) => {
 						const detach = (): void => {
 							if (waiterHandle) {
 								if (waiterHandle.timeout !== undefined) {
@@ -133,7 +142,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 									? setTimeout(() => {
 											detach();
 											signals.length = 0;
-											resolve(0);
+											resolve(null);
 										}, timeoutSeconds * 1_000)
 									: undefined,
 							wake: () => {
@@ -143,7 +152,7 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 							},
 							close: () => {
 								detach();
-								resolve(0);
+								resolve(null);
 							},
 						};
 
@@ -160,7 +169,5 @@ export function inMemoryTimerPriorityQueue(): CreateTimerPriorityQueue {
 				},
 			};
 		},
-	};
-
-	return (_context: TimerPriorityQueueContext): TimerPriorityQueue => timerPriorityQueue;
+	});
 }

--- a/sdk/adapter/redis/src/timer/priority-queue.ts
+++ b/sdk/adapter/redis/src/timer/priority-queue.ts
@@ -5,7 +5,7 @@ import type {
 	TimerAddResult,
 	TimerEntry,
 	TimerPriorityQueue,
-	TimerSignalWaiter,
+	TimerPriorityQueueWaiter,
 	TimerType,
 } from "@aikirun/types/infra/timer";
 import type { Redis } from "ioredis";
@@ -27,15 +27,20 @@ function decodeMember(member: string, rank: number): DueTimer {
 
 /**
  * Atomically adds entries to the sorted set and pushes a signal carrying the
- * minimum dueAt timestamp of the batch. ARGV[1] is the minDueAt; subsequent
- * pairs are score/member.
+ * batch's minimum rank — but only when that minimum beats the previous earliest
+ * entry, or the set was empty. A signal exists to shorten the waiter's sleep;
+ * a timer behind the current earliest is already covered by the wake the
+ * waiter has scheduled for it. ARGV[1] is the minimum rank; subsequent pairs
+ * are score/member.
  */
 const ADD_AND_SIGNAL_SCRIPT = `
-local minDueAt = ARGV[1]
+local head = redis.call('ZRANGE', KEYS[1], 0, 0, 'WITHSCORES')
 for i = 2, #ARGV - 1, 2 do
   redis.call('ZADD', KEYS[1], ARGV[i], ARGV[i + 1])
 end
-redis.call('LPUSH', KEYS[2], minDueAt)
+if #head == 0 or tonumber(ARGV[1]) < tonumber(head[2]) then
+  redis.call('LPUSH', KEYS[2], ARGV[1])
+end
 return 1
 `;
 
@@ -83,18 +88,18 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 					return { status: "failed" };
 				}
 
-				let minDueAt = timers[0].dueAt;
+				let minRank = timers[0].rank;
 				const args: (string | number)[] = [];
 				for (const timer of timers) {
-					if (timer.dueAt < minDueAt) {
-						minDueAt = timer.dueAt;
+					if (timer.rank < minRank) {
+						minRank = timer.rank;
 					}
 					const member = encodeMember(timer.type, timer.id);
 					args.push(timer.rank, member);
 				}
 
 				try {
-					await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minDueAt, ...args);
+					await redis.eval(ADD_AND_SIGNAL_SCRIPT, 2, key, signalKey, minRank, ...args);
 				} catch (err) {
 					logger.warn("Timer add command failed", { err, "aiki.count": timers.length });
 					return { status: "failed" };
@@ -102,7 +107,7 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 				return { status: "added" };
 			},
 
-			async popDue(maxRank: number, limit: number): Promise<DueTimer[]> {
+			async popDue({ maxRank, limit }: { maxRank: number; limit: number }): Promise<DueTimer[]> {
 				redisTracker.assertIsAvailable();
 				const pairs = (await redis.eval(POP_DUE_TIMERS_SCRIPT, 1, key, maxRank, limit)) as string[];
 				if (pairs.length === 0) {
@@ -118,16 +123,16 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 				return result;
 			},
 
-			async peekNextRank(): Promise<number | null> {
+			async peekNext(): Promise<{ rank: number } | null> {
 				redisTracker.assertIsAvailable();
 				const result = await redis.zrangebyscore(key, "-inf", "+inf", "WITHSCORES", "LIMIT", 0, 1);
 				if (result.length < 2) {
 					return null;
 				}
-				return Number(result[1]);
+				return { rank: Number(result[1]) };
 			},
 
-			createSignalWaiter(): TimerSignalWaiter {
+			createWaiter(): TimerPriorityQueueWaiter {
 				const redisDuplicate = redis.duplicate({
 					maxRetriesPerRequest: 0,
 					enableOfflineQueue: false,
@@ -140,28 +145,37 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 				return {
 					/**
 					 * Blocks on the signal list, then drains any remaining signals.
-					 * Returns the minimum signal observed (combining BRPOP value with drained values).
-					 * Returns 0 if BRPOP timed out — drained values are discarded in that case since
-					 * peek-after-pop will rediscover them.
+					 * Returns the minimum signalled rank (combining BRPOP value with drained values).
+					 * Returns null if BRPOP timed out — drained values are discarded in that case
+					 * since peek-after-pop will rediscover them.
+					 * Close tears down the connection, which surfaces here as a rejected
+					 * command; a closed waiter turns that into the contract's null.
 					 */
-					async wait(timeoutSeconds: number): Promise<number> {
-						if (!completedReadyHandshake) {
-							await untilReadyHandshake(redisDuplicate);
-							completedReadyHandshake = true;
-						}
+					async wait(timeoutSeconds: number): Promise<{ rank: number } | null> {
+						try {
+							if (!completedReadyHandshake) {
+								await untilReadyHandshake(redisDuplicate);
+								completedReadyHandshake = true;
+							}
 
-						const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
-						if (result === null) {
-							await redisDuplicate.del(signalKey);
-							return 0;
-						}
+							const result = await redisDuplicate.brpop(signalKey, timeoutSeconds);
+							if (result === null) {
+								await redisDuplicate.del(signalKey);
+								return null;
+							}
 
-						const signal = Number(result[1]);
-						const minSignal = (await redisDuplicate.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
-						if (minSignal === null) {
-							return signal;
+							const signal = Number(result[1]);
+							const minSignal = (await redisDuplicate.eval(DRAIN_SIGNALS_SCRIPT, 1, signalKey)) as number | null;
+							if (minSignal === null) {
+								return { rank: signal };
+							}
+							return { rank: Math.min(signal, minSignal) };
+						} catch (err) {
+							if (closed) {
+								return null;
+							}
+							throw err;
 						}
-						return Math.min(signal, minSignal);
 					},
 
 					async close(): Promise<void> {

--- a/sdk/server/package.json
+++ b/sdk/server/package.json
@@ -45,9 +45,11 @@
 	"devDependencies": {
 		"@aikirun/lib": "workspace:*",
 		"@aikirun/memory": "workspace:*",
+		"@aikirun/redis": "workspace:*",
 		"@aikirun/testing": "workspace:*",
 		"drizzle-kit": "^0.31.8",
 		"fishery": "^2.4.0",
+		"ioredis": "^5.4.1",
 		"postgres": "^3.4.8"
 	},
 	"publishConfig": {

--- a/sdk/server/src/daemon/due-timers-consumer.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.test.ts
@@ -1,7 +1,8 @@
-import { delay } from "@aikirun/lib/async";
+import { createBinaryLatch } from "@aikirun/lib/async";
 import { asConfigProvider } from "@aikirun/lib/config";
 import { noopLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+import type { TimerPriorityQueue } from "@aikirun/types/infra/timer";
 
 import { startDueTimersConsumer } from "./due-timers-consumer";
 import { describe, expect, test } from "bun:test";
@@ -12,33 +13,86 @@ describe("startDueTimersConsumer", () => {
 	test("resolves when the runtime signal aborts while parked in an indefinite wait", async () => {
 		const abortController = new AbortController();
 		const { signal } = abortController;
-		const logger = noopLogger;
+		const waitReached = createBinaryLatch();
 
-		const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger, signal });
-		const configProvider = asConfigProvider(() => ({
-			limit: 1,
-			overshootMs: 10,
-			republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
-		}));
+		const realTimerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger, signal });
+		const timerPriorityQueue: TimerPriorityQueue = {
+			...realTimerPriorityQueue,
+			createWaiter: () => {
+				const realWaiter = realTimerPriorityQueue.createWaiter();
+				return {
+					...realWaiter,
+					wait: (timeoutSeconds: number) => {
+						waitReached.signal();
+						return realWaiter.wait(timeoutSeconds);
+					},
+				};
+			},
+		};
 
 		let resolved = false;
-		const consumer = startDueTimersConsumer(logger, {
+		const consumer = startDueTimersConsumer(noopLogger, {
 			repos: {} as unknown as Repositories,
 			signal,
 			timerPriorityQueue,
 			childRunCanceller: createChildRunCanceller(),
-			configProvider,
+			configProvider: asConfigProvider(() => ({
+				limit: 1,
+				overshootMs: 10,
+				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+			})),
 		}).then(() => {
 			resolved = true;
 		});
 
-		// Let the consumer reach the indefinite wait, then confirm it is genuinely parked.
-		await delay(20);
+		await waitReached.wait();
 		expect(resolved).toBe(false);
 
 		abortController.abort();
 		await consumer;
 
 		expect(resolved).toBe(true);
-	}, 2_000);
+	});
+
+	test("the startup peek discovers timers left over from a previous consumer's lifecycle", async () => {
+		const abortController = new AbortController();
+		const { signal } = abortController;
+		const processingReached = createBinaryLatch();
+
+		const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger, signal });
+		await timerPriorityQueue.add([{ type: "scheduled", id: "run-1", rank: 5 }]);
+		const drainWaiter = timerPriorityQueue.createWaiter();
+		expect(await drainWaiter.wait(0)).toEqual({ rank: 5 });
+		await drainWaiter.close();
+
+		const seenRunLookups: { ids: string[]; status: string }[] = [];
+		const repos = {
+			workflowRun: {
+				listByIdsAndStatus: async (_context: unknown, ids: string[], status: string) => {
+					seenRunLookups.push({ ids, status });
+					processingReached.signal();
+					return [];
+				},
+			},
+		} as unknown as Repositories;
+
+		const consumer = startDueTimersConsumer(noopLogger, {
+			repos,
+			signal,
+			timerPriorityQueue,
+			childRunCanceller: createChildRunCanceller(),
+			configProvider: asConfigProvider(() => ({
+				limit: 1_000,
+				overshootMs: 10,
+				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+			})),
+		});
+
+		await processingReached.wait();
+		abortController.abort();
+		await consumer;
+
+		expect(seenRunLookups).toEqual([{ ids: ["run-1"], status: "scheduled" }]);
+		expect(await timerPriorityQueue.peekNext()).toBeNull();
+	});
 });

--- a/sdk/server/src/daemon/due-timers-consumer.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.ts
@@ -4,7 +4,7 @@ import type { ConfigProvider } from "@aikirun/lib/config";
 import type { Logger } from "@aikirun/lib/logger";
 import { type RetryStrategy, withRetry } from "@aikirun/lib/retry";
 import type { Publisher } from "@aikirun/types/infra/queue";
-import type { DueTimer, TimerPriorityQueue, TimerSignalWaiter, TimerType } from "@aikirun/types/infra/timer";
+import type { DueTimer, TimerPriorityQueue, TimerPriorityQueueWaiter, TimerType } from "@aikirun/types/infra/timer";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStatus } from "@aikirun/types/workflow/run";
 
@@ -40,22 +40,22 @@ export interface DueTimersConsumerDeps {
 }
 
 export async function startDueTimersConsumer(logger: Logger, deps: DueTimersConsumerDeps): Promise<void> {
-	const timerSignalWaiter = deps.timerPriorityQueue.createSignalWaiter();
-	deps.signal.addEventListener("abort", () => void timerSignalWaiter.close(), { once: true });
+	const timerPriorityQueueWaiter = deps.timerPriorityQueue.createWaiter();
+	deps.signal.addEventListener("abort", () => void timerPriorityQueueWaiter.close(), { once: true });
 
 	try {
-		await dueTimersConsumerLoop(logger, deps, timerSignalWaiter);
+		await dueTimersConsumerLoop(logger, deps, timerPriorityQueueWaiter);
 	} finally {
-		await timerSignalWaiter.close();
+		await timerPriorityQueueWaiter.close();
 	}
 }
 
 async function dueTimersConsumerLoop(
 	logger: Logger,
 	deps: DueTimersConsumerDeps,
-	timerSignalWaiter: TimerSignalWaiter
+	timerPriorityQueueWaiter: TimerPriorityQueueWaiter
 ): Promise<void> {
-	const { timerPriorityQueue, signal: abortSignal, configProvider } = deps;
+	const { timerPriorityQueue, signal, configProvider } = deps;
 
 	const retryStrategy: RetryStrategy = {
 		type: "jittered",
@@ -64,49 +64,56 @@ async function dueTimersConsumerLoop(
 		maxDelayMs: 30_000,
 	};
 
-	// Peek on startup to discover entries left over from a previous consumer's lifecycle: they have
-	// no pending signal, so without this the first wait could block indefinitely.
-	const nextTimerRankResponse = await withRetry(() => timerPriorityQueue.peekNextRank(), retryStrategy, {
-		signal: abortSignal,
+	// Peek on startup to discover entries left over from a previous consumer's lifecycle.
+	// The waiter only unblocks on new entries, so without this the first wait could block indefinitely.
+	const nextTimerResponse = await withRetry(() => timerPriorityQueue.peekNext(), retryStrategy, {
+		signal,
 		onError: (err: unknown) => {
-			if (abortSignal.aborted) {
+			if (signal.aborted) {
 				return;
 			}
 			logger.warn("Due timers consumer failed, will retry", { err });
 		},
 	}).run();
-	if (nextTimerRankResponse.state !== "completed") {
+	if (nextTimerResponse.state !== "completed") {
 		return;
 	}
-	let nextTimerDueAtMs = nextTimerRankResponse.result && extractRankDueAtMs(nextTimerRankResponse.result);
+	let nextTimerDueAtMs = nextTimerResponse.result && extractRankDueAtMs(nextTimerResponse.result.rank);
 
-	while (!abortSignal.aborted) {
+	while (!signal.aborted) {
 		await withRetry(
 			async () => {
-				let timerSignal = 0;
+				let newTimer: { rank: number } | null = null;
 
 				if (nextTimerDueAtMs === null) {
-					timerSignal = await timerSignalWaiter.wait(0);
+					newTimer = await timerPriorityQueueWaiter.wait(0);
 				} else {
 					const waitMs = nextTimerDueAtMs - Date.now() + configProvider.config.overshootMs;
 					if (waitMs > 0) {
-						timerSignal = await timerSignalWaiter.wait(waitMs / 1_000);
+						newTimer = await timerPriorityQueueWaiter.wait(waitMs / 1_000);
 					}
 				}
 
-				if (abortSignal.aborted) {
+				if (signal.aborted) {
 					return;
 				}
 
-				if (timerSignal > Date.now()) {
-					if (nextTimerDueAtMs === null || timerSignal < nextTimerDueAtMs) {
-						nextTimerDueAtMs = timerSignal;
+				if (newTimer !== null) {
+					const newTimerDueAt = extractRankDueAtMs(newTimer.rank);
+					if (newTimerDueAt > Date.now()) {
+						if (nextTimerDueAtMs === null || newTimerDueAt < nextTimerDueAtMs) {
+							nextTimerDueAtMs = newTimerDueAt;
+						}
+						return;
 					}
-					return;
 				}
 
-				const context = createDaemonContext({ name: processDueTimers.name, logger, signal: abortSignal });
-				const next = () => timerPriorityQueue.popDue(computeRank({ dueAt: Date.now() }), configProvider.config.limit);
+				const context = createDaemonContext({ name: processDueTimers.name, logger, signal });
+				const next = () =>
+					timerPriorityQueue.popDue({
+						maxRank: computeRank({ dueAt: Date.now() }),
+						limit: configProvider.config.limit,
+					});
 
 				for await (const dueTimers of streamChunks(next, {
 					until: (chunk) => chunk.length < configProvider.config.limit,
@@ -118,14 +125,14 @@ async function dueTimersConsumerLoop(
 					}
 				}
 
-				const nextTimerRank = await timerPriorityQueue.peekNextRank();
-				nextTimerDueAtMs = nextTimerRank && extractRankDueAtMs(nextTimerRank);
+				const nextTimer = await timerPriorityQueue.peekNext();
+				nextTimerDueAtMs = nextTimer && extractRankDueAtMs(nextTimer.rank);
 			},
 			retryStrategy,
 			{
-				signal: abortSignal,
+				signal,
 				onError: (err: unknown) => {
-					if (abortSignal.aborted) {
+					if (signal.aborted) {
 						return;
 					}
 					logger.warn("Due timers consumer failed, will retry", { err });

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -49,7 +49,6 @@ export async function processImminentChildRunWaitTimedOutRuns(
 			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
 				type: "child_wait_timeout",
 				id: run.id,
-				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -49,7 +49,6 @@ export async function processImminentEventWaitTimedOutRuns(
 			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
 				type: "event_wait_timeout",
 				id: run.id,
-				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -82,7 +82,6 @@ export async function processImminentRecurringRuns(
 			const timers: TimerEntry[] = schedulesDueSoon.map((schedule) => ({
 				type: "recurring",
 				id: schedule.id,
-				dueAt: schedule.nextRunAt,
 				rank: computeRank({ dueAt: schedule.nextRunAt }),
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-runs.ts
@@ -49,7 +49,6 @@ export async function processImminentRetryableRuns(
 			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
 				type: "retry",
 				id: run.id,
-				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-retryable-tasks.ts
+++ b/sdk/server/src/daemon/imminent-retryable-tasks.ts
@@ -79,7 +79,6 @@ export async function processImminentRetryableTasks(
 			const timers: TimerEntry[] = tasksDueSoon.map((task) => ({
 				type: "task_retry",
 				id: task.workflowRunId,
-				dueAt: task.dueAt,
 				rank: computeRank({ dueAt: task.dueAt }),
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.ts
@@ -45,7 +45,6 @@ export async function processImminentScheduledRuns(
 			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
 				type: "scheduled",
 				id: run.id,
-				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
@@ -47,7 +47,6 @@ export async function processImminentSleepElapsedRuns(
 			const timers: TimerEntry[] = runsDueSoon.map((run) => ({
 				type: "sleep",
 				id: run.id,
-				dueAt: run.dueAt,
 				rank: run.rank,
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);

--- a/sdk/server/src/daemon/index.test.ts
+++ b/sdk/server/src/daemon/index.test.ts
@@ -5,7 +5,6 @@ import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerPriorityQueue } from "@aikirun/types/infra/timer";
 
-import { processDueTimers } from "./due-timers-consumer";
 import { processImminentChildRunWaitTimedOutRuns } from "./imminent-child-run-wait-timed-out-runs";
 import { processImminentEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
 import { processImminentRecurringRuns } from "./imminent-recurring-runs";
@@ -141,7 +140,7 @@ describe("pollingDaemon", () => {
 		await loop;
 
 		expect(tickCount).toBeGreaterThanOrEqual(2);
-	}, 5_000);
+	});
 
 	test("resolves promptly when aborted while parked in the inter-tick delay", async () => {
 		const abortController = new AbortController();
@@ -170,30 +169,27 @@ describe("startDaemons", () => {
 	function startTestDaemons(
 		signal: AbortSignal,
 		logger: Logger,
-		extraDeps?: { publisher?: Publisher; timerPriorityQueue?: TimerPriorityQueue }
+		deps?: { repos?: Repositories; publisher?: Publisher; timerPriorityQueue?: TimerPriorityQueue }
 	): Promise<void> {
 		return startDaemons(logger, {
-			repos: {} as unknown as Repositories,
+			repos: deps?.repos ?? ({} as unknown as Repositories),
 			signal,
 			configProvider: asConfigProvider(() => defaultServerRuntimeConfig),
+			publisher: deps?.publisher,
+			timerPriorityQueue: deps?.timerPriorityQueue,
 			childRunCanceller: createChildRunCanceller(),
-			...extraDeps,
 		});
 	}
 
 	// Daemons name their context on each tick via logger.child({ "aiki.daemonName" }),
 	// so the child bindings are where mounted daemons become observable.
-	function createDaemonNameRecordingLogger(
-		seenDaemonNames: string[],
-		onDaemonName?: (daemonName: string) => void
-	): Logger {
+	function createDaemonNameRecordingLogger(seenDaemonNames: string[]): Logger {
 		const logger: Logger = {
 			...noopLogger,
 			child: (bindings) => {
 				const daemonName = bindings["aiki.daemonName"];
 				if (typeof daemonName === "string") {
 					seenDaemonNames.push(daemonName);
-					onDaemonName?.(daemonName);
 				}
 				return logger;
 			},
@@ -241,26 +237,30 @@ describe("startDaemons", () => {
 
 	test("mounts the due-timers consumer when a timer priority queue is provided", async () => {
 		const abortController = new AbortController();
-		const consumerWoken = createBinaryLatch();
-		const seenDaemonNames: string[] = [];
+		const consumerProcessingReached = createBinaryLatch();
 
-		const logger = createDaemonNameRecordingLogger(seenDaemonNames, (daemonName) => {
-			if (daemonName === processDueTimers.name) {
-				consumerWoken.signal();
-			}
-		});
-		const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger, signal: abortController.signal });
+		const seenRunLookups: { ids: string[]; status: string }[] = [];
+		const repos = {
+			workflowRun: {
+				listByIdsAndStatus: async (_context: unknown, ids: string[], status: string) => {
+					seenRunLookups.push({ ids, status });
+					consumerProcessingReached.signal();
+					return [];
+				},
+			},
+		} as unknown as Repositories;
+		const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger, signal: abortController.signal });
 
-		const daemons = startTestDaemons(abortController.signal, logger, { timerPriorityQueue });
+		const daemons = startTestDaemons(abortController.signal, noopLogger, { timerPriorityQueue, repos });
 
-		// dueAt 0 wakes the consumer immediately.
-		await timerPriorityQueue.add([{ type: "scheduled", id: "timer-1", dueAt: 0, rank: 0 }]);
-		await consumerWoken.wait();
+		await timerPriorityQueue.add([{ type: "scheduled", id: "timer-1", rank: 0 }]);
+		await consumerProcessingReached.wait();
 
 		abortController.abort();
 		await daemons;
 
-		expect(seenDaemonNames).toEqual(baseDaemonNames.concat(processDueTimers.name));
+		expect(seenRunLookups).toEqual([{ ids: ["timer-1"], status: "scheduled" }]);
+		expect(await timerPriorityQueue.peekNext()).toBeNull();
 	});
 
 	test("resolves when the signal aborts", async () => {

--- a/sdk/server/src/infra/timer/priority-queue.integration.test.ts
+++ b/sdk/server/src/infra/timer/priority-queue.integration.test.ts
@@ -1,0 +1,168 @@
+import type { TimerPriorityQueue, TimerPriorityQueueWaiter } from "@aikirun/types/infra/timer";
+
+import { describe, expect, test } from "bun:test";
+import { withTimerPriorityQueue } from "../../testing/harness";
+
+describe("timer priority queue", () => {
+	describe("add", () => {
+		test("add reports the batch as added", () =>
+			withTimerPriorityQueue(async (queue) => {
+				const result = await queue.add([{ type: "sleep", id: "timer-a", rank: 10 }]);
+				expect(result).toEqual({ status: "added" });
+			}));
+	});
+
+	describe("popDue", () => {
+		test("popDue removes and returns the timers at or below the max rank, earliest first", () =>
+			withTimerPriorityQueue(async (queue) => {
+				await queue.add([
+					{ type: "sleep", id: "timer-a", rank: 10 },
+					{ type: "scheduled", id: "timer-c", rank: 30 },
+					{ type: "retry", id: "timer-b", rank: 20 },
+				]);
+
+				const dueTimers = await queue.popDue({ maxRank: 20, limit: 10 });
+
+				expect(dueTimers).toEqual([
+					{ type: "sleep", id: "timer-a", rank: 10 },
+					{ type: "retry", id: "timer-b", rank: 20 },
+				]);
+				expect(await queue.peekNext()).toEqual({ rank: 30 });
+			}));
+
+		test("popDue honors the limit and leaves the remainder for the next call", () =>
+			withTimerPriorityQueue(async (queue) => {
+				await queue.add([
+					{ type: "sleep", id: "timer-a", rank: 10 },
+					{ type: "scheduled", id: "timer-c", rank: 30 },
+					{ type: "retry", id: "timer-b", rank: 20 },
+				]);
+
+				const firstChunk = await queue.popDue({ maxRank: 30, limit: 2 });
+				const secondChunk = await queue.popDue({ maxRank: 30, limit: 2 });
+
+				expect(firstChunk).toEqual([
+					{ type: "sleep", id: "timer-a", rank: 10 },
+					{ type: "retry", id: "timer-b", rank: 20 },
+				]);
+				expect(secondChunk).toEqual([{ type: "scheduled", id: "timer-c", rank: 30 }]);
+			}));
+
+		test("popDue returns nothing when no timer is at or below the max rank", () =>
+			withTimerPriorityQueue(async (queue) => {
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 30 }]);
+
+				expect(await queue.popDue({ maxRank: 29, limit: 10 })).toEqual([]);
+				expect(await queue.peekNext()).toEqual({ rank: 30 });
+			}));
+
+		test("popDue on an empty queue returns nothing", () =>
+			withTimerPriorityQueue(async (queue) => {
+				expect(await queue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([]);
+			}));
+	});
+
+	describe("peekNext", () => {
+		test("peekNext returns the earliest entry without removing it", () =>
+			withTimerPriorityQueue(async (queue) => {
+				await queue.add([
+					{ type: "retry", id: "timer-b", rank: 20 },
+					{ type: "sleep", id: "timer-a", rank: 10 },
+				]);
+
+				expect(await queue.peekNext()).toEqual({ rank: 10 });
+				expect(await queue.peekNext()).toEqual({ rank: 10 });
+				expect(await queue.popDue({ maxRank: 30, limit: 10 })).toHaveLength(2);
+			}));
+
+		test("peekNext is null on an empty queue", () =>
+			withTimerPriorityQueue(async (queue) => {
+				expect(await queue.peekNext()).toBeNull();
+			}));
+	});
+
+	describe("waiter", () => {
+		async function withTimerPriorityQueueAndWaiter(
+			fn: (queue: TimerPriorityQueue, waiter: TimerPriorityQueueWaiter) => Promise<void>
+		): Promise<void> {
+			await withTimerPriorityQueue(async (queue) => {
+				const waiter = queue.createWaiter();
+				try {
+					await fn(queue, waiter);
+				} finally {
+					await waiter.close();
+				}
+			});
+		}
+
+		test("an add into an empty queue wakes the waiter with the batch's minimum rank", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				await queue.add([
+					{ type: "sleep", id: "timer-a", rank: 30 },
+					{ type: "retry", id: "timer-b", rank: 15 },
+				]);
+
+				expect(await waiter.wait(0)).toEqual({ rank: 15 });
+			}));
+
+		test("an add that beats the current earliest wakes the waiter with the new minimum", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 50 }]);
+				expect(await waiter.wait(0)).toEqual({ rank: 50 });
+
+				await queue.add([{ type: "retry", id: "timer-b", rank: 40 }]);
+
+				expect(await waiter.wait(0)).toEqual({ rank: 40 });
+			}));
+
+		test("an add behind the current earliest does not wake the waiter", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 10 }]);
+				expect(await waiter.wait(0)).toEqual({ rank: 10 });
+
+				await queue.add([{ type: "retry", id: "timer-b", rank: 20 }]);
+
+				// Absence check: a timer behind the current earliest never needs to wake a
+				// waiter, so the only correct outcome is a timeout.
+				expect(await waiter.wait(0.1)).toBeNull();
+				expect(await queue.popDue({ maxRank: 30, limit: 10 })).toEqual([
+					{ type: "sleep", id: "timer-a", rank: 10 },
+					{ type: "retry", id: "timer-b", rank: 20 },
+				]);
+			}));
+
+		test("an add that ties the current earliest does not wake the waiter", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 10 }]);
+				expect(await waiter.wait(0)).toEqual({ rank: 10 });
+
+				await queue.add([{ type: "retry", id: "timer-b", rank: 10 }]);
+
+				expect(await waiter.wait(0.1)).toBeNull();
+			}));
+
+		test("a parked waiter wakes on a qualifying add", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 50 }]);
+				expect(await waiter.wait(0)).toEqual({ rank: 50 });
+
+				const waitPromise = waiter.wait(0);
+				await queue.add([{ type: "retry", id: "timer-b", rank: 5 }]);
+
+				expect(await waitPromise).toEqual({ rank: 5 });
+			}));
+
+		test("close resolves a parked wait with null", () =>
+			withTimerPriorityQueueAndWaiter(async (queue, waiter) => {
+				// The first wake completes any lazy connection setup, so the second wait
+				// is genuinely parked when close arrives.
+				await queue.add([{ type: "sleep", id: "timer-a", rank: 50 }]);
+				expect(await waiter.wait(0)).toEqual({ rank: 50 });
+
+				const waitPromise = waiter.wait(0);
+				await waiter.close();
+
+				expect(await waitPromise).toBeNull();
+			}));
+	});
+});

--- a/sdk/server/src/testing/harness.ts
+++ b/sdk/server/src/testing/harness.ts
@@ -1,6 +1,11 @@
 import { loadDatabaseConfig } from "@aikirun/lib/db";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+import { redisTimerPriorityQueue } from "@aikirun/redis";
 import { type FakePublisher, fakePublisher } from "@aikirun/testing/infra/queue";
 import type { CreateDatabase, Database } from "@aikirun/types/infra/db";
+import type { TimerPriorityQueue } from "@aikirun/types/infra/timer";
+import Redis from "ioredis";
 
 import { daemonContextFactory, namespaceRequestContextFactory } from "./data-factory/middleware/context";
 import { resetDatabase } from "./infra/db/reset";
@@ -101,5 +106,50 @@ export async function withRepos(fn: (repos: Repositories) => Promise<void>): Pro
 		await fn(repos);
 	} finally {
 		await createDb.close();
+	}
+}
+
+/**
+ * Provides a `TimerPriorityQueue` for the scope of `fn`.
+ * `TIMER_PRIORITY_QUEUE_PROVIDER` env variable is read to determine which implementation is used.
+ * Supported values are "memory" and "redis". Default is "memory".
+ *
+ * @example
+ * withTimerPriorityQueue(async (queue) => { ... });
+ */
+export async function withTimerPriorityQueue(fn: (queue: TimerPriorityQueue) => Promise<void>): Promise<void> {
+	const provider = process.env.TIMER_PRIORITY_QUEUE_PROVIDER ?? "memory";
+	const abortController = new AbortController();
+	try {
+		switch (provider) {
+			case "memory": {
+				const queue = inMemoryTimerPriorityQueue()({ logger: noopLogger, signal: abortController.signal });
+				await fn(queue);
+				return;
+			}
+			case "redis": {
+				const redisClient = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379");
+				redisClient.on("error", () => {});
+				try {
+					const timersKey = "aiki:timers";
+					await redisClient.del(timersKey, `${timersKey}:signal`);
+					const queue = redisTimerPriorityQueue(
+						redisClient,
+						timersKey
+					)({
+						logger: noopLogger,
+						signal: abortController.signal,
+					});
+					await fn(queue);
+				} finally {
+					await redisClient.quit();
+				}
+				return;
+			}
+			default:
+				throw new Error(`Unsupported TIMER_PRIORITY_QUEUE_PROVIDER: ${provider}. Must be one of "memory, redis"`);
+		}
+	} finally {
+		abortController.abort();
 	}
 }

--- a/types/src/infra/timer.ts
+++ b/types/src/infra/timer.ts
@@ -13,7 +13,6 @@ export type TimerType =
 export interface TimerEntry {
 	type: TimerType;
 	id: string;
-	dueAt: number;
 	rank: number;
 }
 
@@ -23,8 +22,13 @@ export interface DueTimer {
 	rank: number;
 }
 
-export interface TimerSignalWaiter {
-	wait(timeoutSeconds: number): Promise<number>;
+export interface TimerPriorityQueueWaiter {
+	/**
+	 * Resolves when a new timer whose rank is lower than the
+	 * queue front's rank arrives, or null on timeout or close.
+	 * `timeoutSeconds` of 0 waits indefinitely.
+	 */
+	wait(timeoutSeconds: number): Promise<{ rank: number } | null>;
 	close(): Promise<void>;
 }
 
@@ -32,9 +36,9 @@ export type TimerAddResult = { status: "added" } | { status: "failed" };
 
 export interface TimerPriorityQueue {
 	add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult>;
-	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
-	peekNextRank(): Promise<number | null>;
-	createSignalWaiter(): TimerSignalWaiter;
+	popDue(params: { maxRank: number; limit: number }): Promise<DueTimer[]>;
+	peekNext(): Promise<{ rank: number } | null>;
+	createWaiter(): TimerPriorityQueueWaiter;
 }
 
 export interface TimerPriorityQueueContext {


### PR DESCRIPTION
## Background

The timer priority queue is how due work fires on time instead of waiting for the next poll. The polling daemons (the backstop scans) find imminent runs in the database and add a timer per run; a single consumer sleeps until the earliest timer is due, pops everything due, and moves those runs forward. Two adapters implement the queue: an in-memory heap and a Redis sorted set. The consumer blocks on a waiter created from the queue, and an add can wake it.

A timer's rank is its ordering key: `dueAt * 10 + priority`. Time dominates — a timer due one millisecond earlier always sorts first; priority only breaks ties inside the same millisecond.

Because the backstop scans re-add the same timers on every pass, the queue promises very little on purpose: duplicates, repeat pops, and spurious wakes are all allowed, and the consumer checks run state before acting on anything it pops.

## Problem

Every add wakes the consumer. The consumer compares the woken value against the deadline it is sleeping toward and, almost always, goes straight back to sleep — because most adds are backstop re-adds of timers already in the queue, which are never a new earliest. On the Redis adapter, every one of those useless wakes is queue traffic plus a consumer round-trip.

The contract also spoke two currencies. An entry carried both `dueAt` and `rank`; wakes were denominated in due time while pops and peeks were denominated in rank. Nothing forced the two fields to agree — a caller could mint the rank from one time and pass a different `dueAt`, and the wake would quietly disagree with the pop order.

Close behavior was unspecified, and the adapters disagreed: the in-memory waiter resolved a parked wait when closed; the Redis waiter tore down its connection, so a parked wait rejected. Neither adapter had test coverage.

## Solution

**One currency: rank.** Entries drop `dueAt`. A wake carries the batch's minimum rank, and the consumer decodes a woken rank into a due time exactly the way it already decodes a peeked queue front. This is sound because rank is time-dominant: the earliest rank is the earliest due time, and priority can only reorder timers due in the same millisecond, where the choice cannot change when the consumer should wake.

**Wake only on a new earliest.** A wake exists to shorten the consumer's sleep. A timer that is not the new front of the queue is already covered by the wake the consumer has scheduled for the current front, so it needs no wake of its own. An add therefore wakes only when its batch minimum beats the previous front, or when the queue was empty. The in-memory adapter reads the front before pushing the batch; the Redis script reads the front before its ZADDs and pushes the wake conditionally, all in one atomic script. Backstop re-adds — the bulk of all adds — now stay silent.

One wasted wake survives: a timer due in the same millisecond as the front but with a better priority has a strictly smaller rank, so it still wakes the consumer — which decodes the same due time and goes back to sleep. Suppressing it would mean teaching the adapters to split a rank into time and priority, which they deliberately don't know how to do. The case is rare, and the queue already allows wakes that turn out to be for nothing.

This leans on one existing behavior: the consumer peeks the queue before its first wait, so a consumer that starts against a populated queue does not depend on re-add wakes that no longer come. That peek was already there; a test now pins it, because after this change it is the only thing standing between a restarted consumer and an indefinite park.

**The contract, before and after:**

```ts
// before
interface TimerEntry { type: TimerType; id: string; dueAt: number; rank: number }
interface TimerSignalWaiter {
	wait(timeoutSeconds: number): Promise<number>; // minimum signalled dueAt; 0 = timed out
	close(): Promise<void>;
}
interface TimerPriorityQueue {
	add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult>;
	popDue(maxRank: number, limit: number): Promise<DueTimer[]>;
	peekNextRank(): Promise<number | null>;
	createSignalWaiter(): TimerSignalWaiter;
}

// after
interface TimerEntry { type: TimerType; id: string; rank: number }
interface TimerPriorityQueueWaiter {
	wait(timeoutSeconds: number): Promise<{ rank: number } | null>; // null = timed out or closed
	close(): Promise<void>;
}
interface TimerPriorityQueue {
	add(timers: NonEmptyArray<TimerEntry>): Promise<TimerAddResult>;
	popDue(params: { maxRank: number; limit: number }): Promise<DueTimer[]>;
	peekNext(): Promise<{ rank: number } | null>;
	createWaiter(): TimerPriorityQueueWaiter;
}
```

Three shape decisions worth naming. `null` replaces the `0` sentinel: rank 0 is a real value, and with an object result the natural `if (wake)` check is correct instead of subtly wrong. `popDue` takes an object because its two parameters are both numbers, and a positional swap doesn't crash — it pops nothing, forever, silently. The waiter is named for its owner rather than its mechanism: "signal" is how one adapter happens to wake it, not part of the interface, and an adapter is free to wake its waiters some other way.

**Close is now part of the contract.** Closing a waiter resolves a parked wait with `null`. The Redis waiter's close tears down its blocking connection, which surfaces inside `wait` as a rejected command; a closed waiter turns that rejection into `null`. The contract test for this is what exposed the divergence — the consumer's shutdown path had been relying on close behavior that nothing proved.

**Tests and CI.** One provider-blind contract suite covers add, popDue, peekNext, and the waiter — including absence checks that an add behind the current front, or one that ties it, does not wake. `TIMER_PRIORITY_QUEUE_PROVIDER` picks the adapter (memory by default, which needs no service), and the integration workflow now runs a matrix of memory and redis rows against a Redis service — a new adapter is a matrix row, not new test files. The test harness gains a scoped combinator that hands tests the selected queue, in the same style as its scoped repos combinator. The consumer's unit tests keep a hardcoded in-memory queue: the contract suite proves conformance, so tests of queue consumers may assume any conforming implementation and use the cheapest one.

## Breaking changes

The timer contract in `@aikirun/types` changed: `TimerEntry` loses `dueAt`; `TimerSignalWaiter` / `createSignalWaiter` / `peekNextRank` are now `TimerPriorityQueueWaiter` / `createWaiter` / `peekNext`; `wait` resolves `{ rank } | null` instead of a number with a `0` sentinel; `popDue` takes `{ maxRank, limit }`. New test-only env vars `TIMER_PRIORITY_QUEUE_PROVIDER` and `REDIS_URL`, documented in `.env.test.example` and CONTRIBUTING.