### PR TITLE
Fewer round trips and tenant filters in the run repository

### DIFF
--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -79,7 +79,7 @@ export async function queueChildRunWaitTimedOutRuns(
 
 	const [stateTransitions, workflows] = await Promise.all([
 		repos.stateTransition.getByIds(stateTransitionIds as NonEmptyArray<string>),
-		repos.workflow.getByIdsGlobal(context, workflowIds),
+		repos.workflow.getByIds(context, workflowIds),
 	]);
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
@@ -173,6 +173,7 @@ async function processChunk(
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
 		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			context,
 			"awaiting_child_workflow",
 			workflowRunUpdates
 		);

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -79,7 +79,7 @@ export async function queueEventWaitTimedOutRuns(
 
 	const [stateTransitions, workflows] = await Promise.all([
 		repos.stateTransition.getByIds(stateTransitionIds as NonEmptyArray<string>),
-		repos.workflow.getByIdsGlobal(context, workflowIds),
+		repos.workflow.getByIds(context, workflowIds),
 	]);
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
@@ -172,7 +172,11 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_event", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			context,
+			"awaiting_event",
+			workflowRunUpdates
+		);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -23,7 +23,7 @@ import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workfl
 import { createKeysetStreamCursorAdvancer } from "../lib/keyset-stream";
 import { computeRank } from "../lib/rank";
 import type { DaemonContext } from "../middleware/context";
-import type { CancelledParentRun, ChildRunCanceller } from "../service/cancel-child-runs";
+import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
 import { getDueOccurrences, getNextOccurrence, getReferenceId, scheduleRowToDomain } from "../service/schedule";
 
@@ -416,9 +416,10 @@ async function processOverlapCancelPreviousSchedules(
 		// we should only insert cancellation state transitions if the cancellation occurred, otherwise, we'll have dangling transitions
 
 		// Step 1: Cancel active runs (without setting latestStateTransitionId)
-		const cancelledRunIds = isNonEmptyArray(runIdsToCancel)
-			? await txRepos.workflowRun.bulkTransitionToCancelledGlobal(context, runIdsToCancel)
+		const cancelledRuns = isNonEmptyArray(runIdsToCancel)
+			? await txRepos.workflowRun.bulkTransitionToCancelled(context, runIdsToCancel)
 			: [];
+		const cancelledRunIds = cancelledRuns.map((run) => run.id);
 
 		// Step 2: Discard in-flight tasks and outbox entries for the cancelled runs, then insert
 		// cancel state transitions only for actually cancelled runs and set latestStateTransitionId
@@ -429,8 +430,11 @@ async function processOverlapCancelPreviousSchedules(
 
 			const cancelledRunIdsSet = new Set(cancelledRunIds);
 			const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
-			const cancelledRunStateTransitionIdUpdates: { id: string; stateTransitionId: string }[] = [];
-			const cancelledRuns: CancelledParentRun[] = [];
+			const cancelledRunStateTransitionIdUpdates: {
+				filter: { namespaceId: NamespaceId; id: string };
+				update: { stateTransitionId: string };
+			}[] = [];
+			const cancelledRuns: CancelledRunMeta[] = [];
 
 			for (const run of runsToCancel) {
 				if (!cancelledRunIdsSet.has(run.id)) {
@@ -445,8 +449,11 @@ async function processOverlapCancelPreviousSchedules(
 					attempt: run.attempts,
 					state: { status: "cancelled", reason: "Schedule overlap policy" } satisfies WorkflowRunStateCancelled,
 				});
-				cancelledRunStateTransitionIdUpdates.push({ id: run.id, stateTransitionId });
-				cancelledRuns.push({ namespaceId: run.namespaceId, runId: run.id, pool: run.pool });
+				cancelledRunStateTransitionIdUpdates.push({
+					filter: { namespaceId: run.namespaceId, id: run.id },
+					update: { stateTransitionId },
+				});
+				cancelledRuns.push({ namespaceId: run.namespaceId, id: run.id, pool: run.pool });
 			}
 
 			if (isNonEmptyArray(cancelStateTransitionEntries) && isNonEmptyArray(cancelledRunStateTransitionIdUpdates)) {
@@ -478,7 +485,7 @@ async function fetchActiveRunsBySchedule(
 	repos: ProcessImminentRecurringRunsDeps["repos"],
 	schedules: NonEmptyArray<DueSchedule>
 ) {
-	const workflowAndReferenceIdPairs: { workflowId: string; referenceId: string }[] = [];
+	const workflowAndReferenceIdPairs: { namespaceId: NamespaceId; workflowId: string; referenceId: string }[] = [];
 	const schedulesByWorkflowAndReferenceId = new Map<string, Map<string, DueSchedule>>();
 
 	for (const schedule of schedules) {
@@ -486,7 +493,11 @@ async function fetchActiveRunsBySchedule(
 			continue;
 		}
 		const referenceId = getReferenceId(schedule.id, schedule.lastOccurrence);
-		workflowAndReferenceIdPairs.push({ workflowId: schedule.workflowId, referenceId });
+		workflowAndReferenceIdPairs.push({
+			namespaceId: schedule.namespaceId,
+			workflowId: schedule.workflowId,
+			referenceId,
+		});
 
 		let schedulesByReferenceId = schedulesByWorkflowAndReferenceId.get(schedule.workflowId);
 		if (!schedulesByReferenceId) {

--- a/sdk/server/src/daemon/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-runs.ts
@@ -70,7 +70,7 @@ export async function queueRetryableRuns(
 	const { chunkSize = runs.length } = options ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
-	const workflows = await repos.workflow.getByIdsGlobal(context, workflowIds);
+	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
@@ -140,9 +140,14 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("awaiting_retry", workflowRunUpdates, {
-			incrementAttempts: true,
-		});
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			context,
+			"awaiting_retry",
+			workflowRunUpdates,
+			{
+				incrementAttempts: true,
+			}
+		);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}

--- a/sdk/server/src/daemon/imminent-retryable-tasks.ts
+++ b/sdk/server/src/daemon/imminent-retryable-tasks.ts
@@ -102,7 +102,7 @@ export async function queueRetryableTasks(
 	const { chunkSize = runs.length } = options ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
-	const workflows = await repos.workflow.getByIdsGlobal(context, workflowIds);
+	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
@@ -172,7 +172,7 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("running", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(context, "running", workflowRunUpdates);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}

--- a/sdk/server/src/daemon/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.ts
@@ -75,7 +75,7 @@ export async function queueScheduledRuns(
 
 	const [stateTransitions, workflows] = await Promise.all([
 		repos.stateTransition.getByIds(stateTransitionIds as NonEmptyArray<string>),
-		repos.workflow.getByIdsGlobal(context, workflowIds),
+		repos.workflow.getByIds(context, workflowIds),
 	]);
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
@@ -156,7 +156,11 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("scheduled", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			context,
+			"scheduled",
+			workflowRunUpdates
+		);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}

--- a/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
@@ -68,7 +68,7 @@ export async function queueSleepElapsedRuns(
 	const { chunkSize = runs.length } = options ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
-	const workflows = await repos.workflow.getByIdsGlobal(context, workflowIds);
+	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
 	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
@@ -139,7 +139,11 @@ async function processChunk(
 	}
 
 	const insertedOutboxEntries: WorkflowRunOutboxRowInsertPending[] = await repos.transaction(async (txRepos) => {
-		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued("sleeping", workflowRunUpdates);
+		const transitionedRunIds = await txRepos.workflowRun.bulkTransitionToQueued(
+			context,
+			"sleeping",
+			workflowRunUpdates
+		);
 		if (!isNonEmptyArray(transitionedRunIds)) {
 			return [];
 		}

--- a/sdk/server/src/daemon/recover-overdue-outbox-entries.integration.test.ts
+++ b/sdk/server/src/daemon/recover-overdue-outbox-entries.integration.test.ts
@@ -104,11 +104,16 @@ describe("recoverOverdueOutboxEntries", () => {
 					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
 				);
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
 				expect(run).toEqual(
 					expect.objectContaining({
-						id: runId,
-						status: "queued",
+						run: expect.objectContaining({
+							id: runId,
+							status: "queued",
+						}),
 						state: { status: "queued", reason: "recovery" },
 					})
 				);
@@ -130,9 +135,12 @@ describe("recoverOverdueOutboxEntries", () => {
 					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
 				);
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
-				expect(run).toEqual(expect.objectContaining({ id: runId, status: "queued" }));
-				expect(run?.revision).toBeGreaterThan(revisionWhenClaimed);
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
+				expect(run).toEqual(expect.objectContaining({ run: expect.objectContaining({ id: runId, status: "queued" }) }));
+				expect(run?.run.revision).toBeGreaterThan(revisionWhenClaimed);
 			}));
 
 		test("charges no execution attempt for the lost claim", () =>
@@ -151,8 +159,13 @@ describe("recoverOverdueOutboxEntries", () => {
 					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
 				);
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
-				expect(run).toEqual(expect.objectContaining({ id: runId, attempts: attemptsWhenClaimed }));
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
+				expect(run).toEqual(
+					expect.objectContaining({ run: expect.objectContaining({ id: runId, attempts: attemptsWhenClaimed }) })
+				);
 			}));
 
 		test("leaves a fresh claim untouched", () =>
@@ -256,11 +269,16 @@ describe("recoverOverdueOutboxEntries", () => {
 
 				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
 				expect(run).toEqual(
 					expect.objectContaining({
-						id: runId,
-						status: "stalled",
+						run: expect.objectContaining({
+							id: runId,
+							status: "stalled",
+						}),
 					})
 				);
 				expect(await repos.workflowRunOutbox.listPending(context, 100)).toHaveLength(0);
@@ -280,11 +298,16 @@ describe("recoverOverdueOutboxEntries", () => {
 
 				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
 				expect(run).toEqual(
 					expect.objectContaining({
-						id: runId,
-						status: "stalled",
+						run: expect.objectContaining({
+							id: runId,
+							status: "stalled",
+						}),
 					})
 				);
 				expect(await repos.workflowRunOutbox.listPublishable(context, 100)).toHaveLength(0);
@@ -305,11 +328,16 @@ describe("recoverOverdueOutboxEntries", () => {
 
 				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
 
-				const run = await repos.workflowRun.getByIdWithState(namespaceRequestContext.namespaceId, runId);
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
 				expect(run).toEqual(
 					expect.objectContaining({
-						id: runId,
-						status: "running",
+						run: expect.objectContaining({
+							id: runId,
+							status: "running",
+						}),
 					})
 				);
 				const claimedRows = await repos.workflowRunOutbox.listStaleClaimed(context, {

--- a/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
+++ b/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
@@ -1,6 +1,7 @@
 import { streamChunks } from "@aikirun/lib/async";
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
@@ -52,11 +53,14 @@ export async function recoverOverdueOutboxEntries(
 		}
 
 		await repos.transaction(async (txRepos) => {
-			const releasedRuns = await txRepos.workflowRun.bulkReleaseToQueued(runIds);
+			const releasedRuns = await txRepos.workflowRun.bulkReleaseToQueued(context, runIds);
 
 			if (isNonEmptyArray(releasedRuns)) {
 				const stateTransitionEntries: StateTransitionRowInsert[] = [];
-				const stateTransitionUpdates: { id: string; stateTransitionId: string }[] = [];
+				const stateTransitionUpdates: {
+					filter: { namespaceId: NamespaceId; id: string };
+					update: { stateTransitionId: string };
+				}[] = [];
 
 				for (const run of releasedRuns) {
 					const stateTransitionId = ulid();
@@ -68,7 +72,10 @@ export async function recoverOverdueOutboxEntries(
 						attempt: run.attempts,
 						state: { status: "queued", reason: "recovery" } satisfies WorkflowRunStateQueued,
 					});
-					stateTransitionUpdates.push({ id: run.id, stateTransitionId });
+					stateTransitionUpdates.push({
+						filter: { namespaceId: run.namespaceId as NamespaceId, id: run.id },
+						update: { stateTransitionId },
+					});
 				}
 
 				if (isNonEmptyArray(stateTransitionEntries) && isNonEmptyArray(stateTransitionUpdates)) {

--- a/sdk/server/src/daemon/stall-undeliverable-runs.ts
+++ b/sdk/server/src/daemon/stall-undeliverable-runs.ts
@@ -1,5 +1,6 @@
 import { streamChunks } from "@aikirun/lib/async";
 import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStateStalled } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
@@ -39,19 +40,21 @@ export async function stallUndeliverableRuns(
 
 export async function stallByRunIds(context: DaemonContext, repos: Repos, runIds: NonEmptyArray<string>) {
 	return repos.transaction(async (txRepos) => {
-		const stalledRunIds = await txRepos.workflowRun.bulkTransitionToStalled(runIds);
-		if (!isNonEmptyArray(stalledRunIds)) {
+		const stalledRuns = await txRepos.workflowRun.bulkTransitionToStalled(context, runIds);
+		if (!isNonEmptyArray(stalledRuns)) {
 			return [];
 		}
+		const stalledRunIds = stalledRuns.map((run) => run.id) as NonEmptyArray<string>;
 
 		await discardStaleTasks(stalledRunIds, ["running", "awaiting_retry"], txRepos);
 
 		await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(stalledRunIds);
 
-		const stalledRuns = await txRepos.workflowRun.getByIdsGlobal(context, stalledRunIds);
-
 		const stallStateTransitionEntries: StateTransitionRowInsert[] = [];
-		const stalledRunStateTransitionUpdates: { id: string; stateTransitionId: string }[] = [];
+		const stalledRunStateTransitionUpdates: {
+			filter: { namespaceId: NamespaceId; id: string };
+			update: { stateTransitionId: string };
+		}[] = [];
 
 		for (const run of stalledRuns) {
 			const stateTransitionId = ulid();
@@ -63,7 +66,10 @@ export async function stallByRunIds(context: DaemonContext, repos: Repos, runIds
 				attempt: run.attempts,
 				state: { status: "stalled" } satisfies WorkflowRunStateStalled,
 			});
-			stalledRunStateTransitionUpdates.push({ id: run.id, stateTransitionId });
+			stalledRunStateTransitionUpdates.push({
+				filter: { namespaceId: run.namespaceId as NamespaceId, id: run.id },
+				update: { stateTransitionId },
+			});
 		}
 
 		if (isNonEmptyArray(stallStateTransitionEntries) && isNonEmptyArray(stalledRunStateTransitionUpdates)) {

--- a/sdk/server/src/infra/db/pg/migration/0021_bumpy_songbird.sql
+++ b/sdk/server/src/infra/db/pg/migration/0021_bumpy_songbird.sql
@@ -1,0 +1,2 @@
+DROP INDEX "idx_workflow_run_schedule";--> statement-breakpoint
+CREATE INDEX "idx_workflow_run_schedule_namespace" ON "workflow_run" USING btree ("schedule_id","namespace_id");

--- a/sdk/server/src/infra/db/pg/migration/meta/0021_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0021_snapshot.json
@@ -1,0 +1,1768 @@
+{
+	"id": "d54554fd-a838-4651-a3bf-3a435783fc2c",
+	"prevId": "9b5c49cf-acf3-4405-b284-defa203a12df",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR \"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_id": {
+					"name": "idx_event_wait_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1786719233638,
 			"tag": "0020_flowery_scarecrow",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1786738190034,
+			"tag": "0021_bumpy_songbird",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/child-workflow-run-wait.ts
+++ b/sdk/server/src/infra/db/pg/repository/child-workflow-run-wait.ts
@@ -1,7 +1,8 @@
-import { eq } from "drizzle-orm";
+import { eq, getTableColumns } from "drizzle-orm";
 
+import { toWorkflowRunState } from "./state-transition";
 import type { PgDb } from "../provider";
-import { childWorkflowRunWait } from "../schema";
+import { childWorkflowRunWait, stateTransition } from "../schema";
 
 export type ChildWorkflowRunWaitRow = typeof childWorkflowRunWait.$inferSelect;
 export type ChildWorkflowRunWaitRowInsert = typeof childWorkflowRunWait.$inferInsert;
@@ -12,14 +13,23 @@ export const createChildWorkflowRunWaitRepository = (db: PgDb) => ({
 		await db.insert(childWorkflowRunWait).values(values);
 	},
 
-	async listByParentRunId(parentRunId: string): Promise<ChildWorkflowRunWaitRow[]> {
+	async listByParentRunIdWithChildState(parentRunId: string) {
 		// TODO: explore loading in chunks
-		return db
-			.select()
+		const rows = await db
+			.select({
+				...getTableColumns(childWorkflowRunWait),
+				childWorkflowRunState: stateTransition.state,
+			})
 			.from(childWorkflowRunWait)
+			.leftJoin(stateTransition, eq(childWorkflowRunWait.childWorkflowRunStateTransitionId, stateTransition.id))
 			.where(eq(childWorkflowRunWait.parentWorkflowRunId, parentRunId))
 			.orderBy(childWorkflowRunWait.id)
 			.limit(10_000);
+
+		return rows.map((row) => ({
+			...row,
+			childWorkflowRunState: row.childWorkflowRunState !== null ? toWorkflowRunState(row.childWorkflowRunState) : null,
+		}));
 	},
 });
 

--- a/sdk/server/src/infra/db/pg/repository/task.ts
+++ b/sdk/server/src/infra/db/pg/repository/task.ts
@@ -2,9 +2,10 @@ import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { TaskStatus } from "@aikirun/types/workflow/task";
-import { and, eq, inArray, lte, min, ne, sql } from "drizzle-orm";
+import { and, count, eq, inArray, lte, min, ne, sql } from "drizzle-orm";
 
 import { keysetStreamCursorFilter } from "./lib/keyset-stream";
+import { toTaskState } from "./state-transition";
 import type { KeysetStreamCursor } from "../../../../lib/keyset-stream";
 import type { DaemonContext } from "../../../../middleware/context";
 import type { PgDb } from "../provider";
@@ -72,14 +73,22 @@ export const createTaskRepository = (db: PgDb) => ({
 		return result[0] ?? null;
 	},
 
-	async listByWorkflowRunId(workflowRunId: string): Promise<TaskRow[]> {
+	async listByWorkflowRunIdWithState(workflowRunId: string) {
 		// TODO: explore loading in chunks
-		return db
-			.select()
+		const rows = await db
+			.select({
+				id: task.id,
+				name: task.name,
+				inputHash: task.inputHash,
+				state: stateTransition.state,
+			})
 			.from(task)
+			.innerJoin(stateTransition, eq(task.latestStateTransitionId, stateTransition.id))
 			.where(and(eq(task.workflowRunId, workflowRunId), ne(task.status, "discarded")))
 			.orderBy(task.id)
 			.limit(10_000);
+
+		return rows.map((row) => ({ ...row, state: toTaskState(row.state) }));
 	},
 
 	async listRetryableTasks(_context: DaemonContext, before: TimestampMs, limit: number, cursor?: KeysetStreamCursor) {
@@ -107,6 +116,29 @@ export const createTaskRepository = (db: PgDb) => ({
 			.select({ id: task.id, workflowRunId: task.workflowRunId, attempts: task.attempts, status: task.status })
 			.from(task)
 			.where(and(runIdsFilter, inArray(task.status, statuses)));
+	},
+
+	async countByWorkflowRunIds(workflowRunIds: NonEmptyArray<string>): Promise<Map<string, Record<TaskStatus, number>>> {
+		const rows = await db
+			.select({
+				workflowRunId: task.workflowRunId,
+				status: task.status,
+				count: count(),
+			})
+			.from(task)
+			.where(inArray(task.workflowRunId, workflowRunIds))
+			.groupBy(task.workflowRunId, task.status);
+
+		const result = new Map<string, Record<TaskStatus, number>>();
+		for (const row of rows) {
+			let taskCounts = result.get(row.workflowRunId);
+			if (!taskCounts) {
+				taskCounts = { completed: 0, running: 0, failed: 0, awaiting_retry: 0, discarded: 0 };
+				result.set(row.workflowRunId, taskCounts);
+			}
+			taskCounts[row.status] = row.count;
+		}
+		return result;
 	},
 
 	async bulkDiscard(

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -1,14 +1,9 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type {
-	WorkflowRunId,
-	WorkflowRunState,
-	WorkflowRunStatus,
-	WorkflowStartOptions,
-} from "@aikirun/types/workflow/run";
+import type { WorkflowSource } from "@aikirun/types/workflow";
+import type { WorkflowRunId, WorkflowRunOptions, WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import { NON_TERMINAL_WORKFLOW_RUN_STATUSES } from "@aikirun/types/workflow/run";
-import type { TaskStatus } from "@aikirun/types/workflow/task";
 import { and, count, eq, inArray, lte, or, sql } from "drizzle-orm";
 
 import { keysetStreamCursorFilter } from "./lib/keyset-stream";
@@ -16,7 +11,7 @@ import { toWorkflowRunState } from "./state-transition";
 import type { KeysetStreamCursor } from "../../../../lib/keyset-stream";
 import type { DaemonContext } from "../../../../middleware/context";
 import type { PgDb } from "../provider";
-import { stateTransition, task, workflow, workflowRun } from "../schema";
+import { stateTransition, workflow, workflowRun } from "../schema";
 
 export type WorkflowRunRow = typeof workflowRun.$inferSelect;
 export type WorkflowRunRowInsert = typeof workflowRun.$inferInsert;
@@ -33,7 +28,7 @@ export interface WorkflowRunMeta {
 	workflowId: string;
 	revision: number;
 	attempts: number;
-	options: WorkflowStartOptions | null;
+	options: WorkflowRunOptions | null;
 	latestStateTransitionId: string;
 }
 
@@ -48,10 +43,10 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 	},
 
 	async update(
-		filter: { id: WorkflowRunId; revision?: number },
+		filter: { namespaceId: NamespaceId; id: WorkflowRunId; revision?: number },
 		updates: WorkflowRunRowUpdate
 	): Promise<{ revision: number } | undefined> {
-		const conditions = [eq(workflowRun.id, filter.id)];
+		const conditions = [eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)];
 		if (filter.revision !== undefined) {
 			conditions.push(eq(workflowRun.revision, filter.revision));
 		}
@@ -85,46 +80,39 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 	},
 
 	async getById(
-		namespaceId: NamespaceId,
-		id: string,
+		filter: {
+			namespaceId: NamespaceId;
+			id: string;
+		},
 		options?: { forUpdate?: boolean }
-	): Promise<WorkflowRunRow | null> {
+	) {
 		const query = db
-			.select()
+			.select({ id: workflowRun.id, revision: workflowRun.revision })
 			.from(workflowRun)
-			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
+			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
 			.limit(1);
 
 		const result = options?.forUpdate ? await query.for("update") : await query;
 		return result[0] ?? null;
 	},
 
-	async getByIds(namespaceId: NamespaceId, ids: NonEmptyArray<string>): Promise<WorkflowRunRow[]> {
-		return db
-			.select()
-			.from(workflowRun)
-			.where(and(eq(workflowRun.namespaceId, namespaceId), inArray(workflowRun.id, ids)));
-	},
-
-	async getByIdsGlobal(_context: DaemonContext, ids: NonEmptyArray<string>): Promise<WorkflowRunRow[]> {
-		return db.select().from(workflowRun).where(inArray(workflowRun.id, ids));
-	},
-
-	async getByIdWithState(namespaceId: NamespaceId, id: string, options?: { forUpdate?: boolean }) {
+	async getByIdWithState(filter: { namespaceId: NamespaceId; id: string }, options?: { forUpdate?: boolean }) {
 		const query = db
 			.select({
-				id: workflowRun.id,
-				status: workflowRun.status,
-				revision: workflowRun.revision,
-				attempts: workflowRun.attempts,
-				latestStateTransitionId: workflowRun.latestStateTransitionId,
-				parentWorkflowRunId: workflowRun.parentWorkflowRunId,
-				options: workflowRun.options,
+				run: {
+					id: workflowRun.id,
+					status: workflowRun.status,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
+					options: workflowRun.options,
+				},
 				state: stateTransition.state,
 			})
 			.from(workflowRun)
 			.innerJoin(stateTransition, eq(workflowRun.latestStateTransitionId, stateTransition.id))
-			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.id, id)))
+			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
 			.limit(1);
 
 		const result = options?.forUpdate ? await query.for("update", { of: workflowRun }) : await query;
@@ -132,8 +120,85 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		if (!row) {
 			return null;
 		}
-		(row as Record<string, unknown>).state = toWorkflowRunState(row.state);
-		return row as Omit<typeof row, "state"> & { state: WorkflowRunState };
+		return { ...row, state: toWorkflowRunState(row.state) };
+	},
+
+	async getByIdWithWorkflowAndState(filter: { namespaceId: NamespaceId; id: string }) {
+		const result = await db
+			.select({
+				run: {
+					id: workflowRun.id,
+					createdAt: workflowRun.createdAt,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					input: workflowRun.input,
+					inputHash: workflowRun.inputHash,
+					referenceId: workflowRun.referenceId,
+					options: workflowRun.options,
+					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
+					scheduleId: workflowRun.scheduleId,
+				},
+				workflow: { name: workflow.name, versionId: workflow.versionId, source: workflow.source },
+				state: stateTransition.state,
+			})
+			.from(workflowRun)
+			.innerJoin(workflow, eq(workflowRun.workflowId, workflow.id))
+			.innerJoin(stateTransition, eq(workflowRun.latestStateTransitionId, stateTransition.id))
+			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
+			.limit(1);
+
+		const row = result[0];
+		if (!row) {
+			return null;
+		}
+		return { ...row, state: toWorkflowRunState(row.state) };
+	},
+
+	async getByReferenceWithWorkflowAndState(filter: {
+		namespaceId: NamespaceId;
+		name: string;
+		versionId: string;
+		source: WorkflowSource;
+		referenceId: string;
+	}) {
+		const result = await db
+			.select({
+				run: {
+					id: workflowRun.id,
+					createdAt: workflowRun.createdAt,
+					revision: workflowRun.revision,
+					attempts: workflowRun.attempts,
+					latestStateTransitionId: workflowRun.latestStateTransitionId,
+					input: workflowRun.input,
+					inputHash: workflowRun.inputHash,
+					referenceId: workflowRun.referenceId,
+					options: workflowRun.options,
+					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
+					scheduleId: workflowRun.scheduleId,
+				},
+				workflow: { name: workflow.name, versionId: workflow.versionId, source: workflow.source },
+				state: stateTransition.state,
+			})
+			.from(workflowRun)
+			.innerJoin(workflow, eq(workflowRun.workflowId, workflow.id))
+			.innerJoin(stateTransition, eq(workflowRun.latestStateTransitionId, stateTransition.id))
+			.where(
+				and(
+					eq(workflow.namespaceId, filter.namespaceId),
+					eq(workflow.name, filter.name),
+					eq(workflow.versionId, filter.versionId),
+					eq(workflow.source, filter.source),
+					eq(workflowRun.referenceId, filter.referenceId)
+				)
+			)
+			.limit(1);
+
+		const row = result[0];
+		if (!row) {
+			return null;
+		}
+		return { ...row, state: toWorkflowRunState(row.state) };
 	},
 
 	async listByIdsAndStatus(_context: DaemonContext, ids: NonEmptyArray<string>, status: WorkflowRunStatus) {
@@ -151,27 +216,50 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.where(and(inArray(workflowRun.id, ids), eq(workflowRun.status, status)));
 	},
 
-	async getChildRuns(filter: {
-		parentRunId: string;
-		status?: NonEmptyArray<WorkflowRunStatus>;
-	}): Promise<WorkflowRunRow[]> {
+	async getChildRuns(filter: { namespaceId: NamespaceId; id: string; status?: NonEmptyArray<WorkflowRunStatus> }) {
 		// TODO: explore loading in chunks
-
-		const conditions = [eq(workflowRun.parentWorkflowRunId, filter.parentRunId)];
+		const conditions = [
+			eq(workflowRun.namespaceId, filter.namespaceId),
+			eq(workflowRun.parentWorkflowRunId, filter.id),
+		];
 		if (filter.status) {
 			conditions.push(inArray(workflowRun.status, filter.status));
 		}
 
-		const whereClause = and(...conditions);
+		return db
+			.select({ id: workflowRun.id, options: workflowRun.options })
+			.from(workflowRun)
+			.where(and(...conditions))
+			.limit(10_000);
+	},
 
-		return db.select().from(workflowRun).where(whereClause).limit(10_000);
+	async getChildRunsWithWorkflow(filter: { namespaceId: NamespaceId; id: string }) {
+		// TODO: explore loading in chunks
+		return db
+			.select({
+				run: {
+					id: workflowRun.id,
+					inputHash: workflowRun.inputHash,
+					referenceId: workflowRun.referenceId,
+				},
+				workflow: { name: workflow.name, versionId: workflow.versionId },
+			})
+			.from(workflowRun)
+			.innerJoin(workflow, eq(workflowRun.workflowId, workflow.id))
+			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.parentWorkflowRunId, filter.id)))
+			.limit(10_000);
 	},
 
 	async hasChildRuns(
-		parentRunIds: NonEmptyArray<string>,
+		runs: NonEmptyArray<{ id: string }>,
 		childRunStatus?: NonEmptyArray<WorkflowRunStatus>
 	): Promise<Set<string>> {
-		const conditions = [inArray(workflowRun.parentWorkflowRunId, parentRunIds)];
+		const conditions = [
+			inArray(
+				workflowRun.parentWorkflowRunId,
+				runs.map((run) => run.id)
+			),
+		];
 		if (childRunStatus) {
 			conditions.push(inArray(workflowRun.status, childRunStatus));
 		}
@@ -191,33 +279,52 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result;
 	},
 
-	async getByWorkflowAndReferenceId(workflowId: string, referenceId: string): Promise<WorkflowRunRow | null> {
+	async getByWorkflowAndReferenceId(filter: { namespaceId: NamespaceId; workflowId: string; referenceId: string }) {
 		const result = await db
-			.select()
+			.select({ id: workflowRun.id, inputHash: workflowRun.inputHash })
 			.from(workflowRun)
-			.where(and(eq(workflowRun.workflowId, workflowId), eq(workflowRun.referenceId, referenceId)))
+			.where(
+				and(
+					eq(workflowRun.namespaceId, filter.namespaceId),
+					eq(workflowRun.workflowId, filter.workflowId),
+					eq(workflowRun.referenceId, filter.referenceId)
+				)
+			)
 			.limit(1);
 		return result[0] ?? null;
 	},
 
 	async listByWorkflowAndReferenceIdPairs(filter: {
-		pairs: NonEmptyArray<{ workflowId: string; referenceId: string }>;
+		pairs: NonEmptyArray<{ namespaceId: NamespaceId; workflowId: string; referenceId: string }>;
 		status?: NonEmptyArray<WorkflowRunStatus>;
-	}): Promise<WorkflowRunRow[]> {
+	}) {
 		const pairConditions = or(
-			...filter.pairs.map(({ workflowId, referenceId }) =>
-				and(eq(workflowRun.workflowId, workflowId), eq(workflowRun.referenceId, referenceId))
+			...filter.pairs.map(({ namespaceId, workflowId, referenceId }) =>
+				and(
+					eq(workflowRun.namespaceId, namespaceId),
+					eq(workflowRun.workflowId, workflowId),
+					eq(workflowRun.referenceId, referenceId)
+				)
 			)
 		);
 		const conditions = filter.status ? and(pairConditions, inArray(workflowRun.status, filter.status)) : pairConditions;
 
-		return db.select().from(workflowRun).where(conditions);
+		return db
+			.select({
+				id: workflowRun.id,
+				workflowId: workflowRun.workflowId,
+				referenceId: workflowRun.referenceId,
+				attempts: workflowRun.attempts,
+				options: workflowRun.options,
+			})
+			.from(workflowRun)
+			.where(conditions);
 	},
 
 	// TODO: remove offset based pagination
 	async listByFilters(
-		namespaceId: NamespaceId,
 		filter: {
+			namespaceId: NamespaceId;
 			id?: string;
 			scheduleId?: string;
 			status?: NonEmptyArray<WorkflowRunStatus>;
@@ -230,7 +337,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		offset: number,
 		sort: { order: "asc" | "desc" }
 	) {
-		const conditions = [eq(workflowRun.namespaceId, namespaceId)];
+		const conditions = [eq(workflowRun.namespaceId, filter.namespaceId)];
 		if (filter.id) {
 			conditions.push(eq(workflowRun.id, filter.id));
 		}
@@ -270,29 +377,6 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		]);
 
 		return { rows, total: countResult[0]?.count ?? 0 };
-	},
-
-	async getTaskCountsByRunIds(runIds: NonEmptyArray<string>): Promise<Map<string, Record<TaskStatus, number>>> {
-		const rows = await db
-			.select({
-				workflowRunId: task.workflowRunId,
-				status: task.status,
-				count: count(),
-			})
-			.from(task)
-			.where(inArray(task.workflowRunId, runIds))
-			.groupBy(task.workflowRunId, task.status);
-
-		const result = new Map<string, Record<TaskStatus, number>>();
-		for (const row of rows) {
-			let taskCounts = result.get(row.workflowRunId);
-			if (!taskCounts) {
-				taskCounts = { completed: 0, running: 0, failed: 0, awaiting_retry: 0, discarded: 0 };
-				result.set(row.workflowRunId, taskCounts);
-			}
-			taskCounts[row.status] = row.count;
-		}
-		return result;
 	},
 
 	async countByStatus(
@@ -459,6 +543,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 	},
 
 	async bulkTransitionToQueued(
+		_context: DaemonContext,
 		fromStatus: "scheduled" | "sleeping" | "awaiting_retry" | "awaiting_event" | "awaiting_child_workflow" | "running",
 		runs: NonEmptyArray<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }>,
 		options?: { incrementAttempts?: boolean }
@@ -495,7 +580,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result.map((row) => row.id);
 	},
 
-	async bulkTransitionToCancelled(namespaceId: NamespaceId, runIds: NonEmptyArray<string>): Promise<string[]> {
+	async bulkTransitionToCancelledInNamespace(namespaceId: NamespaceId, runIds: NonEmptyArray<string>) {
 		const result = await db
 			.update(workflowRun)
 			.set({
@@ -513,12 +598,12 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 					inArray(workflowRun.status, NON_TERMINAL_WORKFLOW_RUN_STATUSES)
 				)
 			)
-			.returning({ id: workflowRun.id });
+			.returning({ id: workflowRun.id, attempts: workflowRun.attempts, options: workflowRun.options });
 
-		return result.map((row) => row.id);
+		return result;
 	},
 
-	async bulkTransitionToCancelledGlobal(_context: DaemonContext, runIds: NonEmptyArray<string>): Promise<string[]> {
+	async bulkTransitionToCancelled(_context: DaemonContext, runIds: NonEmptyArray<string>) {
 		const result = await db
 			.update(workflowRun)
 			.set({
@@ -530,12 +615,17 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				nextAttemptAt: null,
 			})
 			.where(and(inArray(workflowRun.id, runIds), inArray(workflowRun.status, NON_TERMINAL_WORKFLOW_RUN_STATUSES)))
-			.returning({ id: workflowRun.id });
+			.returning({
+				id: workflowRun.id,
+				namespaceId: workflowRun.namespaceId,
+				attempts: workflowRun.attempts,
+				options: workflowRun.options,
+			});
 
-		return result.map((row) => row.id);
+		return result;
 	},
 
-	async bulkTransitionToStalled(runIds: NonEmptyArray<string>): Promise<string[]> {
+	async bulkTransitionToStalled(_context: DaemonContext, runIds: NonEmptyArray<string>) {
 		const result = await db
 			.update(workflowRun)
 			.set({
@@ -547,12 +637,12 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				nextAttemptAt: null,
 			})
 			.where(and(inArray(workflowRun.id, runIds), eq(workflowRun.status, "queued")))
-			.returning({ id: workflowRun.id });
+			.returning({ id: workflowRun.id, namespaceId: workflowRun.namespaceId, attempts: workflowRun.attempts });
 
-		return result.map((row) => row.id);
+		return result;
 	},
 
-	async bulkReleaseToQueued(runIds: NonEmptyArray<string>): Promise<{ id: string; attempts: number }[]> {
+	async bulkReleaseToQueued(_context: DaemonContext, runIds: NonEmptyArray<string>) {
 		const result = await db
 			.update(workflowRun)
 			.set({
@@ -564,7 +654,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				nextAttemptAt: null,
 			})
 			.where(and(inArray(workflowRun.id, runIds), eq(workflowRun.status, "running")))
-			.returning({ id: workflowRun.id, attempts: workflowRun.attempts });
+			.returning({ id: workflowRun.id, namespaceId: workflowRun.namespaceId, attempts: workflowRun.attempts });
 
 		return result;
 	},
@@ -572,12 +662,14 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 	// Sets the pointer for whatever run ids it is given, with no guard of its own.
 	// Call it in the same transaction as the guarded bulk transition that returned these ids:
 	// that transition's row locks keep the runs unchanged until this write commits with it.
-	async bulkSetLatestStateTransitionId(runs: NonEmptyArray<{ id: string; stateTransitionId: string }>): Promise<void> {
-		const valueRows = runs.map((run, index) => {
+	async bulkSetLatestStateTransitionId(
+		runs: NonEmptyArray<{ filter: { namespaceId: NamespaceId; id: string }; update: { stateTransitionId: string } }>
+	): Promise<void> {
+		const valueRows = runs.map(({ filter, update }, index) => {
 			if (index === 0) {
-				return sql`(${run.id}::text, ${run.stateTransitionId}::text)`;
+				return sql`(${filter.namespaceId}::text, ${filter.id}::text, ${update.stateTransitionId}::text)`;
 			}
-			return sql`(${run.id}, ${run.stateTransitionId})`;
+			return sql`(${filter.namespaceId}, ${filter.id}, ${update.stateTransitionId})`;
 		});
 
 		await db
@@ -585,20 +677,23 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.set({
 				latestStateTransitionId: sql`v.state_transition_id`,
 			})
-			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(id, state_transition_id)`)
-			.where(sql`${workflowRun.id} = v.id`);
+			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(namespace_id, id, state_transition_id)`)
+			.where(sql`${workflowRun.namespaceId} = v.namespace_id AND ${workflowRun.id} = v.id`);
 	},
 
-	async getRunCount(scheduleId: string): Promise<number> {
-		const result = await db.select({ count: count() }).from(workflowRun).where(eq(workflowRun.scheduleId, scheduleId));
+	async getRunCount(namespaceId: NamespaceId, scheduleId: string): Promise<number> {
+		const result = await db
+			.select({ count: count() })
+			.from(workflowRun)
+			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(workflowRun.scheduleId, scheduleId)));
 		return result[0]?.count ?? 0;
 	},
 
-	async getRunCounts(scheduleIds: NonEmptyArray<string>): Promise<Map<string, number>> {
+	async getRunCounts(namespaceId: NamespaceId, scheduleIds: NonEmptyArray<string>): Promise<Map<string, number>> {
 		const rows = await db
 			.select({ scheduleId: workflowRun.scheduleId, count: count() })
 			.from(workflowRun)
-			.where(inArray(workflowRun.scheduleId, scheduleIds))
+			.where(and(eq(workflowRun.namespaceId, namespaceId), inArray(workflowRun.scheduleId, scheduleIds)))
 			.groupBy(workflowRun.scheduleId);
 
 		const map = new Map<string, number>();

--- a/sdk/server/src/infra/db/pg/repository/workflow.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow.ts
@@ -23,14 +23,7 @@ export const createWorkflowRepository = (db: PgDb) => ({
 		return result[0] ?? null;
 	},
 
-	async getByIds(namespaceId: NamespaceId, ids: NonEmptyArray<string>): Promise<WorkflowRow[]> {
-		return db
-			.select()
-			.from(workflow)
-			.where(and(eq(workflow.namespaceId, namespaceId), inArray(workflow.id, ids)));
-	},
-
-	async getByIdsGlobal(_context: DaemonContext, ids: NonEmptyArray<string>): Promise<WorkflowRow[]> {
+	async getByIds(_context: DaemonContext, ids: NonEmptyArray<string>): Promise<WorkflowRow[]> {
 		return db.select().from(workflow).where(inArray(workflow.id, ids));
 	},
 

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -170,7 +170,7 @@ export const workflowRun = pgTable(
 		index("idx_workflow_run_workflow_id").on(table.workflowId, table.id),
 		index("idx_workflow_run_workflow_status_id").on(table.workflowId, table.status, table.id),
 
-		index("idx_workflow_run_schedule").on(table.scheduleId),
+		index("idx_workflow_run_schedule_namespace").on(table.scheduleId, table.namespaceId),
 		index("idx_workflow_run_parent_workflow_run_status").on(table.parentWorkflowRunId, table.status),
 
 		// TODO: will adding an index on input hash make conflict resolution faster?

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -17,15 +17,15 @@ import type { StateTransitionRowInsert } from "../infra/db/types/state-transitio
 import type { WorkflowRowInsert } from "../infra/db/types/workflow";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
 
-export interface CancelledParentRun {
+export interface CancelledRunMeta {
 	namespaceId: NamespaceId;
-	runId: string;
+	id: string;
 	pool: string | undefined;
 }
 
 export const createChildRunCanceller = () => ({
 	async cancel(
-		parentRuns: NonEmptyArray<CancelledParentRun>,
+		runs: NonEmptyArray<CancelledRunMeta>,
 		repos: Pick<Repositories, "workflowRun" | "workflow" | "stateTransition">,
 		logger: Logger
 	): Promise<void> {
@@ -33,27 +33,23 @@ export const createChildRunCanceller = () => ({
 			return;
 		}
 
-		const parentRunIds = parentRuns.map((r) => r.runId);
-		const parentRunIdsHavingChildren = await repos.workflowRun.hasChildRuns(
-			parentRunIds as NonEmptyArray<string>,
-			NON_TERMINAL_WORKFLOW_RUN_STATUSES
-		);
-		if (parentRunIdsHavingChildren.size === 0) {
+		const runIdsHavingChildren = await repos.workflowRun.hasChildRuns(runs, NON_TERMINAL_WORKFLOW_RUN_STATUSES);
+		if (runIdsHavingChildren.size === 0) {
 			return;
 		}
 
-		const parentRunsHavingChildren = parentRuns.filter((r) => parentRunIdsHavingChildren.has(r.runId));
-		if (!isNonEmptyArray(parentRunsHavingChildren)) {
+		const runsHavingChildren = runs.filter((run) => runIdsHavingChildren.has(run.id));
+		if (!isNonEmptyArray(runsHavingChildren)) {
 			return;
 		}
 
-		logger.info("Scheduling cancel-child-runs workflows", { "aiki.parentRunIds": parentRunIdsHavingChildren });
+		logger.info("Scheduling cancel-child-runs workflows", { "aiki.parentRunIds": runIdsHavingChildren });
 
 		const workflowEntries: WorkflowRowInsert[] = [];
 		const inputHashPromises: Array<Promise<string>> = [];
 		const seenNamespaceIds = new Set<NamespaceId>();
 
-		for (const { namespaceId, runId } of parentRunsHavingChildren) {
+		for (const { namespaceId, id: runId } of runsHavingChildren) {
 			if (!seenNamespaceIds.has(namespaceId)) {
 				seenNamespaceIds.add(namespaceId);
 				workflowEntries.push({
@@ -78,7 +74,7 @@ export const createChildRunCanceller = () => ({
 		const workflowRunEntries: WorkflowRunRowInsert[] = [];
 		const stateTransitionEntries: StateTransitionRowInsert[] = [];
 
-		for (const [i, parentRun] of parentRunsHavingChildren.entries()) {
+		for (const [i, parentRun] of runsHavingChildren.entries()) {
 			const workflow = workflowsByNamespaceId.get(parentRun.namespaceId);
 			const inputHash = inputHashes[i];
 			if (!workflow || inputHash === undefined) {
@@ -93,7 +89,7 @@ export const createChildRunCanceller = () => ({
 				namespaceId: parentRun.namespaceId,
 				workflowId: workflow.id,
 				status: "scheduled",
-				input: parentRun.runId,
+				input: parentRun.id,
 				inputHash,
 				options: {
 					pool: parentRun.pool,

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -237,7 +237,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		if (!result) {
 			throw new NotFoundError(`Schedule not found: ${id}`);
 		}
-		const runCount = await repos.workflowRun.getRunCount(result.schedule.id);
+		const runCount = await repos.workflowRun.getRunCount(namespaceId, result.schedule.id);
 		return { schedule: scheduleRowToDomain(result.schedule, result.workflow), runCount };
 	},
 
@@ -246,7 +246,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		if (!result) {
 			throw new NotFoundError(`Schedule not found with referenceId: ${referenceId}`);
 		}
-		const runCount = await repos.workflowRun.getRunCount(result.schedule.id);
+		const runCount = await repos.workflowRun.getRunCount(namespaceId, result.schedule.id);
 		return { schedule: scheduleRowToDomain(result.schedule, result.workflow), runCount };
 	},
 
@@ -281,7 +281,7 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		if (!isNonEmptyArray(scheduleIds)) {
 			return { schedules: [], total };
 		}
-		const runCountsByScheduleId = await repos.workflowRun.getRunCounts(scheduleIds);
+		const runCountsByScheduleId = await repos.workflowRun.getRunCounts(namespaceId, scheduleIds);
 
 		return {
 			schedules: schedules.map(({ schedule, workflow }) => ({

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -81,7 +81,7 @@ async function transitionStateInTx(
 	txRepos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 ): Promise<TaskInfo> {
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById(namespaceId, runId);
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -52,13 +52,15 @@ describe("WorkflowRunStateMachine transition preconditions", () => {
 				})
 			).rejects.toThrow(WorkflowRunRevisionConflictError);
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "running",
-					revision: revisionWhenClaimed,
-					attempts: attemptsWhenClaimed,
+					run: expect.objectContaining({
+						id: runId,
+						status: "running",
+						revision: revisionWhenClaimed,
+						attempts: attemptsWhenClaimed,
+					}),
 				})
 			);
 		}));
@@ -85,13 +87,15 @@ describe("WorkflowRunStateMachine transition preconditions", () => {
 				attempts: attemptsWhenClaimed,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "completed",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "completed",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "completed", output: { receipt: "r-1" } },
 				})
 			);
@@ -118,13 +122,15 @@ describe("WorkflowRunStateMachine transition preconditions", () => {
 				attempts: attemptsWhenClaimed,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "paused",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "paused",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "paused" },
 				})
 			);
@@ -150,13 +156,15 @@ describe("WorkflowRunStateMachine transition preconditions", () => {
 				})
 			).rejects.toThrow(InvalidWorkflowRunStateTransitionError);
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "running",
-					revision: revisionWhenClaimed,
-					attempts: attemptsWhenClaimed,
+					run: expect.objectContaining({
+						id: runId,
+						status: "running",
+						revision: revisionWhenClaimed,
+						attempts: attemptsWhenClaimed,
+					}),
 				})
 			);
 		}));
@@ -198,13 +206,15 @@ describe("WorkflowRunStateMachine attempt counting", () => {
 				attempts: attemptsWhenClaimed,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "awaiting_retry",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "awaiting_retry",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 				})
 			);
 		}));
@@ -243,13 +253,15 @@ describe("WorkflowRunStateMachine attempt counting", () => {
 				attempts: attemptsWhenClaimed + 1,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "queued",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "queued",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "queued", reason: "retry" },
 				})
 			);
@@ -277,13 +289,15 @@ describe("WorkflowRunStateMachine attempt counting", () => {
 				attempts: attemptsWhenClaimed,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "queued",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "queued",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "queued", reason: "task_retry" },
 				})
 			);
@@ -310,13 +324,15 @@ describe("WorkflowRunStateMachine attempt counting", () => {
 				attempts: attemptsWhenScheduled,
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "queued",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "queued",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "queued", reason: "new" },
 				})
 			);
@@ -352,13 +368,15 @@ describe("WorkflowRunStateMachine sleep lifecycle", () => {
 			const sleeps = await repos.sleep.listByWorkflowRunId(runId);
 			expect(sleeps).toEqual([expect.objectContaining({ workflowRunId: runId, name: "nap", status: "sleeping" })]);
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "sleeping",
-					revision: result.revision,
-					attempts: result.attempts,
+					run: expect.objectContaining({
+						id: runId,
+						status: "sleeping",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
 					state: { status: "sleeping", sleepName: "nap", wakeupAt: sleepStartedAt + 60_000 },
 				})
 			);
@@ -508,11 +526,13 @@ describe("WorkflowRunStateMachine redelivery", () => {
 				state: { status: "scheduled", scheduledInMs: 0, reason: "redelivery" },
 			});
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "scheduled",
+					run: expect.objectContaining({
+						id: runId,
+						status: "scheduled",
+					}),
 					state: expect.objectContaining({ status: "scheduled", reason: "redelivery" }),
 				})
 			);
@@ -542,11 +562,13 @@ describe("WorkflowRunStateMachine redelivery", () => {
 				}
 			);
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "queued",
+					run: expect.objectContaining({
+						id: runId,
+						status: "queued",
+					}),
 					state: { status: "queued", reason: "redelivery" },
 				})
 			);

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -225,13 +225,14 @@ async function transitionStateInTx(
 	const namespaceId = context.namespaceId;
 	const runId = request.id as WorkflowRunId;
 
-	const run = await txRepos.workflowRun.getByIdWithState(namespaceId, runId, {
-		forUpdate: request.type === "pessimistic",
-	});
-	if (!run) {
+	const result = await txRepos.workflowRun.getByIdWithState(
+		{ namespaceId, id: runId },
+		{ forUpdate: request.type === "pessimistic" }
+	);
+	if (!result) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}
-	const fromState = run.state;
+	const { run, state: fromState } = result;
 
 	assertIsValidWorkflowRunStateTransition(runId, fromState, request.state);
 
@@ -300,11 +301,11 @@ async function transitionStateInTx(
 		state: toState,
 	});
 
-	const newRevision = await updateWorkflowRun(runId, request, toState, stateTransitionId, attempts, txRepos);
+	const newRevision = await updateWorkflowRun(context, runId, request, toState, stateTransitionId, attempts, txRepos);
 
 	if (toState.status === "cancelled") {
 		await discardStaleTasks(runId, ["running", "awaiting_retry"], txRepos);
-		await childRunCanceller.cancel([{ namespaceId, runId, pool: run.options?.pool }], txRepos, context.logger);
+		await childRunCanceller.cancel([{ namespaceId, id: runId, pool: run.options?.pool }], txRepos, context.logger);
 	}
 
 	if (isTerminalWorkflowRunStatus(toState.status) && propsRequiredNonNull(run, "parentWorkflowRunId")) {
@@ -345,10 +346,11 @@ async function childWorkflowRunWaitNotNeeded(
 	txRepos: TxRepos
 ) {
 	const childRunId = toState.childWorkflowRunId as WorkflowRunId;
-	const childRun = await txRepos.workflowRun.getByIdWithState(namespaceId, childRunId);
-	if (!childRun) {
+	const childRunResult = await txRepos.workflowRun.getByIdWithState({ namespaceId, id: childRunId });
+	if (!childRunResult) {
 		throw new NotFoundError(`Workflow run not found: ${childRunId}`);
 	}
+	const childRun = childRunResult.run;
 
 	if (childRun.status === toState.childWorkflowRunStatus || isTerminalWorkflowRunStatus(childRun.status)) {
 		await txRepos.childWorkflowRunWait.insert({
@@ -374,6 +376,7 @@ async function childWorkflowRunWaitNotNeeded(
 }
 
 async function updateWorkflowRun(
+	context: NamespaceRequestContext,
 	runId: WorkflowRunId,
 	request: WorkflowRunTransitionStateRequestV1,
 	toState: WorkflowRunState,
@@ -406,6 +409,7 @@ async function updateWorkflowRun(
 	if (request.type === "optimistic") {
 		const result = await txRepos.workflowRun.update(
 			{
+				namespaceId: context.namespaceId,
 				id: runId,
 				revision: request.expectedRevision,
 			},
@@ -416,7 +420,7 @@ async function updateWorkflowRun(
 		}
 		return result.revision;
 	} else {
-		const result = await txRepos.workflowRun.update({ id: runId }, updates);
+		const result = await txRepos.workflowRun.update({ namespaceId: context.namespaceId, id: runId }, updates);
 		if (!result) {
 			throw new NotFoundError(`Workflow run not found: ${runId}`);
 		}
@@ -436,12 +440,15 @@ async function notifyParentOfStateChangeIfNecessary(
 	childRunCanceller: ChildRunCanceller,
 	txRepos: TxRepos
 ): Promise<void> {
-	const parentRun = await txRepos.workflowRun.getByIdWithState(context.namespaceId, childRun.parentWorkflowRunId);
-	if (!parentRun) {
+	const parentRunResult = await txRepos.workflowRun.getByIdWithState({
+		namespaceId: context.namespaceId,
+		id: childRun.parentWorkflowRunId,
+	});
+	if (!parentRunResult) {
 		throw new NotFoundError(`Workflow run not found: ${childRun.parentWorkflowRunId}`);
 	}
 
-	const parentRunState = parentRun.state;
+	const { run: parentRun, state: parentRunState } = parentRunResult;
 
 	if (
 		parentRunState.status === "awaiting_child_workflow" &&

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -56,7 +56,7 @@ async function setNewTaskStateInTx(
 ): Promise<void> {
 	const { namespaceId, logger } = context;
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById(namespaceId, runId, { forUpdate: true });
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { forUpdate: true });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}
@@ -121,7 +121,7 @@ async function setExistingTaskStateInTx(
 ): Promise<void> {
 	const { namespaceId, logger } = context;
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById(namespaceId, runId, { forUpdate: true });
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { forUpdate: true });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -106,13 +106,15 @@ describe("WorkflowRunService cancelByIds", () => {
 			const result = await service.cancelByIds(context, { ids: [runId] });
 			expect(result).toEqual({ cancelledIds: [runId] });
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "cancelled",
-					revision: revisionWhenClaimed + 1,
-					attempts: attemptsWhenClaimed,
+					run: expect.objectContaining({
+						id: runId,
+						status: "cancelled",
+						revision: revisionWhenClaimed + 1,
+						attempts: attemptsWhenClaimed,
+					}),
 					state: { status: "cancelled", reason: "Cancelled" },
 				})
 			);
@@ -145,8 +147,12 @@ describe("WorkflowRunService cancelByIds", () => {
 			const { service } = createService(repos);
 			expect(await service.cancelByIds(context, { ids: [] })).toEqual({ cancelledIds: [] });
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
-			expect(run).toEqual(expect.objectContaining({ id: runId, status: "running", revision: revisionWhenClaimed }));
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "running", revision: revisionWhenClaimed }),
+				})
+			);
 		}));
 
 	test("cancelling a sleeping run cancels its active sleep", () =>
@@ -169,11 +175,13 @@ describe("WorkflowRunService cancelByIds", () => {
 			const result = await withFakeClock(cancelledAt, () => service.cancelByIds(context, { ids: [runId] }));
 			expect(result).toEqual({ cancelledIds: [runId] });
 
-			const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 			expect(run).toEqual(
 				expect.objectContaining({
-					id: runId,
-					status: "cancelled",
+					run: expect.objectContaining({
+						id: runId,
+						status: "cancelled",
+					}),
 					state: { status: "cancelled", reason: "Cancelled" },
 				})
 			);
@@ -230,12 +238,17 @@ describe("WorkflowRunService cancelByIds", () => {
 				const result = await service.cancelByIds(context, { ids: [terminalRunSeed.runId, cancellableRunId] });
 				expect(result).toEqual({ cancelledIds: [cancellableRunId] });
 
-				const terminalRun = await repos.workflowRun.getByIdWithState(context.namespaceId, terminalRunSeed.runId);
+				const terminalRun = await repos.workflowRun.getByIdWithState({
+					namespaceId: context.namespaceId,
+					id: terminalRunSeed.runId,
+				});
 				expect(terminalRun).toEqual(
 					expect.objectContaining({
-						id: terminalRunSeed.runId,
-						status,
-						revision: terminal.revision,
+						run: expect.objectContaining({
+							id: terminalRunSeed.runId,
+							status,
+							revision: terminal.revision,
+						}),
 						state: terminal.state,
 					})
 				);
@@ -254,15 +267,17 @@ describe("WorkflowRunService cancelByIds", () => {
 			const { service } = createService(repos);
 			expect(await service.cancelByIds(context, { ids: [foreignRunSeed.runId] })).toEqual({ cancelledIds: [] });
 
-			const foreignRun = await repos.workflowRun.getByIdWithState(
-				otherNamespaceContext.namespaceId,
-				foreignRunSeed.runId
-			);
+			const foreignRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: otherNamespaceContext.namespaceId,
+				id: foreignRunSeed.runId,
+			});
 			expect(foreignRun).toEqual(
 				expect.objectContaining({
-					id: foreignRunSeed.runId,
-					status: "running",
-					revision: foreignRunSeed.revisionWhenClaimed,
+					run: expect.objectContaining({
+						id: foreignRunSeed.runId,
+						status: "running",
+						revision: foreignRunSeed.revisionWhenClaimed,
+					}),
 				})
 			);
 		}));
@@ -318,8 +333,7 @@ describe("WorkflowRunService cancelByIds", () => {
 			// The child is not cancelled inline: a system workflow run is scheduled to cascade the
 			// cancellation, and the child stays untouched until that run executes.
 			const scheduledRuns = await repos.workflowRun.listByFilters(
-				context.namespaceId,
-				{ status: ["scheduled"] },
+				{ namespaceId: context.namespaceId, status: ["scheduled"] },
 				10,
 				0,
 				{

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyArray } from "@aikirun/lib/collection/array";
+import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { NotFoundError } from "@aikirun/lib/error";
 import { getCompositeId } from "@aikirun/lib/id";
@@ -35,19 +35,11 @@ import { ulid } from "ulidx";
 import type { WorkflowRunStateMachine } from "./state-machine/workflow-run";
 import { WorkflowRunReferenceConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
-import type { ChildWorkflowRunWaitRow } from "../infra/db/types/child-workflow-run-wait";
 import type { EventWaitRow, EventWaitRowInsert } from "../infra/db/types/event-wait";
 import type { SleepRow } from "../infra/db/types/sleep";
-import type {
-	StateTransitionRepository,
-	StateTransitionRow,
-	StateTransitionRowInsert,
-} from "../infra/db/types/state-transition";
-import type { TaskRow } from "../infra/db/types/task";
-import type { WorkflowRepository, WorkflowRow } from "../infra/db/types/workflow";
-import type { WorkflowRunRow } from "../infra/db/types/workflow-run";
+import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { NamespaceRequestContext } from "../middleware/context";
-import type { CancelledParentRun, ChildRunCanceller } from "../service/cancel-child-runs";
+import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
 
 export interface WorkflowRunServiceDeps {
@@ -81,17 +73,12 @@ export const createWorkflowRunService = ({
 	async getWorkflowRunById(context: NamespaceRequestContext, id: string): Promise<WorkflowRunRecord> {
 		const { namespaceId } = context;
 
-		const runRow = await repos.workflowRun.getById(namespaceId, id);
-		if (!runRow) {
+		const result = await repos.workflowRun.getByIdWithWorkflowAndState({ namespaceId, id });
+		if (!result) {
 			throw new NotFoundError(`Workflow run not found: ${id}`);
 		}
 
-		const workflowRow = await repos.workflow.getById(namespaceId, runRow.workflowId);
-		if (!workflowRow) {
-			throw new NotFoundError(`Workflow not found for run: ${id}`);
-		}
-
-		return getWorkflowRun(repos, namespaceId, workflowRow, runRow);
+		return getWorkflowRun(repos, namespaceId, result);
 	},
 
 	async getWorkflowRunByReferenceId(
@@ -101,30 +88,26 @@ export const createWorkflowRunService = ({
 		const { namespaceId } = context;
 		const { name, versionId, referenceId } = filter;
 
-		const workflowRow = await repos.workflow.getByNameAndVersion(namespaceId, { name, versionId, source: "user" });
-		if (!workflowRow) {
-			throw new NotFoundError(`Workflow not found: ${name}:${versionId}`);
+		const result = await repos.workflowRun.getByReferenceWithWorkflowAndState({
+			namespaceId,
+			name,
+			versionId,
+			source: "user",
+			referenceId,
+		});
+		if (!result) {
+			throw new NotFoundError(`Workflow run ${name}:${versionId} not found for reference: ${referenceId}`);
 		}
 
-		const runRow = await repos.workflowRun.getByWorkflowAndReferenceId(workflowRow.id, referenceId);
-		if (!runRow) {
-			throw new NotFoundError(`Workflow run not found for reference: ${name}:${versionId}:${referenceId}`);
-		}
-
-		return getWorkflowRun(repos, namespaceId, workflowRow, runRow);
+		return getWorkflowRun(repos, namespaceId, result);
 	},
 
 	async getWorkflowRunState(context: NamespaceRequestContext, id: string): Promise<WorkflowRunState> {
-		const runRow = await repos.workflowRun.getById(context.namespaceId, id);
-		if (!runRow) {
+		const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id });
+		if (!run) {
 			throw new NotFoundError(`Workflow run not found: ${id}`);
 		}
-
-		const transition = await repos.stateTransition.getById(runRow.latestStateTransitionId);
-		if (!transition) {
-			throw new Error(`State transition not found: ${runRow.latestStateTransitionId}`);
-		}
-		return transition.state as WorkflowRunState;
+		return run.state;
 	},
 
 	async listWorkflowRuns(
@@ -152,8 +135,8 @@ export const createWorkflowRunService = ({
 		const { rows, total } = workflowFilter
 			? isNonEmptyArray(workflowIds)
 				? await repos.workflowRun.listByFilters(
-						namespaceId,
 						{
+							namespaceId,
 							id: filters?.id,
 							scheduleId: filters?.scheduleId,
 							status: isNonEmptyArray(filters?.status) ? filters.status : undefined,
@@ -168,8 +151,8 @@ export const createWorkflowRunService = ({
 					)
 				: { rows: [], total: 0 }
 			: await repos.workflowRun.listByFilters(
-					namespaceId,
 					{
+						namespaceId,
 						id: filters?.id,
 						scheduleId: filters?.scheduleId,
 						status: isNonEmptyArray(filters?.status) ? filters.status : undefined,
@@ -181,7 +164,7 @@ export const createWorkflowRunService = ({
 
 		const runIds = rows.map((row) => row.id);
 		const taskCountsByRunId = isNonEmptyArray(runIds)
-			? await repos.workflowRun.getTaskCountsByRunIds(runIds)
+			? await repos.task.countByWorkflowRunIds(runIds)
 			: new Map<string, Record<TaskStatus, number>>();
 
 		return {
@@ -242,13 +225,11 @@ export const createWorkflowRunService = ({
 		reference: EventReference | undefined
 	): Promise<void> {
 		return repos.transaction(async (txRepos) => {
-			// TODO: should we use getByIdWithState instead?
-			// Con: extra join to get state is pointless if the run is not in awaiting_event state
-			// Pro: If run is awaiting_event, no extra network call to fetch state
-			const run = await txRepos.workflowRun.getById(context.namespaceId, runId);
-			if (!run) {
+			const result = await txRepos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			if (!result) {
 				throw new NotFoundError(`Workflow run not found: ${runId}`);
 			}
+			const { run, state } = result;
 
 			const eventWaitEntry: EventWaitRowInsert = {
 				id: ulid(),
@@ -268,13 +249,7 @@ export const createWorkflowRunService = ({
 				return;
 			}
 
-			const latestStateTransition = await txRepos.stateTransition.getById(run.latestStateTransitionId);
-			if (!latestStateTransition) {
-				throw new Error(`State transition not found: ${run.latestStateTransitionId}`);
-			}
-			const currentState = latestStateTransition.state as WorkflowRunState;
-
-			if (currentState.status === "awaiting_event" && currentState.eventName === eventName) {
+			if (state.status === "awaiting_event" && state.eventName === eventName) {
 				await workflowRunStateMachine.transitionState(
 					context,
 					{
@@ -315,7 +290,7 @@ export const createWorkflowRunService = ({
 			if (!workflow) {
 				throw new NotFoundError(`Workflow not found: ${name}:${versionId}`);
 			}
-			return { workflowId: workflow.id, referenceId };
+			return { namespaceId, workflowId: workflow.id, referenceId };
 		});
 		if (!isNonEmptyArray(workflowIdAndReferenceIdPairs)) {
 			return [];
@@ -323,7 +298,7 @@ export const createWorkflowRunService = ({
 
 		const runs = await repos.workflowRun.listByWorkflowAndReferenceIdPairs({ pairs: workflowIdAndReferenceIdPairs });
 		const runsByKey = new Map(
-			runs.reduce<[string, WorkflowRunRow][]>((acc, run) => {
+			runs.reduce<[string, { id: string }][]>((acc, run) => {
 				if (run.referenceId !== null) {
 					acc.push([`${run.workflowId}:${run.referenceId}`, run]);
 				}
@@ -345,9 +320,10 @@ export const createWorkflowRunService = ({
 		});
 	},
 
-	async listChildRuns(_context: NamespaceRequestContext, request: WorkflowRunListChildRunsRequestV1) {
+	async listChildRuns(context: NamespaceRequestContext, request: WorkflowRunListChildRunsRequestV1) {
 		const childRuns = await repos.workflowRun.getChildRuns({
-			parentRunId: request.parentRunId,
+			namespaceId: context.namespaceId,
+			id: request.parentRunId,
 			status: isNonEmptyArray(request.status) ? request.status : undefined,
 		});
 		return {
@@ -368,20 +344,22 @@ export const createWorkflowRunService = ({
 		}
 
 		return repos.transaction(async (txRepos) => {
-			const cancelledRunIds = await txRepos.workflowRun.bulkTransitionToCancelled(namespaceId, ids);
-			if (!isNonEmptyArray(cancelledRunIds)) {
+			const cancelledRuns = await txRepos.workflowRun.bulkTransitionToCancelledInNamespace(namespaceId, ids);
+			if (!isNonEmptyArray(cancelledRuns)) {
 				return { cancelledIds: [] };
 			}
+			const cancelledRunIds = cancelledRuns.map((run) => run.id) as NonEmptyArray<string>;
 
 			await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
 			await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, Date.now() as TimestampMs);
 			await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
-			const cancelledRuns = await txRepos.workflowRun.getByIds(namespaceId, cancelledRunIds);
-
 			const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
-			const cancelledRunStateTransitionUpdates: { id: string; stateTransitionId: string }[] = [];
-			const cancelledRunsMeta: CancelledParentRun[] = [];
+			const cancelledRunStateTransitionUpdates: {
+				filter: { namespaceId: NamespaceId; id: string };
+				update: { stateTransitionId: string };
+			}[] = [];
+			const cancelledRunsMeta: CancelledRunMeta[] = [];
 
 			for (const run of cancelledRuns) {
 				const stateTransitionId = ulid();
@@ -393,10 +371,10 @@ export const createWorkflowRunService = ({
 					attempt: run.attempts,
 					state: { status: "cancelled", reason: "Cancelled" } satisfies WorkflowRunStateCancelled,
 				});
-				cancelledRunStateTransitionUpdates.push({ id: run.id, stateTransitionId });
+				cancelledRunStateTransitionUpdates.push({ filter: { namespaceId, id: run.id }, update: { stateTransitionId } });
 				cancelledRunsMeta.push({
 					namespaceId,
-					runId: run.id,
+					id: run.id,
 					pool: run.options?.pool,
 				});
 			}
@@ -442,7 +420,11 @@ async function createWorkflowRunInTx(
 	const workflow = await txRepos.workflow.getOrCreate({ namespaceId, name, versionId, source: "user" });
 
 	if (referenceId) {
-		const existingRun = await txRepos.workflowRun.getByWorkflowAndReferenceId(workflow.id, referenceId);
+		const existingRun = await txRepos.workflowRun.getByWorkflowAndReferenceId({
+			namespaceId,
+			workflowId: workflow.id,
+			referenceId,
+		});
 		if (existingRun) {
 			if (existingRun.inputHash !== inputHash) {
 				const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
@@ -511,84 +493,61 @@ async function createWorkflowRunInTx(
 	return runId;
 }
 
+type WorkflowRunWithWorkflowAndState = NonNullable<
+	Awaited<ReturnType<Repositories["workflowRun"]["getByIdWithWorkflowAndState"]>>
+>;
+
 async function getWorkflowRun(
 	repos: WorkflowRunServiceDeps["repos"],
 	namespaceId: NamespaceId,
-	workflowRow: WorkflowRow,
-	runRow: WorkflowRunRow
+	{ run, workflow, state }: WorkflowRunWithWorkflowAndState
 ): Promise<WorkflowRunRecord> {
-	const [latestTransition, taskRows, sleepRows, eventWaitRows, childRunRows, childWorkflowRunWaitRows] =
-		await Promise.all([
-			repos.stateTransition.getById(runRow.latestStateTransitionId),
-			repos.task.listByWorkflowRunId(runRow.id),
-			repos.sleep.listByWorkflowRunId(runRow.id as WorkflowRunId),
-			repos.eventWait.listByWorkflowRunId(runRow.id),
-			repos.workflowRun.getChildRuns({ parentRunId: runRow.id }),
-			repos.childWorkflowRunWait.listByParentRunId(runRow.id),
-		]);
-
-	if (!latestTransition) {
-		throw new Error(`State transition not found: ${runRow.latestStateTransitionId}`);
-	}
-
-	const taskTransitionIds = taskRows.map((task) => task.latestStateTransitionId);
-	const taskTransitionRows = isNonEmptyArray(taskTransitionIds)
-		? await repos.stateTransition.getByIds(taskTransitionIds)
-		: [];
-	const taskTransitionsById = new Map(taskTransitionRows.map((transition) => [transition.id, transition]));
-
-	const tasksByAddress = buildTasksByAddress(taskRows, taskTransitionsById);
-	const sleepsByName = buildSleepsByName(sleepRows);
-	const eventWaitsByName = buildEventWaitsByName(eventWaitRows);
-	const childWorkflowRunsByAddress = await buildChildWorkflowRunsByAddress(
-		namespaceId,
-		childRunRows,
-		childWorkflowRunWaitRows,
-		repos.stateTransition,
-		repos.workflow
-	);
+	const [taskRows, sleepRows, eventWaitRows, childRunRows, childWorkflowRunWaitRows] = await Promise.all([
+		repos.task.listByWorkflowRunIdWithState(run.id),
+		repos.sleep.listByWorkflowRunId(run.id as WorkflowRunId),
+		repos.eventWait.listByWorkflowRunId(run.id),
+		repos.workflowRun.getChildRunsWithWorkflow({ namespaceId, id: run.id }),
+		repos.childWorkflowRunWait.listByParentRunIdWithChildState(run.id),
+	]);
 
 	return {
-		id: runRow.id,
-		name: workflowRow.name,
-		versionId: workflowRow.versionId,
-		source: workflowRow.source,
-		createdAt: runRow.createdAt,
-		revision: runRow.revision,
-		stateTransitionId: runRow.latestStateTransitionId,
-		input: runRow.input,
-		inputHash: runRow.inputHash,
-		referenceId: runRow.referenceId ?? undefined,
-		options: runRow.options !== null ? runRow.options : undefined,
-		attempts: runRow.attempts,
-		state: latestTransition.state as WorkflowRunState,
-		tasks: tasksByAddress,
-		sleeps: sleepsByName,
-		eventWaits: eventWaitsByName,
-		childWorkflowRuns: childWorkflowRunsByAddress,
-		parentWorkflowRunId: runRow.parentWorkflowRunId ?? undefined,
-		scheduleId: runRow.scheduleId ?? undefined,
+		id: run.id,
+		name: workflow.name,
+		versionId: workflow.versionId,
+		source: workflow.source,
+		createdAt: run.createdAt,
+		revision: run.revision,
+		stateTransitionId: run.latestStateTransitionId,
+		input: run.input,
+		inputHash: run.inputHash,
+		referenceId: run.referenceId ?? undefined,
+		options: run.options !== null ? run.options : undefined,
+		attempts: run.attempts,
+		state,
+		tasks: buildTasksByAddress(taskRows),
+		sleeps: buildSleepsByName(sleepRows),
+		eventWaits: buildEventWaitsByName(eventWaitRows),
+		childWorkflowRuns: buildChildWorkflowRunsByAddress(childRunRows, childWorkflowRunWaitRows),
+		parentWorkflowRunId: run.parentWorkflowRunId ?? undefined,
+		scheduleId: run.scheduleId ?? undefined,
 	};
 }
 
 function buildTasksByAddress(
-	tasks: TaskRow[],
-	taskTransitionsById: Map<string, StateTransitionRow>
+	tasks: Array<{
+		id: string;
+		name: string;
+		inputHash: string;
+		state: TaskState;
+	}>
 ): Record<string, TaskInfo[]> {
 	const tasksByAddress: Record<string, TaskInfo[]> = {};
 	for (const task of tasks) {
-		if (task.status === "discarded") {
-			continue;
-		}
 		const address = getCompositeId({ name: task.name, referenceId: task.inputHash });
-		const transition = taskTransitionsById.get(task.latestStateTransitionId);
-		if (!transition) {
-			throw new Error(`Task state transition not found: ${task.latestStateTransitionId}`);
-		}
 		const taskInfo: TaskInfo = {
 			id: task.id,
 			name: task.name,
-			state: transition.state as Exclude<TaskState, TaskStateDiscarded>,
+			state: task.state as Exclude<TaskState, TaskStateDiscarded>,
 			inputHash: task.inputHash,
 		};
 		const tasksForAddress = tasksByAddress[address];
@@ -681,24 +640,10 @@ function buildEventWaitsByName(eventWaitRows: EventWaitRow[]): Record<string, Ev
 	return eventWaitsByName;
 }
 
-async function buildChildWorkflowRunsByAddress(
-	namespaceId: NamespaceId,
-	childRuns: WorkflowRunRow[],
-	childRunWaits: ChildWorkflowRunWaitRow[],
-	stateTransitionRepo: StateTransitionRepository,
-	workflowRepo: WorkflowRepository
-): Promise<Record<string, ChildWorkflowRunInfo[]>> {
-	const childStateTransitionIds = childRunWaits.reduce((acc: string[], { childWorkflowRunStateTransitionId }) => {
-		if (childWorkflowRunStateTransitionId !== null) {
-			acc.push(childWorkflowRunStateTransitionId);
-		}
-		return acc;
-	}, []);
-	const childStateTransitions = isNonEmptyArray(childStateTransitionIds)
-		? await stateTransitionRepo.getByIds(childStateTransitionIds)
-		: [];
-	const childStateTransitionsById = new Map(childStateTransitions.map((transition) => [transition.id, transition]));
-
+function buildChildWorkflowRunsByAddress(
+	childRuns: Awaited<ReturnType<Repositories["workflowRun"]["getChildRunsWithWorkflow"]>>,
+	childRunWaits: Awaited<ReturnType<Repositories["childWorkflowRunWait"]["listByParentRunIdWithChildState"]>>
+): Record<string, ChildWorkflowRunInfo[]> {
 	const waitsByChildRunId = new Map<WorkflowRunId, Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>>();
 
 	for (const childRunWait of childRunWaits) {
@@ -718,23 +663,18 @@ async function buildChildWorkflowRunsByAddress(
 
 		switch (childRunWait.status) {
 			case "completed": {
-				const { completedAt, childWorkflowRunStateTransitionId } = childRunWait;
+				const { completedAt, childWorkflowRunState } = childRunWait;
 				if (completedAt === null) {
 					throw new Error(`Child workflow run wait ${childRunWait.id} completed but no completedAt timestamp`);
 				}
-				if (childWorkflowRunStateTransitionId === null) {
-					throw new Error(`Child workflow run wait ${childRunWait.id} completed but no state transition id`);
-				}
-
-				const childStateTransition = childStateTransitionsById.get(childWorkflowRunStateTransitionId);
-				if (!childStateTransition) {
-					throw new Error(`State transition not found: ${childWorkflowRunStateTransitionId}`);
+				if (childWorkflowRunState === null) {
+					throw new Error(`Child workflow run wait ${childRunWait.id} completed but no child run state`);
 				}
 
 				waits[childWorkflowRunStatus].push({
 					status: childRunWait.status,
 					completedAt: completedAt,
-					childWorkflowRunState: childStateTransition.state as TerminalWorkflowRunState,
+					childWorkflowRunState: childWorkflowRunState as TerminalWorkflowRunState,
 				});
 				break;
 			}
@@ -755,20 +695,9 @@ async function buildChildWorkflowRunsByAddress(
 		}
 	}
 
-	const childWorkflowIds = Array.from(new Set(childRuns.map((run) => run.workflowId)));
-	const childWorkflows = isNonEmptyArray(childWorkflowIds)
-		? await workflowRepo.getByIds(namespaceId, childWorkflowIds)
-		: [];
-	const childWorkflowsById = new Map(childWorkflows.map((workflow) => [workflow.id, workflow]));
-
 	const childRunsByAddress: Record<string, ChildWorkflowRunInfo[]> = {};
 
-	for (const childRun of childRuns) {
-		const childWorkflow = childWorkflowsById.get(childRun.workflowId);
-		if (!childWorkflow) {
-			throw new Error(`Workflow not found for child run: ${childRun.id}`);
-		}
-
+	for (const { run: childRun, workflow: childWorkflow } of childRuns) {
 		const childRunAddress = getCompositeId({
 			name: childWorkflow.name,
 			versionId: childWorkflow.versionId,

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -110,8 +110,8 @@ export async function claimRun(deps: { context: NamespaceRequestContext; repos: 
 	const { context, repos, runId } = deps;
 	const services = createServices(repos);
 
-	const run = await repos.workflowRun.getByIdWithState(context.namespaceId, runId);
-	if (!run) {
+	const result = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+	if (!result) {
 		throw new Error(`Run not found: ${runId}`);
 	}
 
@@ -119,7 +119,7 @@ export async function claimRun(deps: { context: NamespaceRequestContext; repos: 
 		type: "optimistic",
 		id: runId,
 		state: { status: "running" },
-		expectedRevision: run.revision,
+		expectedRevision: result.run.revision,
 	});
 
 	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -3,7 +3,7 @@ import type { Duration } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
-import type { ReplayManifest, SleepResult, WorkflowRunId, WorkflowStartOptions } from "@aikirun/types/workflow/run";
+import type { ReplayManifest, SleepResult, WorkflowRunId, WorkflowRunOptions } from "@aikirun/types/workflow/run";
 
 import type { EventsDefinition, EventWaiters } from "./event";
 import type { WorkflowExecutionConfig } from "./execute";
@@ -13,7 +13,7 @@ export interface WorkflowRun<Input, Context, TEvents extends EventsDefinition = 
 	id: WorkflowRunId;
 	name: WorkflowName;
 	versionId: WorkflowVersionId;
-	options: WorkflowStartOptions;
+	options: WorkflowRunOptions;
 	logger: Logger;
 	sleep: (name: string, duration: Duration) => Promise<SleepResult>;
 	events: EventWaiters<TEvents>;


### PR DESCRIPTION
## Problem

Reading a run record took many small queries, one after another: the run, its workflow, its latest state, then one more query per collection for task states, child run states, and child workflow names. The cancel and stall paths re-read rows they had just updated, inside the same transaction, to get values the update already knew.

Tenancy also depended on the service layer: several repository methods had no namespace filter, so a bug upstream could touch another tenant's rows.

## Solution

Reads that belong together are now one query. The record header joins run, workflow, and latest state; each collection read joins its own states. A record fetch drops from eleven queries in five steps to six queries in two. The cancel, stall, and release updates return id, attempts, options, and namespace, so nothing re-reads inside the transaction. Every query selects only the columns its callers use.

Namespace filters now live in the repository. Namespaced methods take a filter object that includes the namespace (`getById({ namespaceId, id })`), so it cannot be forgotten. Cross-namespace methods take a `DaemonContext` first, so only daemons can call them; when both flavors exist, the namespaced one is named `InNamespace`. Task methods trust run ids, which always come from a namespaced query one step earlier.

One exception: on counts, a namespace filter can force row visits where the index alone could answer. Schedule run counts keep the filter and the index now covers it; child-run checks and per-workflow counts skip the filter because their ids come from namespaced queries.