### PR TITLE
In-process timer priority queue by default

### DIFF
--- a/app/server/package.json
+++ b/app/server/package.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"@aikirun/iam": "workspace:*",
 		"@aikirun/lib": "workspace:*",
+		"@aikirun/memory": "workspace:*",
 		"@aikirun/redis": "workspace:*",
 		"@aikirun/server": "workspace:*",
 		"@aikirun/types": "workspace:*",

--- a/app/server/src/serve.ts
+++ b/app/server/src/serve.ts
@@ -1,6 +1,7 @@
 import process from "node:process";
 import { iam } from "@aikirun/iam";
 import type { Logger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import { attachConnectionSupervisor, redisCache, redisPublisher, redisTimerPriorityQueue } from "@aikirun/redis";
 import { database, server } from "@aikirun/server";
 import { Redis } from "ioredis";
@@ -33,10 +34,8 @@ export async function startAppServer({ config }: { config: AppServerConfig }): P
 					: undefined,
 		},
 		runtime: {
-			...(redis && {
-				publisher: redisPublisher(redis.client),
-				timerPriorityQueue: redisTimerPriorityQueue(redis.client, "aiki:timers"),
-			}),
+			publisher: redis ? redisPublisher(redis.client) : undefined,
+			timerPriorityQueue: redis ? redisTimerPriorityQueue(redis.client, "aiki:timers") : inMemoryTimerPriorityQueue(),
 		},
 	});
 

--- a/app/website/content/docs/architecture/server.md
+++ b/app/website/content/docs/architecture/server.md
@@ -50,7 +50,7 @@ The runtime's daemons drive workflow state transitions:
 
 The publish daemon runs only when a publisher is configured; without one, workers claim work directly from the outbox. Recovery runs unconditionally — a crashed worker's claim is released after `claimIdleTimeoutMs` either way (see [Workflow Run Claims](./workflow-run-claims.md)).
 
-By default, due work is detected by periodic database scans. Configuring a **timer priority queue** (`@aikirun/redis`) promotes near-term timers into a sorted queue that fires them with sub-second precision.
+By default, due work is detected by periodic database scans. Configuring a **timer priority queue** (`@aikirun/redis`) promotes near-term timers into a sorted queue that fires them with sub-second precision. The bundled standalone server always runs one: in-process by default, Redis-backed when `REDIS_URL` is set. With multiple server instances, prefer Redis — the shared queue hands each timer to exactly one instance, where per-instance in-process queues wake every instance for every timer (correctness is not affected, but work is duplicated). The queue is disposable acceleration state — the database keeps every deadline, and the scans repopulate the queue after a restart.
 
 ## Configuration
 

--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -171,7 +171,7 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `AIKI_SERVER_BASE_URL` | If IAM is on | — | Public URL of the server; required only when `AIKI_SERVER_AUTH_SECRET` is also set |
 | `AIKI_SERVER_AUTH_SECRET` | If IAM is on | — | Authentication secret; setting this (with `AIKI_SERVER_BASE_URL`) activates the IAM package |
 | `CORS_ORIGINS` | If the dashboard is cross-origin | — | Comma-separated allowed origins, e.g. a static-host dashboard's; unneeded behind the dashboard image's proxy |
-| `REDIS_URL` | No | — | Redis connection string, e.g. `redis://localhost:6379`; setting it enables Redis-backed work distribution and timer dispatch |
+| `REDIS_URL` | No | — | Redis connection string, e.g. `redis://localhost:6379`; enables Redis-backed work distribution and moves timer dispatch from the in-process queue to a shared Redis-backed one |
 | `LOG_LEVEL` | No | `info` | Log level |
 | `PRETTY_LOGS` | No | `true` | Pretty-print logs (set `false` for JSON output) |
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
       "dependencies": {
         "@aikirun/iam": "workspace:*",
         "@aikirun/lib": "workspace:*",
+        "@aikirun/memory": "workspace:*",
         "@aikirun/redis": "workspace:*",
         "@aikirun/server": "workspace:*",
         "@aikirun/types": "workspace:*",


### PR DESCRIPTION
## Motivation

The timer priority queue is the precision layer for timer firing: the scan daemons discover near-term deadlines in the database and add them to the queue, and a consumer fires each one at its exact due time instead of at the next scan tick. The bundled standalone server wired a queue only when `REDIS_URL` was set — the choice was Redis or nothing. Without Redis, every timer (sleeps, retries, schedules, wait timeouts) fired up to one scan interval late, one second at the default cadence, even though the in-memory adapter already existed.

## Solution

The standalone server now always runs a timer priority queue: Redis-backed when `REDIS_URL` is set, in-process otherwise. A plain no-Redis deployment gets timers firing at their deadline with zero new configuration.

With multiple server instances, per-instance in-process queues hold the same timers, because every instance's scans read the same database. All instances wake at the deadline; one transition wins and the rest match nothing, so firing is correct but duplicated. The docs steer multi-instance deployments to Redis, whose shared queue hands each timer to exactly one instance. The in-process queue is also lost on restart, which is safe by design: the database keeps every deadline and the scans repopulate the queue within one tick.