### PR TITLE
Separate call instructions from persisted run options

### DIFF
--- a/app/dashboard/src/pages/Dashboard.tsx
+++ b/app/dashboard/src/pages/Dashboard.tsx
@@ -400,7 +400,7 @@ function ScheduleRow({ schedule, runCount }: { schedule: Schedule; runCount: num
 	const canResume = schedule.status === "paused";
 	const canDeactivate = schedule.status !== "inactive";
 
-	const referenceId = schedule.options?.reference?.id;
+	const referenceId = schedule.referenceId;
 
 	return (
 		<tr className="hover:bg-slate-50 transition-colors">

--- a/app/dashboard/src/pages/RunDetail.tsx
+++ b/app/dashboard/src/pages/RunDetail.tsx
@@ -420,7 +420,7 @@ export function RunDetail() {
 						<span style={{ display: "inline-flex", alignItems: "center", minHeight: 22 }}>v{currentRun.versionId}</span>
 					</Meta>
 
-					{currentRun.options?.reference && (
+					{currentRun.referenceId && (
 						<Meta label="Reference">
 							<span
 								style={{
@@ -430,12 +430,12 @@ export function RunDetail() {
 									fontWeight: 700,
 									maxWidth: 160,
 								}}
-								title={currentRun.options.reference.id}
+								title={currentRun.referenceId}
 							>
 								<span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-									{currentRun.options.reference.id}
+									{currentRun.referenceId}
 								</span>
-								<CopyButton text={currentRun.options.reference.id} />
+								<CopyButton text={currentRun.referenceId} />
 							</span>
 						</Meta>
 					)}

--- a/app/dashboard/src/pages/SchedulesList.tsx
+++ b/app/dashboard/src/pages/SchedulesList.tsx
@@ -1,9 +1,5 @@
-import {
-	SCHEDULE_STATUSES,
-	type Schedule,
-	type ScheduledWorkflowStartOptions,
-	type ScheduleStatus,
-} from "@aikirun/types/schedule";
+import { SCHEDULE_STATUSES, type Schedule, type ScheduleStatus } from "@aikirun/types/schedule";
+import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 import { useQueryClient } from "@tanstack/react-query";
 import type { CSSProperties } from "react";
 import { useMemo, useState } from "react";
@@ -149,7 +145,7 @@ function fmtDelay(ms: number): string {
 	return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`;
 }
 
-function retrySummary(retry: NonNullable<ScheduledWorkflowStartOptions["retry"]>): string {
+function retrySummary(retry: NonNullable<WorkflowRunOptions["retry"]>): string {
 	switch (retry.type) {
 		case "never":
 			return "never";
@@ -560,7 +556,7 @@ function ScheduleRow({
 								</span>
 								<CopyButton text={schedule.id} />
 							</span>
-							{showRef && schedule.options?.reference?.id && (
+							{showRef && schedule.referenceId && (
 								<>
 									<span style={{ fontSize: 10, color: "var(--t1)", fontWeight: 700, marginLeft: -2, marginRight: 2 }}>
 										•
@@ -576,11 +572,11 @@ function ScheduleRow({
 												whiteSpace: "nowrap",
 												maxWidth: 120,
 											}}
-											title={schedule.options.reference.id}
+											title={schedule.referenceId}
 										>
-											REF: {schedule.options.reference.id}
+											REF: {schedule.referenceId}
 										</span>
-										<CopyButton text={schedule.options.reference.id} />
+										<CopyButton text={schedule.referenceId} />
 									</span>
 								</>
 							)}
@@ -662,9 +658,7 @@ function ScheduleRow({
 					{/* Metadata row */}
 					<div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginBottom: 12 }}>
 						<Meta label="ID" value={schedule.id} copyable />
-						{schedule.options?.reference?.id && (
-							<Meta label="Reference" value={schedule.options.reference.id} copyable />
-						)}
+						{schedule.referenceId && <Meta label="Reference" value={schedule.referenceId} copyable />}
 						<Meta label="Type" value={schedule.spec.type} />
 						{schedule.spec.type === "cron" && <Meta label="Expression" value={schedule.spec.expression} />}
 						{schedule.spec.type === "cron" && schedule.spec.timezone && (

--- a/sdk/server/src/contract/procedure/schedule.ts
+++ b/sdk/server/src/contract/procedure/schedule.ts
@@ -19,12 +19,12 @@ import { type } from "arktype";
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
 import {
 	scheduleActivateOptionsSchema,
-	scheduledWorkflowStartOptionsSchema,
 	scheduleSchema,
 	scheduleSpecSchema,
 	scheduleStatusSchema,
 	scheduleWorkflowFilterSchema,
 } from "../schema/schedule";
+import { workflowRunOptionsSchema } from "../schema/workflow-run";
 
 const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateResponseV1> = oc
 	.input(
@@ -34,7 +34,7 @@ const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateR
 			"workflowRunInput?": "unknown",
 			spec: scheduleSpecSchema,
 			"options?": scheduleActivateOptionsSchema.or("undefined"),
-			"workflowRunOptions?": scheduledWorkflowStartOptionsSchema.or("undefined"),
+			"workflowRunOptions?": workflowRunOptionsSchema.or("undefined"),
 		})
 	)
 	.output(

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -39,7 +39,6 @@ import {
 	cancelByIdsResponseSchema,
 	listChildRunsRequestSchema,
 	listChildRunsResponseSchema,
-	workflowOptionsSchema,
 	workflowRunRecordSchema,
 	workflowRunStateAwaitingChildWorkflowSchema,
 	workflowRunStateAwaitingEventSchema,
@@ -56,6 +55,7 @@ import {
 	workflowRunStateSleepingSchema,
 	workflowRunStateStalledSchema,
 	workflowRunStatusSchema,
+	workflowStartOptionsSchema,
 } from "../schema/workflow-run";
 
 const listV1: ContractProcedure<WorkflowRunListRequestV1, WorkflowRunListResponseV1> = oc
@@ -158,7 +158,7 @@ const createV1: ContractProcedure<WorkflowRunCreateRequestV1, WorkflowRunCreateR
 			"input?": "unknown",
 			inputHash: "string > 0",
 			"parentWorkflowRunId?": "string > 0 | undefined",
-			"options?": workflowOptionsSchema,
+			"options?": workflowStartOptionsSchema,
 		})
 	)
 	.output(

--- a/sdk/server/src/contract/schema/schedule.ts
+++ b/sdk/server/src/contract/schema/schedule.ts
@@ -1,7 +1,7 @@
 import { type } from "arktype";
 
 import { workflowSourceSchema } from "./workflow";
-import { workflowOptionsSchema } from "./workflow-run";
+import { workflowRunOptionsSchema } from "./workflow-run";
 
 export const overlapPolicySchema = type("'allow' | 'skip' | 'cancel_previous'");
 
@@ -33,8 +33,6 @@ export const scheduleActivateOptionsSchema = type({
 	"reference?": scheduleReferenceSchema.or("undefined"),
 });
 
-export const scheduledWorkflowStartOptionsSchema = workflowOptionsSchema.pick("retry", "pool");
-
 export const scheduleWorkflowFilterSchema = type({
 	name: "string > 0",
 	"versionId?": "string > 0 | undefined",
@@ -49,8 +47,8 @@ export const scheduleSchema = type({
 	"workflowRunInput?": "unknown",
 	spec: scheduleSpecSchema,
 	status: scheduleStatusSchema,
-	"options?": scheduleActivateOptionsSchema.or("undefined"),
-	"workflowRunOptions?": scheduledWorkflowStartOptionsSchema.or("undefined"),
+	"referenceId?": "string > 0 | undefined",
+	"workflowRunOptions?": workflowRunOptionsSchema.or("undefined"),
 	createdAt: "number > 0",
 	updatedAt: "number > 0",
 	"lastOccurrence?": "number > 0 | undefined",

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -19,11 +19,14 @@ const workflowReferenceSchema = type({
 	"conflictPolicy?": "'error' | 'return_existing' | undefined",
 });
 
-export const workflowOptionsSchema = type({
-	"reference?": workflowReferenceSchema,
-	"trigger?": triggerStrategySchema,
+export const workflowRunOptionsSchema = type({
 	"pool?": "string | undefined",
 	"retry?": retryStrategySchema,
+});
+
+export const workflowStartOptionsSchema = workflowRunOptionsSchema.and({
+	"reference?": workflowReferenceSchema,
+	"trigger?": triggerStrategySchema,
 });
 
 export const workflowRunStateScheduledSchema = type({
@@ -166,7 +169,8 @@ export const workflowRunRecordSchema = type({
 	stateTransitionId: "string > 0",
 	"input?": "unknown",
 	inputHash: "string > 0",
-	"options?": workflowOptionsSchema.or("undefined"),
+	"referenceId?": "string > 0 | undefined",
+	"options?": workflowRunOptionsSchema.or("undefined"),
 	attempts: "number.integer >= 0",
 	state: workflowRunStateSchema,
 	tasks: type({ "[string]": taskInfoSchema.array() }),

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -5,10 +5,9 @@ import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type { Schedule, ScheduledWorkflowStartOptions, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
+import type { Schedule, ScheduleOverlapPolicy } from "@aikirun/types/schedule";
 import {
 	NON_TERMINAL_WORKFLOW_RUN_STATUSES,
-	type WorkflowReference,
 	type WorkflowRunId,
 	type WorkflowRunStateCancelled,
 	type WorkflowRunStateQueued,
@@ -168,7 +167,7 @@ async function processOverlapAllowSchedules(
 				status: "queued",
 				input: schedule.workflowRunInput,
 				inputHash: schedule.workflowRunInputHash,
-				options: scheduledRunOptions(schedule, referenceId),
+				options: schedule.workflowRunOptions,
 				referenceId,
 				latestStateTransitionId: stateTransitionId,
 			});
@@ -269,7 +268,7 @@ async function processOverlapSkipSchedules(
 			status: "queued",
 			input: schedule.workflowRunInput,
 			inputHash: schedule.workflowRunInputHash,
-			options: scheduledRunOptions(schedule, referenceId),
+			options: schedule.workflowRunOptions,
 			referenceId,
 			latestStateTransitionId: stateTransitionId,
 		});
@@ -370,7 +369,7 @@ async function processOverlapCancelPreviousSchedules(
 			status: "queued",
 			input: schedule.workflowRunInput,
 			inputHash: schedule.workflowRunInputHash,
-			options: scheduledRunOptions(schedule, referenceId),
+			options: schedule.workflowRunOptions,
 			referenceId,
 			latestStateTransitionId: stateTransitionId,
 		});
@@ -473,17 +472,6 @@ async function processOverlapCancelPreviousSchedules(
 	if (deps.publisher && isNonEmptyArray(insertedOutboxEntries)) {
 		await publishOutboxEntries(context, deps.repos, deps.publisher, insertedOutboxEntries, republishBackoff);
 	}
-}
-
-function scheduledRunOptions(
-	schedule: DueSchedule,
-	referenceId: string
-): ScheduledWorkflowStartOptions & { reference: WorkflowReference } {
-	return {
-		reference: { id: referenceId },
-		retry: schedule.workflowRunOptions?.retry,
-		pool: schedule.workflowRunOptions?.pool,
-	};
 }
 
 async function fetchActiveRunsBySchedule(

--- a/sdk/server/src/infra/db/pg/migration/0020_flowery_scarecrow.sql
+++ b/sdk/server/src/infra/db/pg/migration/0020_flowery_scarecrow.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "schedule" DROP COLUMN "conflict_policy";--> statement-breakpoint
+ALTER TABLE "workflow_run" DROP COLUMN "conflict_policy";--> statement-breakpoint
+DROP TYPE "public"."schedule_conflict_policy";--> statement-breakpoint
+DROP TYPE "public"."workflow_run_conflict_policy";--> statement-breakpoint
+UPDATE "workflow_run" SET "options" = "options" - 'reference' - 'trigger' WHERE "options" IS NOT NULL AND ("options" ? 'reference' OR "options" ? 'trigger');--> statement-breakpoint
+UPDATE "workflow_run" SET "options" = NULL WHERE "options" = '{}'::jsonb;

--- a/sdk/server/src/infra/db/pg/migration/meta/0020_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0020_snapshot.json
@@ -1,0 +1,1762 @@
+{
+	"id": "9b5c49cf-acf3-4405-b284-defa203a12df",
+	"prevId": "2730dfa9-7856-4422-a5bd-de01519860d3",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR \"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_id": {
+					"name": "idx_event_wait_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule": {
+					"name": "idx_workflow_run_schedule",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -141,6 +141,13 @@
 			"when": 1786715913819,
 			"tag": "0019_medical_rocket_raccoon",
 			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1786719233638,
+			"tag": "0020_flowery_scarecrow",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -24,7 +24,6 @@ type ScheduleRowUpdate = Partial<
 		| "workflowRunInputHash"
 		| "definitionHash"
 		| "referenceId"
-		| "conflictPolicy"
 		| "workflowRunOptions"
 		| "lastOccurrence"
 		| "nextRunAt"

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -1,19 +1,12 @@
-import {
-	SCHEDULE_CONFLICT_POLICIES,
-	SCHEDULE_OVERLAP_POLICIES,
-	SCHEDULE_STATUSES,
-	SCHEDULE_TYPES,
-	type ScheduledWorkflowStartOptions,
-} from "@aikirun/types/schedule";
+import { SCHEDULE_OVERLAP_POLICIES, SCHEDULE_STATUSES, SCHEDULE_TYPES } from "@aikirun/types/schedule";
 import { WORKFLOW_SOURCES } from "@aikirun/types/workflow";
 import {
 	CHILD_WORKFLOW_RUN_WAIT_STATUSES,
 	EVENT_WAIT_STATUSES,
 	SLEEP_STATUSES,
 	TERMINAL_WORKFLOW_RUN_STATUSES,
-	WORKFLOW_RUN_CONFLICT_POLICIES,
 	WORKFLOW_RUN_STATUSES,
-	type WorkflowStartOptions,
+	type WorkflowRunOptions,
 } from "@aikirun/types/workflow/run";
 import { STATE_TRANSITION_TYPES } from "@aikirun/types/workflow/state-transition";
 import { TASK_STATUSES, type TaskStartOptions } from "@aikirun/types/workflow/task";
@@ -39,11 +32,9 @@ export const workflowSourceEnum = pgEnum("workflow_source", WORKFLOW_SOURCES);
 export const scheduleStatusEnum = pgEnum("schedule_status", SCHEDULE_STATUSES);
 export const scheduleTypeEnum = pgEnum("schedule_type", SCHEDULE_TYPES);
 export const scheduleOverlapPolicyEnum = pgEnum("schedule_overlap_policy", SCHEDULE_OVERLAP_POLICIES);
-export const scheduleConflictPolicyEnum = pgEnum("schedule_conflict_policy", SCHEDULE_CONFLICT_POLICIES);
 
 export const workflowRunStatusEnum = pgEnum("workflow_run_status", WORKFLOW_RUN_STATUSES);
 export const terminalWorkflowRunStatusEnum = pgEnum("terminal_workflow_run_status", TERMINAL_WORKFLOW_RUN_STATUSES);
-export const workflowRunConflictPolicyEnum = pgEnum("workflow_run_conflict_policy", WORKFLOW_RUN_CONFLICT_POLICIES);
 
 export const taskStatusEnum = pgEnum("task_status", TASK_STATUSES);
 
@@ -99,9 +90,8 @@ export const schedule = pgTable(
 		definitionHash: text("definition_hash").notNull(),
 
 		referenceId: text("reference_id"),
-		conflictPolicy: scheduleConflictPolicyEnum("conflict_policy"),
 
-		workflowRunOptions: jsonb("workflow_run_options").$type<ScheduledWorkflowStartOptions>(),
+		workflowRunOptions: jsonb("workflow_run_options").$type<WorkflowRunOptions>(),
 
 		lastOccurrence: timestampMs("last_occurrence"),
 		nextRunAt: timestampMs("next_run_at"),
@@ -142,10 +132,9 @@ export const workflowRun = pgTable(
 
 		input: jsonb("input"),
 		inputHash: text("input_hash").notNull(),
-		options: jsonb("options").$type<WorkflowStartOptions>(),
+		options: jsonb("options").$type<WorkflowRunOptions>(),
 
 		referenceId: text("reference_id"),
-		conflictPolicy: workflowRunConflictPolicyEnum("conflict_policy"),
 
 		latestStateTransitionId: text("latest_state_transition_id").notNull(),
 		scheduledAt: timestampMs("scheduled_at"),

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -5,15 +5,9 @@ import { stableStringify } from "@aikirun/lib/json";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { ScheduleActivateRequestV1, ScheduleListRequestV1 } from "@aikirun/types/api/schedule";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type {
-	Schedule,
-	ScheduleConflictPolicy,
-	ScheduledWorkflowStartOptions,
-	ScheduleId,
-	ScheduleSpec,
-	ScheduleStatus,
-} from "@aikirun/types/schedule";
+import type { Schedule, ScheduleId, ScheduleSpec, ScheduleStatus } from "@aikirun/types/schedule";
 import type { WorkflowName, WorkflowSource, WorkflowVersionId } from "@aikirun/types/workflow";
+import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 import CronExpressionParser from "cron-parser";
 import { ulid } from "ulidx";
 
@@ -174,7 +168,6 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 							workflowRunInputHash,
 							definitionHash,
 							referenceId: undefined,
-							conflictPolicy: options?.reference?.conflictPolicy,
 							workflowRunOptions,
 							nextRunAt,
 						});
@@ -215,7 +208,6 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 					{ id: existingNonReferencedSchedule.id, referenceId: null },
 					{
 						referenceId,
-						conflictPolicy: options?.reference?.conflictPolicy ?? null,
 						status: "active",
 						nextRunAt,
 					}
@@ -233,7 +225,6 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 				workflowRunInputHash,
 				definitionHash,
 				referenceId,
-				conflictPolicy: options?.reference?.conflictPolicy,
 				workflowRunOptions,
 				nextRunAt,
 			});
@@ -353,8 +344,7 @@ async function createSchedule(
 		workflowRunInputHash: string;
 		definitionHash: string;
 		referenceId: string | undefined;
-		conflictPolicy: ScheduleConflictPolicy | undefined | null;
-		workflowRunOptions: ScheduledWorkflowStartOptions | undefined;
+		workflowRunOptions: WorkflowRunOptions | undefined;
 		nextRunAt: TimestampMs;
 	}
 ): Promise<ScheduleRow> {
@@ -373,7 +363,6 @@ async function createSchedule(
 		workflowRunInputHash: params.workflowRunInputHash,
 		definitionHash: params.definitionHash,
 		referenceId: params.referenceId,
-		conflictPolicy: params.conflictPolicy,
 		workflowRunOptions: params.workflowRunOptions,
 		nextRunAt: params.nextRunAt,
 	});
@@ -393,9 +382,7 @@ export function scheduleRowToDomain(
 		status: schedule.status,
 		spec,
 		workflowRunInput: schedule.workflowRunInput,
-		options: schedule.referenceId
-			? { reference: { id: schedule.referenceId, conflictPolicy: schedule.conflictPolicy ?? undefined } }
-			: undefined,
+		referenceId: schedule.referenceId ?? undefined,
 		workflowRunOptions: schedule.workflowRunOptions ?? undefined,
 		createdAt: schedule.createdAt,
 		updatedAt: schedule.updatedAt,

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -479,9 +479,8 @@ async function createWorkflowRunInTx(
 		status: "scheduled",
 		input,
 		inputHash,
-		options,
+		options: options && { retry: options.retry, pool: options.pool },
 		referenceId,
-		conflictPolicy: options?.reference?.conflictPolicy,
 		latestStateTransitionId: transitionId,
 		scheduledAt: scheduledAt as TimestampMs,
 	});
@@ -559,6 +558,7 @@ async function getWorkflowRun(
 		stateTransitionId: runRow.latestStateTransitionId,
 		input: runRow.input,
 		inputHash: runRow.inputHash,
+		referenceId: runRow.referenceId ?? undefined,
 		options: runRow.options !== null ? runRow.options : undefined,
 		attempts: runRow.attempts,
 		state: latestTransition.state as WorkflowRunState,

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -2,14 +2,9 @@ import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
 import type { Client } from "@aikirun/types/client";
-import type {
-	ScheduleActivateOptions,
-	ScheduledWorkflowStartOptions,
-	ScheduleId,
-	ScheduleOverlapPolicy,
-	ScheduleSpec,
-} from "@aikirun/types/schedule";
+import type { ScheduleActivateOptions, ScheduleId, ScheduleOverlapPolicy, ScheduleSpec } from "@aikirun/types/schedule";
 import { INTERNAL } from "@aikirun/types/symbols";
+import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 
 import type { EventsDefinition } from "./run/event";
 import type { WorkflowVersion } from "./workflow-version";
@@ -37,7 +32,7 @@ export interface ScheduleHandle {
 }
 
 type ScheduleBuilderActivateOptions = ScheduleActivateOptions & {
-	workflowRun?: ScheduledWorkflowStartOptions;
+	workflowRun?: WorkflowRunOptions;
 };
 
 export interface ScheduleBuilder {

--- a/types/src/api/schedule.ts
+++ b/types/src/api/schedule.ts
@@ -1,11 +1,6 @@
-import type {
-	Schedule,
-	ScheduleActivateOptions,
-	ScheduledWorkflowStartOptions,
-	ScheduleSpec,
-	ScheduleStatus,
-} from "../schedule";
+import type { Schedule, ScheduleActivateOptions, ScheduleSpec, ScheduleStatus } from "../schedule";
 import type { WorkflowSource } from "../workflow";
+import type { WorkflowRunOptions } from "../workflow/run";
 
 export interface ScheduleApi {
 	activateV1: (_: ScheduleActivateRequestV1) => Promise<ScheduleActivateResponseV1>;
@@ -23,7 +18,7 @@ export interface ScheduleActivateRequestV1 {
 	workflowRunInput?: unknown;
 	spec: ScheduleSpec;
 	options?: ScheduleActivateOptions;
-	workflowRunOptions?: ScheduledWorkflowStartOptions;
+	workflowRunOptions?: WorkflowRunOptions;
 }
 
 export interface ScheduleActivateResponseV1 {

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -1,5 +1,5 @@
 import type { WorkflowSource } from "./workflow";
-import type { WorkflowStartOptions } from "./workflow/run";
+import type { WorkflowRunOptions } from "./workflow/run";
 
 export type ScheduleId = string & { _brand: "schedule_id" };
 
@@ -38,8 +38,6 @@ export interface ScheduleReference {
 	conflictPolicy?: ScheduleConflictPolicy;
 }
 
-export type ScheduledWorkflowStartOptions = Pick<WorkflowStartOptions, "retry" | "pool">;
-
 export interface ScheduleActivateOptions {
 	reference?: ScheduleReference;
 }
@@ -52,8 +50,8 @@ export interface Schedule {
 	status: ScheduleStatus;
 	spec: ScheduleSpec;
 	workflowRunInput?: unknown;
-	options?: ScheduleActivateOptions;
-	workflowRunOptions?: ScheduledWorkflowStartOptions;
+	referenceId?: string;
+	workflowRunOptions?: WorkflowRunOptions;
 	createdAt: number;
 	updatedAt: number;
 	lastOccurrence?: number;

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -52,11 +52,14 @@ export interface WorkflowReference {
 	conflictPolicy?: WorkflowRunConflictPolicy;
 }
 
-export interface WorkflowStartOptions {
+export interface WorkflowRunOptions {
 	retry?: RetryStrategy;
+	pool?: string;
+}
+
+export interface WorkflowStartOptions extends WorkflowRunOptions {
 	trigger?: TriggerStrategy;
 	reference?: WorkflowReference;
-	pool?: string;
 }
 
 export type WorkflowDefinitionStartOptions = Pick<WorkflowStartOptions, "retry">;
@@ -265,7 +268,8 @@ export interface WorkflowRunRecord<Input = unknown, Output = unknown> {
 	stateTransitionId: string;
 	input?: Input;
 	inputHash: string;
-	options?: WorkflowStartOptions;
+	referenceId?: string;
+	options?: WorkflowRunOptions;
 	attempts: number;
 	state: WorkflowRunState<Output>;
 	// TODO:


### PR DESCRIPTION
## Problem

When a run is created, the caller can pass retry, pool, trigger, and reference (with a conflict policy). These are not all the same kind of thing. Retry and pool are read for the rest of the run's life: retries use the retry strategy, dispatch uses the pool. Trigger and reference are instructions for the create call itself: the trigger becomes `scheduledAt`, the reference goes into its own `reference_id` column for duplicate detection, and the conflict policy only tells that one call what to do when the reference already exists.

Still, the whole object was stored as the run's `options`, and the conflict policy also had its own column on both `workflow_run` and `schedule` — a column nothing ever read. Schedules had a related quirk: the API response rebuilt an `options.reference` object from the `reference_id` column, minus the conflict policy, so the response looked like the activation call but was not.

## Solution

The options type is split in two. `WorkflowRunOptions` holds what the run reads after creation; `WorkflowStartOptions` extends it with the create-call instructions:

```ts
interface WorkflowRunOptions {
	retry?: RetryStrategy;
	pool?: string;
}

interface WorkflowStartOptions extends WorkflowRunOptions {
	trigger?: TriggerStrategy;
	reference?: WorkflowReference;
}
```

Create requests still take `WorkflowStartOptions`. The row and the record store only `WorkflowRunOptions`. Run and schedule responses expose the reference as a plain `referenceId` field, read from the column. `ScheduledWorkflowStartOptions` is deleted — schedules store the same `WorkflowRunOptions` for the runs they mint.

## Breaking changes

- `WorkflowRunRecord.options` no longer contains `reference` or `trigger`; the reference is now `record.referenceId`.
- `Schedule.options` is replaced by `Schedule.referenceId`.
- Migration drops both `conflict_policy` columns and removes `reference`/`trigger` from stored run options.