### PR TITLE
Compare-and-set schedule occurrence writes

### DIFF
--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -17,6 +17,7 @@ import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
 import type { Repositories } from "../infra/db/types";
+import type { ScheduleOccurrenceUpdate } from "../infra/db/types/schedule";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -146,7 +147,7 @@ async function processOverlapAllowSchedules(
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
-	const scheduleUpdates: { id: string; lastOccurrence: TimestampMs; nextRunAt: TimestampMs }[] = [];
+	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
 		const occurrences = getDueOccurrences(schedule, now);
@@ -197,9 +198,11 @@ async function processOverlapAllowSchedules(
 		// biome-ignore lint/style/noNonNullAssertion: isNonEmptyArray guarantees at least one element
 		const lastOccurrence = occurrences.at(-1)!;
 		scheduleUpdates.push({
-			id: schedule.id,
-			lastOccurrence: lastOccurrence as TimestampMs,
-			nextRunAt: getNextOccurrence(schedule.spec, lastOccurrence) as TimestampMs,
+			filter: { id: schedule.id, nextRunAt: schedule.nextRunAt as TimestampMs },
+			update: {
+				lastOccurrence: lastOccurrence as TimestampMs,
+				nextRunAt: getNextOccurrence(schedule.spec, lastOccurrence) as TimestampMs,
+			},
 		});
 	}
 
@@ -237,7 +240,7 @@ async function processOverlapSkipSchedules(
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
-	const scheduleUpdates: { id: string; lastOccurrence?: TimestampMs; nextRunAt: TimestampMs }[] = [];
+	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
 		const occurrences = getDueOccurrences(schedule, now);
@@ -248,8 +251,8 @@ async function processOverlapSkipSchedules(
 
 		if (activeRunsByScheduleId.has(schedule.id)) {
 			scheduleUpdates.push({
-				id: schedule.id,
-				nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs,
+				filter: { id: schedule.id, nextRunAt: schedule.nextRunAt as TimestampMs },
+				update: { nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs },
 			});
 			continue;
 		}
@@ -292,9 +295,11 @@ async function processOverlapSkipSchedules(
 			status: "pending",
 		});
 		scheduleUpdates.push({
-			id: schedule.id,
-			lastOccurrence: occurrence as TimestampMs,
-			nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs,
+			filter: { id: schedule.id, nextRunAt: schedule.nextRunAt as TimestampMs },
+			update: {
+				lastOccurrence: occurrence as TimestampMs,
+				nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs,
+			},
 		});
 	}
 
@@ -335,7 +340,7 @@ async function processOverlapCancelPreviousSchedules(
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
 	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
 	const newOutboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
-	const scheduleUpdates: { id: string; lastOccurrence: TimestampMs; nextRunAt: TimestampMs }[] = [];
+	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
 		const occurrences = getDueOccurrences(schedule, now);
@@ -391,9 +396,11 @@ async function processOverlapCancelPreviousSchedules(
 			status: "pending",
 		});
 		scheduleUpdates.push({
-			id: schedule.id,
-			lastOccurrence: occurrence as TimestampMs,
-			nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs,
+			filter: { id: schedule.id, nextRunAt: schedule.nextRunAt as TimestampMs },
+			update: {
+				lastOccurrence: occurrence as TimestampMs,
+				nextRunAt: getNextOccurrence(schedule.spec, occurrence) as TimestampMs,
+			},
 		});
 	}
 

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -31,6 +31,10 @@ type ScheduleRowUpdate = Partial<
 		| "workflowId"
 	>
 >;
+export interface ScheduleOccurrenceUpdate {
+	filter: { id: string; nextRunAt: TimestampMs };
+	update: { lastOccurrence?: TimestampMs; nextRunAt: TimestampMs };
+}
 
 export const createScheduleRepository = (db: PgDb) => ({
 	async create(input: ScheduleRowInsert): Promise<ScheduleRow> {
@@ -70,34 +74,39 @@ export const createScheduleRepository = (db: PgDb) => ({
 		return result[0] ?? null;
 	},
 
-	async bulkUpdateOccurrence(
-		entries: NonEmptyArray<{ id: string; lastOccurrence?: TimestampMs; nextRunAt: TimestampMs }>
-	): Promise<void> {
-		const valueRows = entries.map((entry, index) => {
-			const lastOccurrenceIso = entry.lastOccurrence ? new Date(entry.lastOccurrence).toISOString() : null;
-			const nextRunAtIso = new Date(entry.nextRunAt).toISOString();
+	async bulkUpdateOccurrence(entries: NonEmptyArray<ScheduleOccurrenceUpdate>): Promise<void> {
+		const valueRows = entries.map(({ filter, update }, index) => {
+			const expectedNextRunAtIso = new Date(filter.nextRunAt).toISOString();
+			const lastOccurrenceIso = update.lastOccurrence ? new Date(update.lastOccurrence).toISOString() : null;
+			const nextRunAtIso = new Date(update.nextRunAt).toISOString();
 			if (index === 0) {
-				return sql`(${entry.id}::text, ${nextRunAtIso}::timestamptz, ${lastOccurrenceIso}::timestamptz)`;
+				return sql`(${filter.id}::text, ${expectedNextRunAtIso}::timestamptz, ${lastOccurrenceIso}::timestamptz, ${nextRunAtIso}::timestamptz)`;
 			}
-			return sql`(${entry.id}, ${nextRunAtIso}, ${lastOccurrenceIso})`;
+			return sql`(${filter.id}, ${expectedNextRunAtIso}, ${lastOccurrenceIso}, ${nextRunAtIso})`;
 		});
 
+		// The update applies only while nextRunAt still holds the value the caller read.
+		// Every occurrence advance changes nextRunAt, so an update built from an outdated
+		// read matches nothing.
 		await db
 			.update(schedule)
 			.set({
 				nextRunAt: sql`v.next_run_at`,
 				lastOccurrence: sql`COALESCE(v.last_occurrence, ${schedule.lastOccurrence})`,
 			})
-			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, next_run_at, last_occurrence)`)
-			.where(sql`${schedule.id} = v.id`);
+			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, expected_next_run_at, last_occurrence, next_run_at)`)
+			.where(sql`${schedule.id} = v.id AND ${schedule.nextRunAt} = v.expected_next_run_at`);
 	},
 
 	async get(
 		namespaceId: NamespaceId,
-		filter: { definitionHash?: string; referenceId?: string | null }
+		filter: { id?: string; definitionHash?: string; referenceId?: string | null }
 	): Promise<ScheduleRow | null> {
 		const conditions = [eq(schedule.namespaceId, namespaceId)];
 
+		if (filter.id) {
+			conditions.push(eq(schedule.id, filter.id));
+		}
 		if (filter.definitionHash) {
 			conditions.push(eq(schedule.definitionHash, filter.definitionHash));
 		}

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -569,6 +569,9 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result;
 	},
 
+	// Sets the pointer for whatever run ids it is given, with no guard of its own.
+	// Call it in the same transaction as the guarded bulk transition that returned these ids:
+	// that transition's row locks keep the runs unchanged until this write commits with it.
 	async bulkSetLatestStateTransitionId(runs: NonEmptyArray<{ id: string; stateTransitionId: string }>): Promise<void> {
 		const valueRows = runs.map((run, index) => {
 			if (index === 0) {

--- a/sdk/server/src/infra/db/schedule.integration.test.ts
+++ b/sdk/server/src/infra/db/schedule.integration.test.ts
@@ -1,0 +1,80 @@
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { NamespaceId } from "@aikirun/types/namespace";
+
+import type { Repositories } from "./types";
+import { describe, expect, test } from "bun:test";
+import { createServiceHarness } from "../../testing/harness";
+import { seedActiveSchedule } from "../../testing/seed/schedule";
+
+const withHarness = createServiceHarness();
+
+async function getScheduleRow(repos: Pick<Repositories, "schedule">, namespaceId: NamespaceId, id: string) {
+	const schedule = await repos.schedule.get(namespaceId, { id });
+	if (!schedule) {
+		throw new Error(`Schedule not found: ${id}`);
+	}
+	return schedule;
+}
+
+describe("schedule repository occurrence guard", () => {
+	test("bulkUpdateOccurrence leaves the schedule untouched when the expected nextRunAt does not match", () =>
+		withHarness(async ({ context, repos }) => {
+			const { schedule } = await seedActiveSchedule({ namespaceRequestContext: context, repos });
+			const currentNextRunAt = schedule.nextRunAt as TimestampMs;
+
+			await repos.schedule.bulkUpdateOccurrence([
+				{
+					filter: { id: schedule.id, nextRunAt: (currentNextRunAt - 60_000) as TimestampMs },
+					update: {
+						lastOccurrence: currentNextRunAt,
+						nextRunAt: (currentNextRunAt + 60_000) as TimestampMs,
+					},
+				},
+			]);
+
+			expect(await getScheduleRow(repos, context.namespaceId, schedule.id)).toEqual(
+				expect.objectContaining({
+					lastOccurrence: null,
+					nextRunAt: currentNextRunAt,
+				})
+			);
+		}));
+
+	test("bulkUpdateOccurrence advances only the schedules whose expected nextRunAt matches", () =>
+		withHarness(async ({ context, repos }) => {
+			const matchedSeed = await seedActiveSchedule({ namespaceRequestContext: context, repos });
+			const mismatchedSeed = await seedActiveSchedule(
+				{ namespaceRequestContext: context, repos },
+				{ workflowName: "send-reminders" }
+			);
+			const matchedNextRunAt = matchedSeed.schedule.nextRunAt as TimestampMs;
+			const mismatchedNextRunAt = mismatchedSeed.schedule.nextRunAt as TimestampMs;
+
+			await repos.schedule.bulkUpdateOccurrence([
+				{
+					filter: { id: matchedSeed.schedule.id, nextRunAt: matchedNextRunAt },
+					update: {
+						lastOccurrence: matchedNextRunAt,
+						nextRunAt: (matchedNextRunAt + 60_000) as TimestampMs,
+					},
+				},
+				{
+					filter: { id: mismatchedSeed.schedule.id, nextRunAt: (mismatchedNextRunAt - 60_000) as TimestampMs },
+					update: { nextRunAt: (mismatchedNextRunAt + 60_000) as TimestampMs },
+				},
+			]);
+
+			expect(await getScheduleRow(repos, context.namespaceId, matchedSeed.schedule.id)).toEqual(
+				expect.objectContaining({
+					lastOccurrence: matchedNextRunAt,
+					nextRunAt: matchedNextRunAt + 60_000,
+				})
+			);
+			expect(await getScheduleRow(repos, context.namespaceId, mismatchedSeed.schedule.id)).toEqual(
+				expect.objectContaining({
+					lastOccurrence: null,
+					nextRunAt: mismatchedNextRunAt,
+				})
+			);
+		}));
+});

--- a/sdk/server/src/infra/db/types/schedule.ts
+++ b/sdk/server/src/infra/db/types/schedule.ts
@@ -1,1 +1,1 @@
-export type { ScheduleRepository, ScheduleRow } from "../pg/repository/schedule";
+export type { ScheduleOccurrenceUpdate, ScheduleRepository, ScheduleRow } from "../pg/repository/schedule";

--- a/sdk/server/src/testing/seed/schedule.ts
+++ b/sdk/server/src/testing/seed/schedule.ts
@@ -1,0 +1,31 @@
+import type { Repositories } from "../../infra/db/types";
+import type { NamespaceRequestContext } from "../../middleware/context";
+import { createScheduleService } from "../../service/schedule";
+import { namespaceRequestContextFactory } from "../data-factory/middleware/context";
+
+const seededSchedule = {
+	workflowName: "send-invoices",
+	workflowVersionId: "v1",
+	workflowRunInput: { region: "eu-west" },
+	spec: { type: "interval", everyMs: 60_000 },
+} as const;
+
+export async function seedActiveSchedule(
+	deps: { repos: Repositories; namespaceRequestContext?: NamespaceRequestContext },
+	overrides?: { workflowName?: string }
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+
+	const scheduleService = createScheduleService({ repos });
+	const { schedule } = await scheduleService.activateSchedule(
+		namespaceRequestContext,
+		namespaceRequestContext.namespaceId,
+		{
+			...seededSchedule,
+			workflowName: overrides?.workflowName ?? seededSchedule.workflowName,
+		}
+	);
+
+	return { schedule };
+}


### PR DESCRIPTION
## Problem

The recurring-runs daemon turns due schedules into workflow runs. A schedule row carries two timestamps: `lastOccurrence`, the last occurrence the daemon has handled, from which the next occurrences are computed, and `nextRunAt`, the time the daemon compares against the clock to find due schedules. When a pass picks up a due schedule, it computes the occurrences and, in one transaction, inserts the new runs and advances the two timestamps. Nothing claims a schedule first — a due schedule stays visible to every scanner until an advance commits.

Here is the race, on a schedule that fires every minute with the skip overlap policy (an occurrence is dropped while the previous one is still running):

```
state: run from the 10:00 occurrence still active, nextRunAt = 10:01

10:01   server A picks up the schedule: due. Sees the active run → skip.
        Prepares nextRunAt = 10:02 ... then stalls before committing.

10:02   server B picks up the schedule: still due, A never committed.
        Sees the active run → skips 10:02. Writes nextRunAt = 10:03. Commits.

10:02+  server A finally commits: nextRunAt = 10:02.
        Backward from 10:03 — and already in the past. The schedule is due again.
```

A's stale write applied because the update matched on the schedule id alone. Now the schedule is due when it should not be — and if the active run happens to finish before the next pass, that pass finds a due schedule with no active run and creates a run for an occurrence that had already been dropped. The skip policy quietly did not skip.

Only the skip overlap policy path can get here. On the other overlap policies (allow, cancel_previous), the race settles itself: two passes handling the same occurrence build the same run reference id from the schedule id and the occurrence time, the slower insert hits a unique index, and its whole transaction rolls back with the occurrence write inside it.

## Solution

`nextRunAt` works as a version number for the schedule: the definition never changes, so every advance moves `nextRunAt` forward and no value repeats. Each occurrence update now carries the `nextRunAt` the pass read, and the write applies only where the row still holds that value:

```ts
// before
bulkUpdateOccurrence(entries: NonEmptyArray<{ id, lastOccurrence?, nextRunAt }>)

// after
bulkUpdateOccurrence(entries: NonEmptyArray<{
	filter: { id, nextRunAt }, // the value read at scan time
	update: { lastOccurrence?, nextRunAt },
}>)
```

In the scenario above, A's late write expects `nextRunAt` to still be 10:01, finds 10:03, and touches nothing — the schedule stays where B put it.