### PR TITLE
Task write endpoints on the task API

### DIFF
--- a/sdk/server/src/contract/procedure/task.ts
+++ b/sdk/server/src/contract/procedure/task.ts
@@ -1,10 +1,26 @@
 import type { Equal, ExpectTrue } from "@aikirun/lib/testing/expect";
-import type { TaskApi, TaskGetByIdRequestV1, TaskGetByIdResponseV1 } from "@aikirun/types/api/task";
+import type {
+	TaskApi,
+	TaskGetByIdRequestV1,
+	TaskGetByIdResponseV1,
+	TaskSetStateRequestV1,
+	TaskTransitionStateRequestV1,
+	TaskTransitionStateResponseV1,
+} from "@aikirun/types/api/task";
 import { oc } from "@orpc/contract";
 import { type } from "arktype";
 
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
-import { taskRecordSchema } from "../schema/task";
+import {
+	taskInfoSchema,
+	taskOptionsSchema,
+	taskRecordSchema,
+	taskSetStateRequestSchema,
+	taskStateAwaitingRetrySchema,
+	taskStateCompletedSchema,
+	taskStateFailedSchema,
+	taskStateRunningSchema,
+} from "../schema/task";
 
 const getByIdV1: ContractProcedure<TaskGetByIdRequestV1, TaskGetByIdResponseV1> = oc
 	.input(
@@ -18,8 +34,58 @@ const getByIdV1: ContractProcedure<TaskGetByIdRequestV1, TaskGetByIdResponseV1> 
 		})
 	);
 
+const transitionStateV1: ContractProcedure<TaskTransitionStateRequestV1, TaskTransitionStateResponseV1> = oc
+	.input(
+		type({
+			type: "'create'",
+			workflowRunId: "string > 0",
+			taskName: "string > 0",
+			"options?": taskOptionsSchema,
+			"input?": "unknown",
+			taskState: taskStateRunningSchema.omit("attempts"),
+			expectedWorkflowRunRevision: "number.integer >= 0",
+		})
+			.or({
+				type: "'retry'",
+				id: "string > 0",
+				workflowRunId: "string > 0",
+				"options?": taskOptionsSchema,
+				taskState: taskStateRunningSchema,
+				expectedWorkflowRunRevision: "number.integer >= 0",
+			})
+			.or({
+				id: "string > 0",
+				workflowRunId: "string > 0",
+				taskState: taskStateCompletedSchema.omit("output").and({ "output?": "unknown" }),
+				expectedWorkflowRunRevision: "number.integer >= 0",
+			})
+			.or({
+				id: "string > 0",
+				workflowRunId: "string > 0",
+				taskState: taskStateFailedSchema,
+				expectedWorkflowRunRevision: "number.integer >= 0",
+			})
+			.or({
+				id: "string > 0",
+				workflowRunId: "string > 0",
+				taskState: taskStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }),
+				expectedWorkflowRunRevision: "number.integer >= 0",
+			})
+	)
+	.output(
+		type({
+			taskInfo: taskInfoSchema,
+		})
+	);
+
+const setStateV1: ContractProcedure<TaskSetStateRequestV1, void> = oc
+	.input(taskSetStateRequestSchema)
+	.output(type("undefined"));
+
 export const taskContract = {
 	getByIdV1,
+	transitionStateV1,
+	setStateV1,
 };
 
 export type TaskContract = typeof taskContract;

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -25,25 +25,14 @@ import type {
 	WorkflowRunMulticastEventByReferenceRequestV1,
 	WorkflowRunMulticastEventRequestV1,
 	WorkflowRunSendEventRequestV1,
-	WorkflowRunSetTaskStateRequestV1,
 	WorkflowRunTransitionStateRequestV1,
 	WorkflowRunTransitionStateResponseV1,
-	WorkflowRunTransitionTaskStateRequestV1,
-	WorkflowRunTransitionTaskStateResponseV1,
 } from "@aikirun/types/api/workflow-run";
 import { oc } from "@orpc/contract";
 import { type } from "arktype";
 
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
 import { stateTransitionSchema } from "../schema/state-transition";
-import {
-	taskInfoSchema,
-	taskOptionsSchema,
-	taskStateAwaitingRetrySchema,
-	taskStateCompletedSchema,
-	taskStateFailedSchema,
-	taskStateRunningSchema,
-} from "../schema/task";
 import { workflowSourceSchema } from "../schema/workflow";
 import {
 	cancelByIdsRequestSchema,
@@ -52,7 +41,6 @@ import {
 	listChildRunsResponseSchema,
 	workflowOptionsSchema,
 	workflowRunRecordSchema,
-	workflowRunSetTaskStateRequestSchema,
 	workflowRunStateAwaitingChildWorkflowSchema,
 	workflowRunStateAwaitingEventSchema,
 	workflowRunStateAwaitingRetrySchema,
@@ -220,57 +208,6 @@ const transitionStateV1: ContractProcedure<WorkflowRunTransitionStateRequestV1, 
 			})
 		);
 
-const transitionTaskStateV1: ContractProcedure<
-	WorkflowRunTransitionTaskStateRequestV1,
-	WorkflowRunTransitionTaskStateResponseV1
-> = oc
-	.input(
-		type({
-			type: "'create'",
-			id: "string > 0",
-			taskName: "string > 0",
-			"options?": taskOptionsSchema,
-			"input?": "unknown",
-			taskState: taskStateRunningSchema.omit("attempts"),
-			expectedWorkflowRunRevision: "number.integer >= 0",
-		})
-			.or({
-				type: "'retry'",
-				id: "string > 0",
-				taskId: "string > 0",
-				"options?": taskOptionsSchema,
-				taskState: taskStateRunningSchema,
-				expectedWorkflowRunRevision: "number.integer >= 0",
-			})
-			.or({
-				id: "string > 0",
-				taskId: "string > 0",
-				taskState: taskStateCompletedSchema.omit("output").and({ "output?": "unknown" }),
-				expectedWorkflowRunRevision: "number.integer >= 0",
-			})
-			.or({
-				id: "string > 0",
-				taskId: "string > 0",
-				taskState: taskStateFailedSchema,
-				expectedWorkflowRunRevision: "number.integer >= 0",
-			})
-			.or({
-				id: "string > 0",
-				taskId: "string > 0",
-				taskState: taskStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }),
-				expectedWorkflowRunRevision: "number.integer >= 0",
-			})
-	)
-	.output(
-		type({
-			taskInfo: taskInfoSchema,
-		})
-	);
-
-const setTaskStateV1: ContractProcedure<WorkflowRunSetTaskStateRequestV1, void> = oc
-	.input(workflowRunSetTaskStateRequestSchema)
-	.output(type("undefined"));
-
 const listTransitionsV1: ContractProcedure<WorkflowRunListTransitionsRequestV1, WorkflowRunListTransitionsResponseV1> =
 	oc
 		.input(
@@ -393,8 +330,6 @@ export const workflowRunContract = {
 	getStateV1,
 	createV1,
 	transitionStateV1,
-	transitionTaskStateV1,
-	setTaskStateV1,
 	listTransitionsV1,
 	sendEventV1,
 	multicastEventV1,

--- a/sdk/server/src/contract/schema/task.ts
+++ b/sdk/server/src/contract/schema/task.ts
@@ -57,3 +57,16 @@ export const taskRecordSchema = type({
 	"options?": taskOptionsSchema.or("undefined"),
 	state: taskStateSchema,
 });
+
+export const taskSetStateRequestSchema = type({
+	type: "'new'",
+	workflowRunId: "string > 0",
+	taskName: "string > 0",
+	"input?": "unknown",
+	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),
+}).or({
+	type: "'existing'",
+	id: "string > 0",
+	workflowRunId: "string > 0",
+	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),
+});

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -209,24 +209,3 @@ export const cancelByIdsRequestSchema = type({
 export const cancelByIdsResponseSchema = type({
 	cancelledIds: type("string > 0").array(),
 });
-
-const taskStateOutputSchema = type({
-	status: "'completed'",
-	output: "unknown",
-}).or({
-	status: "'failed'",
-	error: serializedErrorSchema,
-});
-
-export const workflowRunSetTaskStateRequestSchema = type({
-	type: "'new'",
-	id: "string > 0",
-	taskName: "string > 0",
-	"input?": "unknown",
-	state: taskStateOutputSchema,
-}).or({
-	type: "'existing'",
-	id: "string > 0",
-	taskId: "string > 0",
-	state: taskStateOutputSchema,
-});

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -84,12 +84,18 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result.length > 0;
 	},
 
-	async getById(namespaceId: NamespaceId, id: string): Promise<WorkflowRunRow | null> {
-		const result = await db
+	async getById(
+		namespaceId: NamespaceId,
+		id: string,
+		options?: { forUpdate?: boolean }
+	): Promise<WorkflowRunRow | null> {
+		const query = db
 			.select()
 			.from(workflowRun)
 			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
 			.limit(1);
+
+		const result = options?.forUpdate ? await query.for("update") : await query;
 		return result[0] ?? null;
 	},
 
@@ -121,7 +127,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
 			.limit(1);
 
-		const result = options?.forUpdate ? await query.for("update") : await query;
+		const result = options?.forUpdate ? await query.for("update", { of: workflowRun }) : await query;
 		const row = result[0];
 		if (!row) {
 			return null;

--- a/sdk/server/src/router/index.ts
+++ b/sdk/server/src/router/index.ts
@@ -5,6 +5,7 @@ import { createWorkflowRouter } from "./workflow";
 import { createWorkflowRunRouter, type WorkflowRunRouterDeps } from "./workflow-run";
 import type { ScheduleService } from "../service/schedule";
 import type { TaskService } from "../service/task";
+import type { TaskStateMachineService } from "../service/task-state-machine";
 import type { WorkflowService } from "../service/workflow";
 
 export function createPublicRouter() {
@@ -14,18 +15,21 @@ export function createPublicRouter() {
 export interface NamespaceAuthedRouterDeps extends WorkflowRunRouterDeps {
 	scheduleService: ScheduleService;
 	taskService: TaskService;
+	taskStateMachineService: TaskStateMachineService;
 	workflowService: WorkflowService;
 }
 
 export function createNamespaceAuthedRouter(deps: NamespaceAuthedRouterDeps) {
 	return namespaceAuthedImplementer.router({
 		schedule: createScheduleRouter(deps.scheduleService),
-		task: createTaskRouter({ taskService: deps.taskService }),
+		task: createTaskRouter({
+			taskService: deps.taskService,
+			taskStateMachineService: deps.taskStateMachineService,
+		}),
 		workflow: createWorkflowRouter(deps.workflowService),
 		workflowRun: createWorkflowRunRouter({
 			workflowRunService: deps.workflowRunService,
 			workflowRunStateMachineService: deps.workflowRunStateMachineService,
-			taskStateMachineService: deps.taskStateMachineService,
 			workflowRunOutboxService: deps.workflowRunOutboxService,
 		}),
 	});

--- a/sdk/server/src/router/task.ts
+++ b/sdk/server/src/router/task.ts
@@ -1,18 +1,29 @@
 import { namespaceAuthedImplementer } from "./implementer";
 import type { TaskService } from "../service/task";
+import type { TaskStateMachineService } from "../service/task-state-machine";
 
 export interface TaskRouterDeps {
 	taskService: TaskService;
+	taskStateMachineService: TaskStateMachineService;
 }
 
 export function createTaskRouter(deps: TaskRouterDeps) {
 	const os = namespaceAuthedImplementer.task;
-	const { taskService } = deps;
+	const { taskService, taskStateMachineService } = deps;
 
 	return os.router({
 		getByIdV1: os.getByIdV1.handler(async ({ input: request, context }) => {
 			const task = await taskService.getTaskById(context, request.id);
 			return { task };
+		}),
+
+		transitionStateV1: os.transitionStateV1.handler(async ({ input: request, context }) => {
+			const taskInfo = await taskStateMachineService.transitionState(context, request);
+			return { taskInfo };
+		}),
+
+		setStateV1: os.setStateV1.handler(async ({ input: request, context }) => {
+			await taskService.setTaskState(context, request);
 		}),
 	});
 }

--- a/sdk/server/src/router/workflow-run.ts
+++ b/sdk/server/src/router/workflow-run.ts
@@ -2,7 +2,6 @@ import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import { namespaceAuthedImplementer } from "./implementer";
 import { runConcurrently } from "../lib/concurrency";
-import type { TaskStateMachineService } from "../service/task-state-machine";
 import type { WorkflowRunService } from "../service/workflow-run";
 import type { WorkflowRunOutboxService } from "../service/workflow-run-outbox";
 import type { WorkflowRunStateMachineService } from "../service/workflow-run-state-machine";
@@ -10,14 +9,12 @@ import type { WorkflowRunStateMachineService } from "../service/workflow-run-sta
 export interface WorkflowRunRouterDeps {
 	workflowRunService: WorkflowRunService;
 	workflowRunStateMachineService: WorkflowRunStateMachineService;
-	taskStateMachineService: TaskStateMachineService;
 	workflowRunOutboxService: WorkflowRunOutboxService;
 }
 
 export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps) {
 	const os = namespaceAuthedImplementer.workflowRun;
-	const { workflowRunService, workflowRunStateMachineService, taskStateMachineService, workflowRunOutboxService } =
-		deps;
+	const { workflowRunService, workflowRunStateMachineService, workflowRunOutboxService } = deps;
 
 	return os.router({
 		listV1: os.listV1.handler(async ({ input: request, context }) => {
@@ -50,15 +47,6 @@ export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps) {
 
 		transitionStateV1: os.transitionStateV1.handler(async ({ input: request, context }) => {
 			return workflowRunStateMachineService.transitionState(context, request);
-		}),
-
-		transitionTaskStateV1: os.transitionTaskStateV1.handler(async ({ input: request, context }) => {
-			const taskInfo = await taskStateMachineService.transitionState(context, request);
-			return { taskInfo };
-		}),
-
-		setTaskStateV1: os.setTaskStateV1.handler(async ({ input: request, context }) => {
-			await workflowRunService.setTaskState(context, request);
 		}),
 
 		listTransitionsV1: os.listTransitionsV1.handler(async ({ input: request, context }) => {

--- a/sdk/server/src/service/task-state-machine.integration.test.ts
+++ b/sdk/server/src/service/task-state-machine.integration.test.ts
@@ -34,9 +34,9 @@ describe("TaskStateMachineService transitionState", () => {
 			const taskStateMachine = createTaskStateMachineService({ repos });
 			expect(
 				taskStateMachine.transitionState(context, {
-					id: attackerRunSeed.runId,
+					workflowRunId: attackerRunSeed.runId,
 					expectedWorkflowRunRevision: attackerRunSeed.revisionWhenClaimed,
-					taskId: victimTaskSeed.taskInfo.id,
+					id: victimTaskSeed.taskInfo.id,
 					taskState: { status: "completed", attempts: 2, output: "hijacked" },
 				})
 			).rejects.toBeInstanceOf(NotFoundError);

--- a/sdk/server/src/service/task-state-machine.ts
+++ b/sdk/server/src/service/task-state-machine.ts
@@ -1,10 +1,7 @@
 import { hashInput } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
-import type {
-	TransitionTaskStateToRunning,
-	WorkflowRunTransitionTaskStateRequestV1,
-} from "@aikirun/types/api/workflow-run";
+import type { TaskTransitionStateRequestV1, TransitionTaskStateToRunning } from "@aikirun/types/api/task";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 import type {
 	TaskId,
@@ -50,7 +47,7 @@ export function assertIsValidTaskStateTransition(
 }
 
 export function isTaskStateTransitionToRunning(
-	request: WorkflowRunTransitionTaskStateRequestV1
+	request: TaskTransitionStateRequestV1
 ): request is TransitionTaskStateToRunning {
 	return request.taskState.status === "running";
 }
@@ -62,7 +59,7 @@ export interface TaskStateMachineServiceDeps {
 export const createTaskStateMachineService = ({ repos }: TaskStateMachineServiceDeps) => ({
 	async transitionState(
 		context: NamespaceRequestContext,
-		request: WorkflowRunTransitionTaskStateRequestV1,
+		request: TaskTransitionStateRequestV1,
 		txRepos?: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 	): Promise<TaskInfo> {
 		if (txRepos) {
@@ -77,10 +74,10 @@ export type TaskStateMachineService = ReturnType<typeof createTaskStateMachineSe
 
 async function transitionStateInTx(
 	{ namespaceId, logger }: NamespaceRequestContext,
-	request: WorkflowRunTransitionTaskStateRequestV1,
+	request: TaskTransitionStateRequestV1,
 	txRepos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 ): Promise<TaskInfo> {
-	const runId = request.id as WorkflowRunId;
+	const runId = request.workflowRunId as WorkflowRunId;
 	const run = await txRepos.workflowRun.getById(namespaceId, runId);
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
@@ -134,7 +131,7 @@ async function transitionStateInTx(
 		return { id: taskId, name: taskName, state: taskState, inputHash };
 	}
 
-	const taskId = request.taskId as TaskId;
+	const taskId = request.id as TaskId;
 	const existingTask = await txRepos.task.getById({ id: taskId, workflowRunId: runId });
 	if (!existingTask) {
 		throw new NotFoundError(`Task not found: ${taskId}`);

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -6,6 +6,7 @@ import { createTaskService } from "../service/task";
 import { createTaskStateMachineService } from "../service/task-state-machine";
 import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
+import { seedClaimedRun } from "../testing/seed/run";
 import { seedRunningTask } from "../testing/seed/task";
 
 const withHarness = createServiceHarness();
@@ -42,9 +43,9 @@ describe("TaskService getTaskById", () => {
 			const taskStateMachine = createTaskStateMachineService({ repos });
 			await taskStateMachine.transitionState(context, {
 				type: "retry",
-				id: runId,
+				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
-				taskId: taskInfo.id,
+				id: taskInfo.id,
 				taskState: { status: "running", attempts: 2 },
 			});
 
@@ -65,5 +66,42 @@ describe("TaskService getTaskById", () => {
 
 			const taskService = createTaskService({ repos });
 			expect(taskService.getTaskById(context, foreignTaskSeed.taskInfo.id)).rejects.toBeInstanceOf(NotFoundError);
+		}));
+});
+
+describe("TaskService setTaskState", () => {
+	test("does not set the state of a task belonging to another run", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const otherNamespaceContext = namespaceRequestContextFactory.build({ namespaceId: "other-ns" as NamespaceId });
+			const victimTaskSeed = await seedRunningTask({
+				namespaceRequestContext: otherNamespaceContext,
+				repos,
+				publisher,
+			});
+			const victimRowBefore = await repos.task.getById({
+				id: victimTaskSeed.taskInfo.id,
+				workflowRunId: victimTaskSeed.runId,
+			});
+
+			// The attacker holds a perfectly valid run of their own; only the task is foreign.
+			const attackerRunSeed = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const taskService = createTaskService({ repos });
+			expect(
+				taskService.setTaskState(context, {
+					type: "existing",
+					id: victimTaskSeed.taskInfo.id,
+					workflowRunId: attackerRunSeed.runId,
+					state: { status: "completed", output: "hijacked" },
+				})
+			).rejects.toBeInstanceOf(NotFoundError);
+
+			expect(await repos.task.getById({ id: victimTaskSeed.taskInfo.id, workflowRunId: victimTaskSeed.runId })).toEqual(
+				victimRowBefore
+			);
 		}));
 });

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -1,12 +1,22 @@
+import { hashInput } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
-import type { TaskRecord, TaskState } from "@aikirun/types/workflow/task";
+import type {
+	TaskSetStateRequestExisting,
+	TaskSetStateRequestNew,
+	TaskSetStateRequestV1,
+} from "@aikirun/types/api/task";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import type { TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
+import { monotonicFactory, ulid } from "ulidx";
 
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
 
 export interface TaskServiceDeps {
-	repos: Pick<Repositories, "task">;
+	repos: Pick<Repositories, "task" | "workflowRun" | "stateTransition" | "transaction">;
 }
+
+const monotonicUlid = monotonicFactory();
 
 export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 	async getTaskById(context: NamespaceRequestContext, taskId: string): Promise<TaskRecord> {
@@ -25,6 +35,130 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 			state: task.state as TaskState,
 		};
 	},
+
+	async setTaskState(context: NamespaceRequestContext, request: TaskSetStateRequestV1): Promise<void> {
+		if (request.type === "new") {
+			const inputHash = await hashInput(request.input);
+			return repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, inputHash, txRepos));
+		}
+		return repos.transaction(async (txRepos) => setExistingTaskStateInTx(context, request, txRepos));
+	},
 });
 
 export type TaskService = ReturnType<typeof createTaskService>;
+
+async function setNewTaskStateInTx(
+	context: NamespaceRequestContext,
+	request: TaskSetStateRequestNew,
+	inputHash: string,
+	txRepos: Pick<Repositories, "task" | "workflowRun" | "stateTransition">
+): Promise<void> {
+	const { namespaceId, logger } = context;
+	const runId = request.workflowRunId as WorkflowRunId;
+	const run = await txRepos.workflowRun.getById(namespaceId, runId, { forUpdate: true });
+	if (!run) {
+		throw new NotFoundError(`Workflow run not found: ${runId}`);
+	}
+
+	const taskId = ulid();
+	const runningStateTransitionId = monotonicUlid();
+	const targetStateTransitionId = monotonicUlid();
+
+	logger.info("Setting task state (new task)", {
+		"aiki.runId": runId,
+		"aiki.taskId": taskId,
+		"aiki.state": request.state,
+	});
+
+	const runningState: TaskStateRunning = {
+		status: "running",
+		attempts: 1,
+	};
+
+	const targetState: TaskState =
+		request.state.status === "completed"
+			? { status: "completed", attempts: 1, output: request.state.output }
+			: { status: request.state.status satisfies "failed", attempts: 1, error: request.state.error };
+
+	await txRepos.task.create({
+		id: taskId,
+		name: request.taskName,
+		workflowRunId: runId,
+		status: targetState.status,
+		attempts: 1,
+		input: request.input,
+		inputHash: inputHash,
+		options: null,
+		latestStateTransitionId: targetStateTransitionId,
+	});
+	await txRepos.stateTransition.appendBatch([
+		{
+			id: runningStateTransitionId,
+			workflowRunId: runId,
+			type: "task",
+			taskId,
+			status: runningState.status,
+			attempt: runningState.attempts,
+			state: runningState,
+		},
+		{
+			id: targetStateTransitionId,
+			workflowRunId: runId,
+			type: "task",
+			taskId,
+			status: targetState.status,
+			attempt: targetState.attempts,
+			state: targetState,
+		},
+	]);
+}
+
+async function setExistingTaskStateInTx(
+	context: NamespaceRequestContext,
+	request: TaskSetStateRequestExisting,
+	txRepos: Pick<Repositories, "task" | "workflowRun" | "stateTransition">
+): Promise<void> {
+	const { namespaceId, logger } = context;
+	const runId = request.workflowRunId as WorkflowRunId;
+	const run = await txRepos.workflowRun.getById(namespaceId, runId, { forUpdate: true });
+	if (!run) {
+		throw new NotFoundError(`Workflow run not found: ${runId}`);
+	}
+
+	const existingTaskRow = await txRepos.task.getById({ id: request.id, workflowRunId: runId });
+	if (!existingTaskRow) {
+		throw new NotFoundError(`Task not found: ${request.id}`);
+	}
+
+	logger.info("Setting task state (existing task)", {
+		"aiki.runId": runId,
+		"aiki.taskId": request.id,
+		"aiki.state": request.state,
+	});
+
+	const attempts = existingTaskRow.attempts;
+
+	const state: TaskState =
+		request.state.status === "completed"
+			? { status: "completed", attempts: attempts + 1, output: request.state.output }
+			: { status: request.state.status satisfies "failed", attempts: attempts + 1, error: request.state.error };
+
+	const transitionId = ulid();
+	await txRepos.stateTransition.append({
+		id: transitionId,
+		workflowRunId: runId,
+		type: "task",
+		taskId: existingTaskRow.id,
+		status: state.status,
+		attempt: state.attempts,
+		state: state,
+	});
+	await txRepos.task.update(
+		{ id: existingTaskRow.id, workflowRunId: runId },
+		{
+			status: state.status,
+			attempts: state.attempts,
+			latestStateTransitionId: transitionId,
+		}
+	);
+}

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -1,5 +1,4 @@
 import { hashInput } from "@aikirun/lib/crypto";
-import { NotFoundError } from "@aikirun/lib/error";
 import type { WorkflowRunTransitionStateResponseV1 } from "@aikirun/types/api/workflow-run";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
@@ -282,7 +281,7 @@ describe("WorkflowRunService cancelByIds", () => {
 			const taskStateMachine = createTaskStateMachineService({ repos });
 			const taskInfo = await taskStateMachine.transitionState(context, {
 				type: "create",
-				id: runId,
+				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
 				taskName: "charge-card",
 				input: { amountCents: 1250 },
@@ -338,43 +337,6 @@ describe("WorkflowRunService cancelByIds", () => {
 		}));
 });
 
-describe("WorkflowRunService setTaskState", () => {
-	test("does not set the state of a task belonging to another run", () =>
-		withHarness(async ({ context, repos, publisher }) => {
-			const otherNamespaceContext = namespaceRequestContextFactory.build({ namespaceId: "other-ns" as NamespaceId });
-			const victimTaskSeed = await seedRunningTask({
-				namespaceRequestContext: otherNamespaceContext,
-				repos,
-				publisher,
-			});
-			const victimRowBefore = await repos.task.getById({
-				id: victimTaskSeed.taskInfo.id,
-				workflowRunId: victimTaskSeed.runId,
-			});
-
-			// The attacker holds a perfectly valid run of their own; only the task is foreign.
-			const attackerRunSeed = await seedClaimedRun({
-				namespaceRequestContext: context,
-				repos,
-				publisher,
-			});
-
-			const { service } = createService(repos);
-			expect(
-				service.setTaskState(context, {
-					type: "existing",
-					id: attackerRunSeed.runId,
-					taskId: victimTaskSeed.taskInfo.id,
-					state: { status: "completed", output: "hijacked" },
-				})
-			).rejects.toBeInstanceOf(NotFoundError);
-
-			expect(await repos.task.getById({ id: victimTaskSeed.taskInfo.id, workflowRunId: victimTaskSeed.runId })).toEqual(
-				victimRowBefore
-			);
-		}));
-});
-
 describe("WorkflowRunService listWorkflowRunTransitions", () => {
 	test("lists a task's transitions with their stored states", () =>
 		withHarness(async ({ context, repos, publisher }) => {
@@ -387,9 +349,9 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 			const taskStateMachine = createTaskStateMachineService({ repos });
 			await taskStateMachine.transitionState(context, {
 				type: "retry",
-				id: runId,
+				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
-				taskId: taskInfo.id,
+				id: taskInfo.id,
 				taskState: { status: "running", attempts: 2 },
 			});
 

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -1,5 +1,4 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
-import { hashInput } from "@aikirun/lib/crypto";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { NotFoundError } from "@aikirun/lib/error";
 import { getCompositeId } from "@aikirun/lib/id";
@@ -13,7 +12,6 @@ import type {
 	WorkflowRunListResponseV1,
 	WorkflowRunListTransitionsRequestV1,
 	WorkflowRunReference,
-	WorkflowRunSetTaskStateRequestV1,
 } from "@aikirun/types/api/workflow-run";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
@@ -31,14 +29,8 @@ import type {
 	WorkflowRunStateCancelled,
 	WorkflowRunStateScheduledByNew,
 } from "@aikirun/types/workflow/run";
-import type {
-	TaskInfo,
-	TaskState,
-	TaskStateDiscarded,
-	TaskStateRunning,
-	TaskStatus,
-} from "@aikirun/types/workflow/task";
-import { monotonicFactory, ulid } from "ulidx";
+import type { TaskInfo, TaskState, TaskStateDiscarded, TaskStatus } from "@aikirun/types/workflow/task";
+import { ulid } from "ulidx";
 
 import { WorkflowRunConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
@@ -73,8 +65,6 @@ export interface WorkflowRunServiceDeps {
 	childRunCanceller: ChildRunCanceller;
 	workflowRunStateMachineService: WorkflowRunStateMachineService;
 }
-
-const monotonic = monotonicFactory();
 
 export const createWorkflowRunService = ({
 	repos,
@@ -352,112 +342,6 @@ export const createWorkflowRunService = ({
 				throw new NotFoundError(`Workflow run not found: ${name}:${versionId}:${referenceId}`);
 			}
 			return run.id as WorkflowRunId;
-		});
-	},
-
-	async setTaskState(context: NamespaceRequestContext, request: WorkflowRunSetTaskStateRequestV1): Promise<void> {
-		const { namespaceId, logger } = context;
-		const runId = request.id as WorkflowRunId;
-
-		return repos.transaction(async (txRepos) => {
-			const run = await txRepos.workflowRun.getById(namespaceId, runId);
-			if (!run) {
-				throw new NotFoundError(`Workflow run not found: ${runId}`);
-			}
-
-			if (request.type === "new") {
-				const inputHash = await hashInput(request.input);
-
-				const taskId = ulid();
-				const runningStateTransitionId = monotonic();
-				const finalStateTransitionId = monotonic();
-
-				logger.info("Setting task state (new task)", {
-					"aiki.runId": runId,
-					"aiki.taskId": taskId,
-					"aiki.state": request.state,
-				});
-
-				const runningState: TaskStateRunning = {
-					status: "running",
-					attempts: 1,
-				};
-
-				const finalState: TaskState =
-					request.state.status === "completed"
-						? { status: "completed", attempts: 1, output: request.state.output }
-						: { status: request.state.status satisfies "failed", attempts: 1, error: request.state.error };
-
-				await txRepos.task.create({
-					id: taskId,
-					name: request.taskName,
-					workflowRunId: runId,
-					status: finalState.status,
-					attempts: 1,
-					input: request.input,
-					inputHash: inputHash,
-					options: null,
-					latestStateTransitionId: finalStateTransitionId,
-				});
-				await txRepos.stateTransition.append({
-					id: runningStateTransitionId,
-					workflowRunId: runId,
-					type: "task",
-					taskId,
-					status: runningState.status,
-					attempt: runningState.attempts,
-					state: runningState,
-				});
-				await txRepos.stateTransition.append({
-					id: finalStateTransitionId,
-					workflowRunId: runId,
-					type: "task",
-					taskId,
-					status: finalState.status,
-					attempt: finalState.attempts,
-					state: finalState,
-				});
-
-				return;
-			}
-
-			const existingTaskRow = await txRepos.task.getById({ id: request.taskId, workflowRunId: runId });
-			if (!existingTaskRow) {
-				throw new NotFoundError(`Task not found: ${request.taskId}`);
-			}
-
-			logger.info("Setting task state (existing task)", {
-				"aiki.runId": runId,
-				"aiki.taskId": request.taskId,
-				"aiki.state": request.state,
-			});
-
-			const attempts = existingTaskRow.attempts;
-
-			const finalState: TaskState =
-				request.state.status === "completed"
-					? { status: "completed", attempts: attempts + 1, output: request.state.output }
-					: { status: request.state.status satisfies "failed", attempts: attempts + 1, error: request.state.error };
-
-			const finalTransitionId = ulid();
-			await txRepos.stateTransition.append({
-				id: finalTransitionId,
-				workflowRunId: runId,
-				type: "task",
-				taskId: existingTaskRow.id,
-				status: finalState.status,
-				attempt: finalState.attempts,
-				state: finalState,
-			});
-
-			await txRepos.task.update(
-				{ id: existingTaskRow.id, workflowRunId: runId },
-				{
-					status: finalState.status,
-					attempts: finalState.attempts,
-					latestStateTransitionId: finalTransitionId,
-				}
-			);
 		});
 	},
 

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -14,7 +14,7 @@ export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePubli
 	const taskStateMachine = createTaskStateMachineService({ repos });
 	const taskInfo = await taskStateMachine.transitionState(namespaceRequestContext, {
 		type: "create",
-		id: seeded.runId,
+		workflowRunId: seeded.runId,
 		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
 		taskName: seededTask.name,
 		input: seededTask.input,

--- a/sdk/workflow/src/run/handle.test.ts
+++ b/sdk/workflow/src/run/handle.test.ts
@@ -5,6 +5,7 @@ import {
 	workflowRunStateByStatus,
 } from "@aikirun/testing/data-factory/workflow/run";
 import { runningTaskInfoFactory } from "@aikirun/testing/data-factory/workflow/task";
+import type { TransitionTaskStateToRunningCreate } from "@aikirun/types/api/task";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowRunId, WorkflowRunRecord } from "@aikirun/types/workflow/run";
 import {
@@ -12,7 +13,6 @@ import {
 	WorkflowRunNotExecutableError,
 	WorkflowRunRevisionConflictError,
 } from "@aikirun/types/workflow/run";
-import type { TransitionTaskStateToRunningCreate } from "@aikirun/types/workflow/task";
 
 import { workflowRunHandle } from "./handle";
 import { describe, expect, test } from "bun:test";
@@ -112,14 +112,14 @@ describe("workflowRunHandle", () => {
 				const handle = workflowRunHandle(client, record);
 
 				const taskInfo = runningTaskInfoFactory.build();
-				const request: Omit<TransitionTaskStateToRunningCreate, "id" | "expectedWorkflowRunRevision"> = {
+				const request: Omit<TransitionTaskStateToRunningCreate, "workflowRunId" | "expectedWorkflowRunRevision"> = {
 					type: "create",
 					taskName: "reserve-seat",
 					options: {},
 					taskState: taskInfo.state,
 				};
-				client.api.workflowRun.transitionTaskStateV1.once(
-					{ ...request, id: record.id, expectedWorkflowRunRevision: 5 },
+				client.api.task.transitionStateV1.once(
+					{ ...request, workflowRunId: record.id, expectedWorkflowRunRevision: 5 },
 					{ taskInfo }
 				);
 
@@ -133,14 +133,14 @@ describe("workflowRunHandle", () => {
 				const record = runningWorkflowRunRecordFactory.build({ revision: 5 });
 				const handle = workflowRunHandle(client, record);
 
-				const request: Omit<TransitionTaskStateToRunningCreate, "id" | "expectedWorkflowRunRevision"> = {
+				const request: Omit<TransitionTaskStateToRunningCreate, "workflowRunId" | "expectedWorkflowRunRevision"> = {
 					type: "create",
 					taskName: "reserve-seat",
 					options: {},
 					taskState: { status: "running" },
 				};
-				client.api.workflowRun.transitionTaskStateV1.rejectsOnce(
-					{ ...request, id: record.id, expectedWorkflowRunRevision: 5 },
+				client.api.task.transitionStateV1.rejectsOnce(
+					{ ...request, workflowRunId: record.id, expectedWorkflowRunRevision: 5 },
 					{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
 				);
 
@@ -152,14 +152,14 @@ describe("workflowRunHandle", () => {
 				const record = runningWorkflowRunRecordFactory.build({ revision: 5 });
 				const handle = workflowRunHandle(client, record);
 				const nonConflictError = { code: "SOME_OTHER_ERROR" };
-				const request: Omit<TransitionTaskStateToRunningCreate, "id" | "expectedWorkflowRunRevision"> = {
+				const request: Omit<TransitionTaskStateToRunningCreate, "workflowRunId" | "expectedWorkflowRunRevision"> = {
 					type: "create",
 					taskName: "reserve-seat",
 					options: {},
 					taskState: { status: "running" },
 				};
-				client.api.workflowRun.transitionTaskStateV1.rejectsOnce(
-					{ ...request, id: record.id, expectedWorkflowRunRevision: 5 },
+				client.api.task.transitionStateV1.rejectsOnce(
+					{ ...request, workflowRunId: record.id, expectedWorkflowRunRevision: 5 },
 					nonConflictError
 				);
 

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -3,11 +3,8 @@ import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
 import type { DistributiveOmit } from "@aikirun/lib/object";
-import type {
-	WorkflowRunStateRequest,
-	WorkflowRunTransitionStateResponseV1,
-	WorkflowRunTransitionTaskStateRequestV1,
-} from "@aikirun/types/api/workflow-run";
+import type { TaskTransitionStateRequestV1 } from "@aikirun/types/api/task";
+import type { WorkflowRunStateRequest, WorkflowRunTransitionStateResponseV1 } from "@aikirun/types/api/workflow-run";
 import type { ApiClient, Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type {
@@ -155,7 +152,7 @@ export interface WorkflowRunHandle<Input, Output, Context, TEvents extends Event
 		client: Client<Context>;
 		transitionState: (state: WorkflowRunStateRequest) => Promise<void>;
 		transitionTaskState: (
-			request: DistributiveOmit<WorkflowRunTransitionTaskStateRequestV1, "id" | "expectedWorkflowRunRevision">
+			request: DistributiveOmit<TaskTransitionStateRequestV1, "workflowRunId" | "expectedWorkflowRunRevision">
 		) => Promise<TaskInfo>;
 		assertExecutionAllowed: () => void;
 	};
@@ -377,12 +374,12 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 	}
 
 	private async transitionTaskState(
-		request: DistributiveOmit<WorkflowRunTransitionTaskStateRequestV1, "id" | "expectedWorkflowRunRevision">
+		request: DistributiveOmit<TaskTransitionStateRequestV1, "workflowRunId" | "expectedWorkflowRunRevision">
 	): Promise<TaskInfo> {
 		try {
-			const { taskInfo } = await this.api.workflowRun.transitionTaskStateV1({
+			const { taskInfo } = await this.api.task.transitionStateV1({
 				...request,
-				id: this.run.id,
+				workflowRunId: this.run.id,
 				expectedWorkflowRunRevision: this.run.revision,
 			});
 			return taskInfo;

--- a/sdk/workflow/src/system/cancel-child-runs.test.ts
+++ b/sdk/workflow/src/system/cancel-child-runs.test.ts
@@ -92,7 +92,7 @@ describe("createCancelChildRunsV1", () => {
 					}
 				);
 
-			client.api.workflowRun.transitionTaskStateV1
+			client.api.task.transitionStateV1
 				.once(
 					{
 						type: "create",
@@ -100,16 +100,16 @@ describe("createCancelChildRunsV1", () => {
 						taskName: runningListNonTerminalChildrenTask.name,
 						options: {},
 						taskState: { status: runningListNonTerminalChildrenTask.state.status },
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: runningListNonTerminalChildrenTask }
 				)
 				.once(
 					{
-						taskId: runningListNonTerminalChildrenTask.id,
+						id: runningListNonTerminalChildrenTask.id,
 						taskState: completedListNonTerminalChildrenTask.state,
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: completedListNonTerminalChildrenTask }
@@ -121,16 +121,16 @@ describe("createCancelChildRunsV1", () => {
 						taskName: runningCancelRunsTask.name,
 						options: {},
 						taskState: { status: runningCancelRunsTask.state.status },
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: runningCancelRunsTask }
 				)
 				.once(
 					{
-						taskId: runningCancelRunsTask.id,
+						id: runningCancelRunsTask.id,
 						taskState: completedCancelRunsTask.state,
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: completedCancelRunsTask }
@@ -189,7 +189,7 @@ describe("createCancelChildRunsV1", () => {
 					}
 				);
 
-			client.api.workflowRun.transitionTaskStateV1
+			client.api.task.transitionStateV1
 				.once(
 					{
 						type: "create",
@@ -197,16 +197,16 @@ describe("createCancelChildRunsV1", () => {
 						taskName: runningListNonTerminalChildrenTask.name,
 						options: {},
 						taskState: { status: runningListNonTerminalChildrenTask.state.status },
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: runningListNonTerminalChildrenTask }
 				)
 				.once(
 					{
-						taskId: runningListNonTerminalChildrenTask.id,
+						id: runningListNonTerminalChildrenTask.id,
 						taskState: completedListNonTerminalChildrenTask.state,
-						id: runRecord.id,
+						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
 					{ taskInfo: completedListNonTerminalChildrenTask }

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -83,7 +83,7 @@ describe("task", () => {
 						state: { output },
 					});
 
-					client.api.workflowRun.transitionTaskStateV1
+					client.api.task.transitionStateV1
 						.once(
 							{
 								type: "create",
@@ -91,16 +91,16 @@ describe("task", () => {
 								taskName: sendEmail.name,
 								options: {},
 								taskState: { status: "running" },
-								id: runRecord.id,
+								workflowRunId: runRecord.id,
 								expectedWorkflowRunRevision: runRecord.revision,
 							},
 							{ taskInfo: runningTaskInfo }
 						)
 						.once(
 							{
-								taskId: runningTaskInfo.id,
+								id: runningTaskInfo.id,
 								taskState: completedTaskInfo.state,
-								id: runRecord.id,
+								workflowRunId: runRecord.id,
 								expectedWorkflowRunRevision: runRecord.revision,
 							},
 							{ taskInfo: completedTaskInfo }
@@ -139,7 +139,7 @@ describe("task", () => {
 					state: { attempts: 2, output },
 				});
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
@@ -147,16 +147,16 @@ describe("task", () => {
 							taskName: chargeCard.name,
 							options: { retry },
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: completedTaskInfo.state,
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: completedTaskInfo }
@@ -183,7 +183,7 @@ describe("task", () => {
 				const input = { cardId: "card-1" };
 				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name });
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
@@ -191,21 +191,21 @@ describe("task", () => {
 							taskName: chargeCard.name,
 							options: { retry },
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: {
 								status: "awaiting_retry",
 								attempts: 1,
 								error: expect.objectContaining({ message: "down" }),
 								nextAttemptInMs: 1_000,
 							},
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
@@ -229,7 +229,7 @@ describe("task", () => {
 				const input = { cardId: "card-1" };
 				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name });
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
@@ -237,20 +237,20 @@ describe("task", () => {
 							taskName: chargeCard.name,
 							options: {},
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: {
 								status: "failed",
 								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
@@ -447,7 +447,7 @@ describe("task", () => {
 					state: { output },
 				});
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
@@ -455,16 +455,16 @@ describe("task", () => {
 							taskName: sendEmail.name,
 							options: { retry },
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: completedTaskInfo.state,
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: completedTaskInfo }

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -175,7 +175,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		);
 
 		await handle[INTERNAL].transitionTaskState({
-			taskId: taskInfo.id,
+			id: taskInfo.id,
 			taskState: { status: "completed", attempts: lastAttempt, output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
@@ -253,7 +253,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 
 		const taskInfo = await handle[INTERNAL].transitionTaskState({
 			type: "retry",
-			taskId,
+			id: taskId,
 			options: startOptions,
 			taskState: { status: "running", attempts },
 		});
@@ -275,7 +275,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		);
 
 		await handle[INTERNAL].transitionTaskState({
-			taskId: taskInfo.id,
+			id: taskInfo.id,
 			taskState: { status: "completed", attempts: lastAttempt, output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
@@ -330,7 +330,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 						"aiki.reason": serializableError.message,
 					});
 					await handle[INTERNAL].transitionTaskState({
-						taskId,
+						id: taskId,
 						taskState: { status: "failed", attempts, error: serializableError },
 					});
 					throw new TaskFailedError(taskId, attempts, serializableError.message);
@@ -349,7 +349,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 				}
 
 				await handle[INTERNAL].transitionTaskState({
-					taskId,
+					id: taskId,
 					taskState: {
 						status: "awaiting_retry",
 						attempts,

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -350,27 +350,27 @@ describe("workflow version execution", () => {
 
 				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name });
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
 							taskName: chargeCard.name,
 							options: {},
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: {
 								status: "failed",
 								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
@@ -422,27 +422,27 @@ describe("workflow version execution", () => {
 
 				const runningTaskInfo = runningTaskInfoFactory.build({ name: chargeCard.name });
 
-				client.api.workflowRun.transitionTaskStateV1
+				client.api.task.transitionStateV1
 					.once(
 						{
 							type: "create",
 							taskName: chargeCard.name,
 							options: {},
 							taskState: { status: "running" },
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }
 					)
 					.once(
 						{
-							taskId: runningTaskInfo.id,
+							id: runningTaskInfo.id,
 							taskState: {
 								status: "failed",
 								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
-							id: runRecord.id,
+							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
 						{ taskInfo: runningTaskInfo }

--- a/types/src/api/task.ts
+++ b/types/src/api/task.ts
@@ -1,7 +1,19 @@
-import type { TaskRecord } from "../workflow/task";
+import type { DistributiveOmit, OptionalProp } from "@aikirun/lib/object";
+
+import type {
+	TaskInfo,
+	TaskRecord,
+	TaskStartOptions,
+	TaskStateAwaitingRetry,
+	TaskStateCompleted,
+	TaskStateFailed,
+	TaskStateRunning,
+} from "../workflow/task";
 
 export interface TaskApi {
 	getByIdV1: (_: TaskGetByIdRequestV1) => Promise<TaskGetByIdResponseV1>;
+	transitionStateV1: (_: TaskTransitionStateRequestV1) => Promise<TaskTransitionStateResponseV1>;
+	setStateV1: (_: TaskSetStateRequestV1) => Promise<void>;
 }
 
 export interface TaskGetByIdRequestV1 {
@@ -11,3 +23,73 @@ export interface TaskGetByIdRequestV1 {
 export interface TaskGetByIdResponseV1 {
 	task: TaskRecord;
 }
+
+export interface TransitionTaskStateBase {
+	workflowRunId: string;
+	expectedWorkflowRunRevision: number;
+}
+
+export interface TransitionTaskStateToRunningCreate extends TransitionTaskStateBase {
+	type: "create";
+	taskName: string;
+	options?: TaskStartOptions;
+	input?: unknown;
+	taskState: Omit<TaskStateRunning, "attempts">;
+}
+
+export interface TransitionTaskStateToRunningRetry extends TransitionTaskStateBase {
+	type: "retry";
+	id: string;
+	options?: TaskStartOptions;
+	taskState: TaskStateRunning;
+}
+
+export type TransitionTaskStateToRunning = TransitionTaskStateToRunningCreate | TransitionTaskStateToRunningRetry;
+
+export interface TransitionTaskStateToCompleted extends TransitionTaskStateBase {
+	id: string;
+	taskState: TaskStateCompletedRequest;
+}
+
+export type TaskStateCompletedRequest = OptionalProp<TaskStateCompleted<unknown>, "output">;
+
+export interface TransitionTaskStateToFailed extends TransitionTaskStateBase {
+	id: string;
+	taskState: TaskStateFailed;
+}
+
+export interface TransitionTaskStateToAwaitingRetry extends TransitionTaskStateBase {
+	id: string;
+	taskState: TaskStateAwaitingRetryRequest;
+}
+
+export type TaskStateAwaitingRetryRequest = Omit<TaskStateAwaitingRetry, "nextAttemptAt"> & {
+	nextAttemptInMs: number;
+};
+
+export type TaskTransitionStateRequestV1 =
+	| TransitionTaskStateToRunning
+	| TransitionTaskStateToCompleted
+	| TransitionTaskStateToFailed
+	| TransitionTaskStateToAwaitingRetry;
+
+export interface TaskTransitionStateResponseV1 {
+	taskInfo: TaskInfo;
+}
+
+export interface TaskSetStateRequestNew {
+	type: "new";
+	workflowRunId: string;
+	taskName: string;
+	input?: unknown;
+	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
+}
+
+export interface TaskSetStateRequestExisting {
+	type: "existing";
+	id: string;
+	workflowRunId: string;
+	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
+}
+
+export type TaskSetStateRequestV1 = TaskSetStateRequestNew | TaskSetStateRequestExisting;

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -18,17 +18,7 @@ import type {
 } from "../workflow/run";
 import type { EventSendOptions } from "../workflow/run/event";
 import type { StateTransition } from "../workflow/state-transition";
-import type {
-	TaskInfo,
-	TaskStateCompleted,
-	TaskStateFailed,
-	TaskStatus,
-	TransitionTaskStateToAwaitingRetry,
-	TransitionTaskStateToCompleted,
-	TransitionTaskStateToFailed,
-	TransitionTaskStateToRunningCreate,
-	TransitionTaskStateToRunningRetry,
-} from "../workflow/task";
+import type { TaskStatus } from "../workflow/task";
 
 export interface WorkflowRunApi {
 	listV1: (_: WorkflowRunListRequestV1) => Promise<WorkflowRunListResponseV1>;
@@ -37,10 +27,6 @@ export interface WorkflowRunApi {
 	getStateV1: (_: WorkflowRunGetStateRequestV1) => Promise<WorkflowRunGetStateResponseV1>;
 	createV1: (_: WorkflowRunCreateRequestV1) => Promise<WorkflowRunCreateResponseV1>;
 	transitionStateV1: (_: WorkflowRunTransitionStateRequestV1) => Promise<WorkflowRunTransitionStateResponseV1>;
-	transitionTaskStateV1: (
-		_: WorkflowRunTransitionTaskStateRequestV1
-	) => Promise<WorkflowRunTransitionTaskStateResponseV1>;
-	setTaskStateV1: (_: WorkflowRunSetTaskStateRequestV1) => Promise<void>;
 	listTransitionsV1: (_: WorkflowRunListTransitionsRequestV1) => Promise<WorkflowRunListTransitionsResponseV1>;
 	sendEventV1: (_: WorkflowRunSendEventRequestV1) => Promise<void>;
 	multicastEventV1: (_: WorkflowRunMulticastEventRequestV1) => Promise<void>;
@@ -206,37 +192,6 @@ export interface WorkflowRunTransitionStateResponseV1 {
 	state: WorkflowRunState;
 	attempts: number;
 }
-
-export type TransitionTaskStateToRunning = TransitionTaskStateToRunningCreate | TransitionTaskStateToRunningRetry;
-
-export type WorkflowRunTransitionTaskStateRequestV1 =
-	| TransitionTaskStateToRunning
-	| TransitionTaskStateToCompleted
-	| TransitionTaskStateToFailed
-	| TransitionTaskStateToAwaitingRetry;
-
-export interface WorkflowRunTransitionTaskStateResponseV1 {
-	taskInfo: TaskInfo;
-}
-
-export interface WorkflowRunSetTaskStateRequestNew {
-	type: "new";
-	id: string;
-	taskName: string;
-	input?: unknown;
-	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
-}
-
-export interface WorkflowRunSetTaskStateRequestExisting {
-	type: "existing";
-	id: string;
-	taskId: string;
-	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
-}
-
-export type WorkflowRunSetTaskStateRequestV1 =
-	| WorkflowRunSetTaskStateRequestNew
-	| WorkflowRunSetTaskStateRequestExisting;
 
 export interface WorkflowRunListTransitionsRequestV1 {
 	id: string;

--- a/types/src/workflow/task/task.ts
+++ b/types/src/workflow/task/task.ts
@@ -1,4 +1,3 @@
-import type { OptionalProp } from "@aikirun/lib/object";
 import type { RetryStrategy } from "@aikirun/lib/retry";
 import type { SerializableError } from "@aikirun/lib/serializable";
 
@@ -67,44 +66,3 @@ export interface TaskRecord<Input = unknown, Output = unknown> {
 	options?: TaskStartOptions;
 	state: TaskState<Output>;
 }
-
-export interface TransitionTaskStateBase {
-	id: string;
-	expectedWorkflowRunRevision: number;
-}
-
-export interface TransitionTaskStateToRunningCreate extends TransitionTaskStateBase {
-	type: "create";
-	taskName: string;
-	options?: TaskStartOptions;
-	input?: unknown;
-	taskState: Omit<TaskStateRunning, "attempts">;
-}
-
-export interface TransitionTaskStateToRunningRetry extends TransitionTaskStateBase {
-	type: "retry";
-	taskId: string;
-	options?: TaskStartOptions;
-	taskState: TaskStateRunning;
-}
-
-export interface TransitionTaskStateToCompleted extends TransitionTaskStateBase {
-	taskId: string;
-	taskState: TaskStateCompletedRequest;
-}
-
-export type TaskStateCompletedRequest = OptionalProp<TaskStateCompleted<unknown>, "output">;
-
-export interface TransitionTaskStateToFailed extends TransitionTaskStateBase {
-	taskId: string;
-	taskState: TaskStateFailed;
-}
-
-export interface TransitionTaskStateToAwaitingRetry extends TransitionTaskStateBase {
-	taskId: string;
-	taskState: TaskStateAwaitingRetryRequest;
-}
-
-export type TaskStateAwaitingRetryRequest = Omit<TaskStateAwaitingRetry, "nextAttemptAt"> & {
-	nextAttemptInMs: number;
-};


### PR DESCRIPTION
## Problem

The task write endpoints lived on the workflow-run API. Reviewing `setTaskState` on the way also surfaced two problems: it is a pessimistic write (the request carries no expected revision) but locked nothing, so concurrent calls for the same run could lose updates; and it hashed the task input inside the open transaction.

## Changes

**`workflowRun.transitionTaskStateV1` → `task.transitionStateV1`, `workflowRun.setTaskStateV1` → `task.setStateV1`.** The request and response types move to the task API module, and the set-state service logic moves from the workflow-run service to the task service.

```typescript
// before (workflowRun.transitionTaskStateV1)
{ type: "retry"; id: runId; taskId; expectedWorkflowRunRevision; taskState }

// after (task.transitionStateV1)
{ type: "retry"; id: taskId; workflowRunId; expectedWorkflowRunRevision; taskState }
```

**`setTaskState` locks the run row.** Since the request carries no expected revision, both branches begin their transaction by locking the run row, which serializes concurrent writers for the same run. Input hashing moved ahead of the transaction, and a new task's two transition rows are one batch insert.

**Run-row locks are narrowed.** The joined run-with-state read now locks only the run row (`FOR UPDATE OF workflow_run`), not the append-only transition row it joins, and the plain run read gains an optional `forUpdate` for callers that need only existence plus the lock.

## Breaking changes

- `transitionTaskStateV1` and `setTaskStateV1` moved from the workflowRun API to `task.transitionStateV1` / `task.setStateV1`; requests use `id` for the task and `workflowRunId` for the run.
- The transition/set-state request types moved from `@aikirun/types/workflow/task` to `@aikirun/types/api/task`.