### PR TITLE
Compare-and-set task writes

### DIFF
--- a/lib/src/collection/array/utils.test.ts
+++ b/lib/src/collection/array/utils.test.ts
@@ -1,4 +1,4 @@
-import { chunkLazy, groupBy, isNonEmptyArray, partitionArray, shuffleArray } from "./utils";
+import { asNonEmptyArray, chunkLazy, groupBy, isNonEmptyArray, partitionArray, shuffleArray } from "./utils";
 import { describe, expect, spyOn, test } from "bun:test";
 
 describe("isNonEmptyArray", () => {
@@ -16,6 +16,12 @@ describe("isNonEmptyArray", () => {
 
 	test("returns false for undefined", () => {
 		expect(isNonEmptyArray(undefined)).toBe(false);
+	});
+});
+
+describe("asNonEmptyArray", () => {
+	test("returns array unchanged", () => {
+		expect(asNonEmptyArray([1, 2, 3])).toEqual([1, 2, 3]);
 	});
 });
 

--- a/lib/src/collection/array/utils.ts
+++ b/lib/src/collection/array/utils.ts
@@ -23,6 +23,10 @@ export function isNonEmptyArray<T>(value: T[] | undefined): value is NonEmptyArr
 	return value !== undefined && value.length > 0;
 }
 
+export function asNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
+	return value as NonEmptyArray<T>;
+}
+
 export function* chunkLazy<T>(items: T[], size: number): Generator<NonEmptyArray<T>> {
 	let sliceStart = 0;
 	while (sliceStart < items.length) {

--- a/sdk/server/src/errors.ts
+++ b/sdk/server/src/errors.ts
@@ -53,6 +53,24 @@ export class InvalidTaskStateTransitionError extends Error {
 	}
 }
 
+export class TaskStateConflictError extends Error {
+	public readonly workflowRunId: WorkflowRunId;
+	public readonly taskId: TaskId;
+	public readonly expectedStatus: TaskStatus;
+	public readonly expectedAttempts: number;
+
+	constructor(workflowRunId: WorkflowRunId, taskId: TaskId, expected: { status: TaskStatus; attempts: number }) {
+		super(
+			`State conflict for task ${taskId}: expected ${expected.status} with attempts ${expected.attempts} (workflow ${workflowRunId})`
+		);
+		this.name = "TaskStateConflictError";
+		this.workflowRunId = workflowRunId;
+		this.taskId = taskId;
+		this.expectedStatus = expected.status;
+		this.expectedAttempts = expected.attempts;
+	}
+}
+
 export class ScheduleConflictError extends Error {
 	public readonly definitionHash: string;
 	public readonly referenceId?: string;

--- a/sdk/server/src/infra/db/pg/repository/task.ts
+++ b/sdk/server/src/infra/db/pg/repository/task.ts
@@ -53,11 +53,21 @@ export const createTaskRepository = (db: PgDb) => ({
 		return result[0] ?? null;
 	},
 
-	async update(filter: { id: string; workflowRunId: string }, updates: TaskRowUpdate): Promise<TaskRow | null> {
+	async update(
+		filter: { id: string; workflowRunId: string; status: TaskStatus; attempts: number },
+		updates: TaskRowUpdate
+	): Promise<TaskRow | null> {
 		const result = await db
 			.update(task)
 			.set(updates)
-			.where(and(eq(task.id, filter.id), eq(task.workflowRunId, filter.workflowRunId)))
+			.where(
+				and(
+					eq(task.id, filter.id),
+					eq(task.workflowRunId, filter.workflowRunId),
+					eq(task.status, filter.status),
+					eq(task.attempts, filter.attempts)
+				)
+			)
 			.returning();
 		return result[0] ?? null;
 	},
@@ -88,42 +98,46 @@ export const createTaskRepository = (db: PgDb) => ({
 			.limit(limit);
 	},
 
-	async listByWorkflowRunIdsAndStatuses(
-		workflowRunIds: string | NonEmptyArray<string>,
-		statuses: TaskStatus[]
-	): Promise<Array<Pick<TaskRow, "id" | "workflowRunId" | "attempts">>> {
+	async listByWorkflowRunIdsAndStatuses(workflowRunIds: string | NonEmptyArray<string>, statuses: TaskStatus[]) {
 		const runIdsFilter =
 			typeof workflowRunIds === "string"
 				? eq(task.workflowRunId, workflowRunIds)
 				: inArray(task.workflowRunId, workflowRunIds);
 		return db
-			.select({ id: task.id, workflowRunId: task.workflowRunId, attempts: task.attempts })
+			.select({ id: task.id, workflowRunId: task.workflowRunId, attempts: task.attempts, status: task.status })
 			.from(task)
 			.where(and(runIdsFilter, inArray(task.status, statuses)));
 	},
 
 	async bulkDiscard(
 		tasks: NonEmptyArray<{
-			filter: { id: string; workflowRunId: string };
+			filter: { id: string; workflowRunId: string; status: TaskStatus; attempts: number };
 			update: { latestStateTransitionId: string };
 		}>
-	): Promise<void> {
+	): Promise<string[]> {
 		const valueRows = tasks.map(({ filter, update }, index) => {
 			if (index === 0) {
-				return sql`(${filter.id}::text, ${filter.workflowRunId}::text, ${update.latestStateTransitionId}::text)`;
+				return sql`(${filter.id}::text, ${filter.workflowRunId}::text, ${filter.status}::task_status, ${filter.attempts}::integer, ${update.latestStateTransitionId}::text)`;
 			}
-			return sql`(${filter.id}, ${filter.workflowRunId}, ${update.latestStateTransitionId})`;
+			return sql`(${filter.id}, ${filter.workflowRunId}, ${filter.status}, ${filter.attempts}, ${update.latestStateTransitionId})`;
 		});
 
-		await db
+		const result = await db
 			.update(task)
 			.set({
 				status: "discarded",
 				nextAttemptAt: null,
 				latestStateTransitionId: sql`v.state_transition_id`,
 			})
-			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, workflow_run_id, state_transition_id)`)
-			.where(sql`${task.id} = v.id AND ${task.workflowRunId} = v.workflow_run_id`);
+			.from(
+				sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, workflow_run_id, status, attempts, state_transition_id)`
+			)
+			.where(
+				sql`${task.id} = v.id AND ${task.workflowRunId} = v.workflow_run_id AND ${task.status} = v.status AND ${task.attempts} = v.attempts`
+			)
+			.returning({ id: task.id });
+
+		return result.map((row) => row.id);
 	},
 });
 

--- a/sdk/server/src/infra/db/task.integration.test.ts
+++ b/sdk/server/src/infra/db/task.integration.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { createTaskStateMachineService } from "../../service/task-state-machine";
+import { createServiceHarness } from "../../testing/harness";
+import { seedCompletedTask, seedRunningTask } from "../../testing/seed/task";
+
+const withHarness = createServiceHarness();
+
+describe("task repository compare-and-swap guards", () => {
+	test("update leaves the task untouched when the expected status does not match", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+			const rowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+
+			const updated = await repos.task.update(
+				{ id: taskInfo.id, workflowRunId: runId, status: "awaiting_retry", attempts: 1 },
+				{ status: "running", attempts: 2 }
+			);
+
+			expect(updated).toBeNull();
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(rowBefore);
+		}));
+
+	test("update leaves the task untouched when the expected attempts do not match", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			// A retry is the one transition that keeps the status and bumps attempts —
+			// the change a status-only guard cannot see.
+			const taskStateMachine = createTaskStateMachineService({ repos });
+			await taskStateMachine.transitionState(context, {
+				type: "retry",
+				id: taskInfo.id,
+				workflowRunId: runId,
+				expectedWorkflowRunRevision: revisionWhenClaimed,
+				taskState: { status: "running", attempts: 2 },
+			});
+			const rowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+
+			const updated = await repos.task.update(
+				{ id: taskInfo.id, workflowRunId: runId, status: "running", attempts: 1 },
+				{ status: "completed", attempts: 1 }
+			);
+
+			expect(updated).toBeNull();
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(rowBefore);
+		}));
+
+	test("bulkDiscard skips a task whose attempts moved past the expected value", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const taskStateMachine = createTaskStateMachineService({ repos });
+			await taskStateMachine.transitionState(context, {
+				type: "retry",
+				id: taskInfo.id,
+				workflowRunId: runId,
+				expectedWorkflowRunRevision: revisionWhenClaimed,
+				taskState: { status: "running", attempts: 2 },
+			});
+			const rowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+
+			const discardedTaskIds = await repos.task.bulkDiscard([
+				{
+					filter: { id: taskInfo.id, workflowRunId: runId, status: "running", attempts: 1 },
+					update: { latestStateTransitionId: "never-applied" },
+				},
+			]);
+
+			expect(discardedTaskIds).toEqual([]);
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(rowBefore);
+		}));
+
+	test("bulkDiscard discards only the tasks whose expected status still matches", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const staleTaskSeed = await seedRunningTask({ namespaceRequestContext: context, repos, publisher });
+			const completedTaskSeed = await seedCompletedTask({ namespaceRequestContext: context, repos, publisher });
+			const completedRowBefore = await repos.task.getById({
+				id: completedTaskSeed.taskInfo.id,
+				workflowRunId: completedTaskSeed.runId,
+			});
+
+			// Both discards expect "running" — the read-time status. The completed row keeps
+			// attempts 1, so only its status differs and its discard must match nothing.
+			const staleTransitionId = "stale-transition-1";
+			const discardedTaskIds = await repos.task.bulkDiscard([
+				{
+					filter: { id: staleTaskSeed.taskInfo.id, workflowRunId: staleTaskSeed.runId, status: "running", attempts: 1 },
+					update: { latestStateTransitionId: staleTransitionId },
+				},
+				{
+					filter: {
+						id: completedTaskSeed.taskInfo.id,
+						workflowRunId: completedTaskSeed.runId,
+						status: "running",
+						attempts: 1,
+					},
+					update: { latestStateTransitionId: "never-applied" },
+				},
+			]);
+
+			expect(discardedTaskIds).toEqual([staleTaskSeed.taskInfo.id]);
+			expect(await repos.task.getById({ id: staleTaskSeed.taskInfo.id, workflowRunId: staleTaskSeed.runId })).toEqual(
+				expect.objectContaining({
+					status: "discarded",
+					nextAttemptAt: null,
+					latestStateTransitionId: staleTransitionId,
+				})
+			);
+			expect(
+				await repos.task.getById({ id: completedTaskSeed.taskInfo.id, workflowRunId: completedTaskSeed.runId })
+			).toEqual(completedRowBefore);
+		}));
+});

--- a/sdk/server/src/router/error-handler.ts
+++ b/sdk/server/src/router/error-handler.ts
@@ -5,6 +5,7 @@ import {
 	InvalidTaskStateTransitionError,
 	InvalidWorkflowRunStateTransitionError,
 	ScheduleConflictError,
+	TaskStateConflictError,
 	WorkflowRunConflictError,
 	WorkflowRunRevisionConflictError,
 } from "../errors";
@@ -41,6 +42,10 @@ export function handleError<T extends RequestContext>({ logger }: T, err: unknow
 
 	if (err instanceof ScheduleConflictError) {
 		throw new ORPCError("SCHEDULE_CONFLICT", { message: err.message, status: 409 });
+	}
+
+	if (err instanceof TaskStateConflictError) {
+		throw new ORPCError("TASK_STATE_CONFLICT", { message: err.message, status: 409 });
 	}
 
 	if (err instanceof InvalidWorkflowRunStateTransitionError) {

--- a/sdk/server/src/service/discard-stale-tasks.ts
+++ b/sdk/server/src/service/discard-stale-tasks.ts
@@ -1,5 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import { isNonEmptyArray } from "@aikirun/lib/collection/array";
+import { asNonEmptyArray, isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TaskStateDiscarded } from "@aikirun/types/workflow/task";
 import { ulid } from "ulidx";
 
@@ -18,33 +18,40 @@ export async function discardStaleTasks(
 		return;
 	}
 
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
-	const taskUpdates: Array<{
-		filter: { id: string; workflowRunId: string };
-		update: { latestStateTransitionId: string };
-	}> = [];
-
-	for (const task of staleTasks) {
-		const transitionId = ulid();
-		stateTransitionEntries.push({
-			id: transitionId,
-			workflowRunId: task.workflowRunId,
-			type: "task",
-			taskId: task.id,
-			status: "discarded",
-			attempt: task.attempts,
-			state: { status: "discarded", attempts: task.attempts } satisfies TaskStateDiscarded,
-		});
-		taskUpdates.push({
-			filter: { id: task.id, workflowRunId: task.workflowRunId },
-			update: { latestStateTransitionId: transitionId },
-		});
-	}
-
-	if (!isNonEmptyArray(stateTransitionEntries) || !isNonEmptyArray(taskUpdates)) {
+	const taskUpdatesById = new Map(
+		staleTasks.map((task) => [
+			task.id,
+			{
+				filter: { id: task.id, workflowRunId: task.workflowRunId, status: task.status, attempts: task.attempts },
+				update: { latestStateTransitionId: ulid() },
+			},
+		])
+	);
+	const taskUpdates = Array.from(taskUpdatesById.values());
+	const discardedTaskIds = await txRepos.task.bulkDiscard(asNonEmptyArray(taskUpdates));
+	if (!isNonEmptyArray(discardedTaskIds)) {
 		return;
 	}
 
-	await txRepos.stateTransition.appendBatch(stateTransitionEntries);
-	await txRepos.task.bulkDiscard(taskUpdates);
+	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+
+	for (const discardedTaskId of discardedTaskIds) {
+		const taskUpdate = taskUpdatesById.get(discardedTaskId);
+		if (!taskUpdate) {
+			continue;
+		}
+		stateTransitionEntries.push({
+			id: taskUpdate.update.latestStateTransitionId,
+			workflowRunId: taskUpdate.filter.workflowRunId,
+			type: "task",
+			taskId: discardedTaskId,
+			status: "discarded",
+			attempt: taskUpdate.filter.attempts,
+			state: { status: "discarded", attempts: taskUpdate.filter.attempts } satisfies TaskStateDiscarded,
+		});
+	}
+
+	if (isNonEmptyArray(stateTransitionEntries)) {
+		await txRepos.stateTransition.appendBatch(stateTransitionEntries);
+	}
 }

--- a/sdk/server/src/service/task-state-machine.ts
+++ b/sdk/server/src/service/task-state-machine.ts
@@ -14,7 +14,7 @@ import type {
 } from "@aikirun/types/workflow/task";
 import { ulid } from "ulidx";
 
-import { InvalidTaskStateTransitionError, WorkflowRunRevisionConflictError } from "../errors";
+import { InvalidTaskStateTransitionError, TaskStateConflictError, WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
 
@@ -176,8 +176,8 @@ async function transitionStateInTx(
 		state: taskState,
 	});
 
-	await txRepos.task.update(
-		{ id: taskId, workflowRunId: runId },
+	const updatedTask = await txRepos.task.update(
+		{ id: taskId, workflowRunId: runId, status: existingTask.status, attempts: existingTask.attempts },
 		{
 			status: taskState.status,
 			attempts: taskState.attempts,
@@ -185,6 +185,12 @@ async function transitionStateInTx(
 			nextAttemptAt: taskState.status === "awaiting_retry" ? (taskState.nextAttemptAt as TimestampMs) : null,
 		}
 	);
+	if (!updatedTask) {
+		throw new TaskStateConflictError(runId, taskId, {
+			status: existingTask.status,
+			attempts: existingTask.attempts,
+		});
+	}
 
 	if (taskState.status === "awaiting_retry") {
 		// The workflow run stays in `running` while the task waits for its retry, so the outbox row

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -6,9 +6,10 @@ import type {
 	TaskSetStateRequestV1,
 } from "@aikirun/types/api/task";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
-import type { TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
+import type { TaskId, TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
 import { monotonicFactory, ulid } from "ulidx";
 
+import { TaskStateConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
 
@@ -153,12 +154,23 @@ async function setExistingTaskStateInTx(
 		attempt: state.attempts,
 		state: state,
 	});
-	await txRepos.task.update(
-		{ id: existingTaskRow.id, workflowRunId: runId },
+	const updatedTask = await txRepos.task.update(
+		{
+			id: existingTaskRow.id,
+			workflowRunId: runId,
+			status: existingTaskRow.status,
+			attempts: existingTaskRow.attempts,
+		},
 		{
 			status: state.status,
 			attempts: state.attempts,
 			latestStateTransitionId: transitionId,
 		}
 	);
+	if (!updatedTask) {
+		throw new TaskStateConflictError(runId, existingTaskRow.id as TaskId, {
+			status: existingTaskRow.status,
+			attempts: existingTaskRow.attempts,
+		});
+	}
 }

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -4,7 +4,11 @@ import { type SeedRunDeps, seedClaimedRun } from "./run";
 import { createTaskStateMachineService } from "../../service/task-state-machine";
 import { namespaceRequestContextFactory } from "../data-factory/middleware/context";
 
-const seededTask = { name: "reserve-inventory", input: { sku: "SKU-42", quantity: 3 } } as const;
+const seededTask = {
+	name: "reserve-inventory",
+	input: { sku: "SKU-42", quantity: 3 },
+	output: { reservationId: "rsv-1" },
+} as const;
 
 export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePublisher }) {
 	const { repos } = deps;
@@ -22,4 +26,20 @@ export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePubli
 	});
 
 	return { ...seeded, taskInfo, taskInput: seededTask.input };
+}
+
+export async function seedCompletedTask(deps: SeedRunDeps & { publisher: FakePublisher }) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedRunningTask({ ...deps, namespaceRequestContext });
+
+	const taskStateMachine = createTaskStateMachineService({ repos });
+	const taskInfo = await taskStateMachine.transitionState(namespaceRequestContext, {
+		id: seeded.taskInfo.id,
+		workflowRunId: seeded.runId,
+		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
+		taskState: { status: "completed", attempts: 1, output: seededTask.output },
+	});
+
+	return { ...seeded, taskInfo };
 }


### PR DESCRIPTION
## Problem

A task row carries `(status, attempts)` and a pointer to its latest entry in the append-only state transition history. Three writers update it: the task state machine (worker-driven transitions), `setTaskState` (setting a task's state directly through the API), and `discardStaleTasks` (the run-level paths — cancellation, stalling, run retry — discarding a run's leftover tasks).

Each writer reads the task, validates the transition against that read, then writes. The write filtered only on `(id, workflowRunId)`, so it applied regardless of what the row held by then. Nothing orders the writers: task transitions check the run revision but never increment it, and worker transitions read the run row without locking it, so the run-row lock that `setTaskState` and the run-level paths hold cannot serialize a worker against them. A writer with a stale read can overwrite a transition that landed in between — a discard can land on a task that just completed.

## Solution

`(status, attempts)` is a complete version key for a task: every legal transition changes at least one of the two. The only transition that keeps the status is a retry (`running → running`), and it bumps `attempts`. A row matching the read-time `(status, attempts)` is therefore exactly the row that was read.

Every task write now carries that read-time pair in its filter:

```ts
// before
update(filter: { id, workflowRunId }, updates): Promise<TaskRow | null>
bulkDiscard(tasks: Array<{ filter: { id, workflowRunId }, update }>): Promise<void>

// after
update(filter: { id, workflowRunId, status, attempts }, updates): Promise<TaskRow | null>
bulkDiscard(tasks: Array<{ filter: { id, workflowRunId, status, attempts }, update }>): Promise<string[]> // discarded ids
```

- The task state machine and `setTaskState` throw `TaskStateConflictError` (a new error, mapped to 409) when the update matches no row; the throw rolls back the transition they appended in the same transaction.
- `discardStaleTasks` discards first and appends discard transitions only for the ids `bulkDiscard` returned. A task that moved on between the listing and the discard keeps its row and history untouched.