### PR TITLE
Standardize Redis configuration on a single URL

### DIFF
--- a/app/server/.env.example
+++ b/app/server/.env.example
@@ -8,9 +8,7 @@ AIKI_SERVER_PORT=9850
 CORS_ORIGINS=http://localhost:9851
 
 # Optional: Redis for lower-latency message delivery
-# REDIS_HOST=localhost
-# REDIS_PORT=6379
-# REDIS_PASSWORD=
+# REDIS_URL=redis://localhost:6379
 
 DATABASE_PROVIDER=pg
 

--- a/app/server/src/config/loader.ts
+++ b/app/server/src/config/loader.ts
@@ -13,11 +13,9 @@ export async function loadAppServerConfig(params?: { path?: string }): Promise<C
 
 	const db = loadDatabaseConfig();
 
-	const redisRaw = process.env.REDIS_HOST
+	const redisRaw = process.env.REDIS_URL
 		? {
-				host: process.env.REDIS_HOST,
-				port: process.env.REDIS_PORT,
-				password: process.env.REDIS_PASSWORD,
+				url: process.env.REDIS_URL,
 			}
 		: undefined;
 

--- a/app/server/src/config/schema.ts
+++ b/app/server/src/config/schema.ts
@@ -16,9 +16,7 @@ const uniqueCommaSeparatedToItems = type("string").pipe((v) =>
 );
 
 export const redisConfigSchema = type({
-	host: "string > 0 = 'localhost'",
-	port: "string.integer.parse | number.integer > 0 = 6379",
-	"password?": "string | undefined",
+	url: "string > 0",
 });
 
 export const authConfigSchema = type({

--- a/app/server/src/serve.ts
+++ b/app/server/src/serve.ts
@@ -78,11 +78,7 @@ export async function startAppServer({ config }: { config: AppServerConfig }): P
 }
 
 function createRedis(config: RedisConfig, logger: Logger) {
-	const redis = new Redis({
-		host: config.host,
-		port: config.port,
-		password: config.password,
-	});
+	const redis = new Redis(config.url);
 	const connectionSupervisor = attachConnectionSupervisor(redis, { logger });
 
 	type State =

--- a/app/website/content/docs/architecture/server.md
+++ b/app/website/content/docs/architecture/server.md
@@ -72,7 +72,7 @@ Optional pieces plug in the same way — `cache`, `iam` (multi-tenancy and auth)
 import { redisPublisher, redisTimerPriorityQueue } from "@aikirun/redis";
 import { Redis } from "ioredis";
 
-const redis = new Redis({ host: "localhost", port: 6379 });
+const redis = new Redis("redis://localhost:6379");
 
 const aikiServer = server({
   db: database({ provider: "pg", url: databaseUrl }),

--- a/app/website/content/docs/architecture/subscribers.md
+++ b/app/website/content/docs/architecture/subscribers.md
@@ -39,10 +39,7 @@ import { redisSubscriber } from "@aikirun/redis";
 
 const aikiWorker = worker({
   workflows: [orderWorkflowV1],
-  subscriber: redisSubscriber({
-    host: "localhost",
-    port: 6379,
-  }),
+  subscriber: redisSubscriber({ url: "redis://localhost:6379" }),
 });
 ```
 

--- a/app/website/content/docs/core-concepts/workers.md
+++ b/app/website/content/docs/core-concepts/workers.md
@@ -100,7 +100,7 @@ import { redisSubscriber } from "@aikirun/redis";
 
 const aikiWorker = worker({
   workflows: [orderWorkflowV1],
-  subscriber: redisSubscriber({ host: "localhost", port: 6379 }),
+  subscriber: redisSubscriber({ url: "redis://localhost:6379" }),
 });
 ```
 

--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -171,9 +171,7 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `AIKI_SERVER_BASE_URL` | If IAM is on | — | Public URL of the server; required only when `AIKI_SERVER_AUTH_SECRET` is also set |
 | `AIKI_SERVER_AUTH_SECRET` | If IAM is on | — | Authentication secret; setting this (with `AIKI_SERVER_BASE_URL`) activates the IAM package |
 | `CORS_ORIGINS` | If the dashboard is cross-origin | — | Comma-separated allowed origins, e.g. a static-host dashboard's; unneeded behind the dashboard image's proxy |
-| `REDIS_HOST` | No | — | Enables Redis-backed work distribution and timer dispatch |
-| `REDIS_PORT` | No | `6379` | Redis port |
-| `REDIS_PASSWORD` | No | — | Redis password |
+| `REDIS_URL` | No | — | Redis connection string, e.g. `redis://localhost:6379`; setting it enables Redis-backed work distribution and timer dispatch |
 | `LOG_LEVEL` | No | `info` | Log level |
 | `PRETTY_LOGS` | No | `true` | Pretty-print logs (set `false` for JSON output) |
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,9 +30,7 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
-      REDIS_HOST: ${REDIS_HOST:-}
-      REDIS_PORT: ${REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_URL: ${REDIS_URL:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       PRETTY_LOGS: ${PRETTY_LOGS:-true}
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,7 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@host.docker.internal:5432/aiki}
       DATABASE_MAX_CONNECTIONS: ${DATABASE_MAX_CONNECTIONS:-10}
       DATABASE_CA_CERT: ${DATABASE_CA_CERT:-}
-      REDIS_HOST: ${REDIS_HOST:-}
-      REDIS_PORT: ${REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_URL: ${REDIS_URL:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       PRETTY_LOGS: ${PRETTY_LOGS:-true}
     extra_hosts:

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -18,6 +18,4 @@ DATABASE_MAX_CONNECTIONS=10
 # AIKI_API_KEY=yourApiKey
 
 # Optional: Redis for lower-latency message delivery
-# REDIS_HOST=localhost
-# REDIS_PORT=6379
-# REDIS_PASSWORD=
+# REDIS_URL=redis://localhost:6379

--- a/examples/src/runner.ts
+++ b/examples/src/runner.ts
@@ -98,14 +98,8 @@ async function setup(): Promise<Setup> {
 	const url = process.env.AIKI_SERVER_URL ?? "http://localhost:9850";
 	const apiKey = process.env.AIKI_API_KEY;
 
-	const redisHost = process.env.REDIS_HOST;
-	const subscriber = redisHost
-		? redisSubscriber({
-				host: redisHost,
-				port: Number(process.env.REDIS_PORT ?? 6379),
-				...(process.env.REDIS_PASSWORD && { password: process.env.REDIS_PASSWORD }),
-			})
-		: undefined;
+	const redisUrl = process.env.REDIS_URL;
+	const subscriber = redisUrl ? redisSubscriber({ url: redisUrl }) : undefined;
 
 	return {
 		client: client({ url, ...(apiKey && { apiKey }) }),

--- a/sdk/adapter/redis/README.md
+++ b/sdk/adapter/redis/README.md
@@ -17,7 +17,7 @@ import { orderWorkflowV1 } from "./workflows.ts";
 
 const aikiWorker = worker({
 	workflows: [orderWorkflowV1],
-	subscriber: redisSubscriber({ host: "localhost", port: 6379 }),
+	subscriber: redisSubscriber({ url: "redis://localhost:6379" }),
 });
 ```
 

--- a/sdk/adapter/redis/src/connection.ts
+++ b/sdk/adapter/redis/src/connection.ts
@@ -2,10 +2,7 @@ import type { Logger } from "@aikirun/lib/logger";
 import type { Redis } from "ioredis";
 
 export interface RedisConnectionParams {
-	host: string;
-	port: number;
-	password?: string;
-	db?: number;
+	url: string;
 	connectTimeoutMs?: number;
 }
 

--- a/sdk/adapter/redis/src/queue/subscriber.ts
+++ b/sdk/adapter/redis/src/queue/subscriber.ts
@@ -95,11 +95,7 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 	return ({ workflows, pools, logger, signal }): Subscriber => {
 		const connectTimeoutMs = params.connectTimeoutMs ?? 5_000;
 
-		const redis = new Redis({
-			host: params.host,
-			port: params.port,
-			password: params.password,
-			db: params.db,
+		const redis = new Redis(params.url, {
 			maxRetriesPerRequest: 0,
 			enableOfflineQueue: false,
 			connectTimeout: connectTimeoutMs,


### PR DESCRIPTION
## Motivation

Redis configuration had two shapes. The server app, compose files, examples, and docs read discrete `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` variables, and the Redis subscriber — the adapter workers use to pull ready runs from Redis queues — took `{ host, port, password, db }` params. The test harness and CI already used a single `REDIS_URL` connection string, which is also how the database settled the same question (`DATABASE_URL`).

The discrete shape had two real costs. Redis is optional, and the server enabled it when `REDIS_HOST` was set — so a deployment that set only `REDIS_PASSWORD` silently ran without Redis. And it had no TLS story: adding one would mean more variables, while a URL carries TLS through the `rediss://` scheme, which the ioredis client library handles natively.

## Solution

A Redis connection is a URL everywhere. The server reads `REDIS_URL`, and its presence is the enable toggle — the config either holds a URL or holds no Redis at all, with no partial state. The subscriber's connection params follow:

```typescript
// before
redisSubscriber({ host, port, password?, db? })
// after
redisSubscriber({ url })
```

Host, port, password, and db index all ride the URL (`redis://:password@host:port/db`). Compose files, env examples, and docs now document the single variable. The adapter README's quick-start example was also broken independently of this change (it passed the subscriber factory to itself); it now shows a valid call.

## Breaking changes

- `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD` are replaced by `REDIS_URL`.
- `redisSubscriber` takes `{ url }` instead of `{ host, port, password, db }`.