### PR TITLE
Present and pin the run revision on child and task writes

### DIFF
--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -157,7 +157,7 @@ const createV1: ContractProcedure<WorkflowRunCreateRequestV1, WorkflowRunCreateR
 			versionId: "string > 0",
 			"input?": "unknown",
 			inputHash: "string > 0",
-			"parentWorkflowRunId?": "string > 0 | undefined",
+			"parent?": type({ workflowRunId: "string > 0", expectedRevision: "number.integer >= 0" }).or("undefined"),
 			"options?": workflowStartOptionsSchema,
 		})
 	)

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -79,24 +79,18 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result.length > 0;
 	},
 
-	async getById(
-		filter: {
-			namespaceId: NamespaceId;
-			id: string;
-		},
-		options?: { forUpdate?: boolean }
-	) {
+	async getById(filter: { namespaceId: NamespaceId; id: string }, options?: { lock?: "share" }) {
 		const query = db
 			.select({ id: workflowRun.id, revision: workflowRun.revision })
 			.from(workflowRun)
 			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
 			.limit(1);
 
-		const result = options?.forUpdate ? await query.for("update") : await query;
+		const result = options?.lock ? await query.for(options.lock) : await query;
 		return result[0] ?? null;
 	},
 
-	async getByIdWithState(filter: { namespaceId: NamespaceId; id: string }, options?: { forUpdate?: boolean }) {
+	async getByIdWithState(filter: { namespaceId: NamespaceId; id: string }, options?: { lock?: "update" }) {
 		const query = db
 			.select({
 				run: {
@@ -115,7 +109,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
 			.limit(1);
 
-		const result = options?.forUpdate ? await query.for("update", { of: workflowRun }) : await query;
+		const result = options?.lock ? await query.for(options.lock, { of: workflowRun }) : await query;
 		const row = result[0];
 		if (!row) {
 			return null;

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -81,7 +81,7 @@ async function transitionStateInTx(
 	txRepos: Pick<Repositories, "workflowRun" | "task" | "stateTransition" | "workflowRunOutbox">
 ): Promise<TaskInfo> {
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId });
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -227,7 +227,7 @@ async function transitionStateInTx(
 
 	const result = await txRepos.workflowRun.getByIdWithState(
 		{ namespaceId, id: runId },
-		{ forUpdate: request.type === "pessimistic" }
+		request.type === "pessimistic" ? { lock: "update" } : undefined
 	);
 	if (!result) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -56,7 +56,7 @@ async function setNewTaskStateInTx(
 ): Promise<void> {
 	const { namespaceId, logger } = context;
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { forUpdate: true });
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}
@@ -121,7 +121,7 @@ async function setExistingTaskStateInTx(
 ): Promise<void> {
 	const { namespaceId, logger } = context;
 	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { forUpdate: true });
+	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -6,6 +6,7 @@ import type { TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
 import { createTaskStateMachine } from "./state-machine/task";
 import { createWorkflowRunStateMachine, type WorkflowRunStateMachine } from "./state-machine/workflow-run";
 import { describe, expect, test } from "bun:test";
+import { WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
@@ -314,6 +315,33 @@ describe("WorkflowRunService cancelByIds", () => {
 			expect(discardedTasks).toEqual([expect.objectContaining({ id: taskInfo.id, workflowRunId: runId })]);
 		}));
 
+	test("does not create a child when the parent revision is stale", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+
+			// A running → running transition moves only the revision
+			const { service, stateMachine } = createService(repos);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: parent.runId,
+				state: { status: "running" },
+				expectedRevision: parent.revisionWhenClaimed,
+			});
+
+			const childInput = { orderId: "order-9" };
+			expect(
+				service.createWorkflowRun(context, {
+					name: parent.workflowName,
+					versionId: parent.workflowVersionId,
+					input: childInput,
+					inputHash: await hashInput(childInput),
+					parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
+				})
+			).rejects.toThrow(WorkflowRunRevisionConflictError);
+
+			expect(await repos.workflowRun.getChildRuns({ namespaceId: context.namespaceId, id: parent.runId })).toBeEmpty();
+		}));
+
 	test("cancelling a parent with a live child schedules the cancel-child-runs workflow", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
@@ -325,7 +353,7 @@ describe("WorkflowRunService cancelByIds", () => {
 				versionId: parent.workflowVersionId,
 				input: childInput,
 				inputHash: await hashInput(childInput),
-				parentWorkflowRunId: parent.runId,
+				parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
 			});
 
 			await service.cancelByIds(context, { ids: [parent.runId] });

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -33,7 +33,7 @@ import type { TaskInfo, TaskState, TaskStateDiscarded, TaskStatus } from "@aikir
 import { ulid } from "ulidx";
 
 import type { WorkflowRunStateMachine } from "./state-machine/workflow-run";
-import { WorkflowRunReferenceConflictError } from "../errors";
+import { WorkflowRunReferenceConflictError, WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import type { EventWaitRow, EventWaitRowInsert } from "../infra/db/types/event-wait";
 import type { SleepRow } from "../infra/db/types/sleep";
@@ -413,9 +413,18 @@ async function createWorkflowRunInTx(
 ): Promise<WorkflowRunId> {
 	const name = request.name as WorkflowName;
 	const versionId = request.versionId as WorkflowVersionId;
-	const parentWorkflowRunId = request.parentWorkflowRunId as WorkflowRunId | undefined;
-	const { input, inputHash, options } = request;
+	const { input, inputHash, options, parent } = request;
 	const referenceId = options?.reference?.id;
+
+	if (parent) {
+		const parentRun = await txRepos.workflowRun.getById({ namespaceId, id: parent.workflowRunId }, { lock: "share" });
+		if (!parentRun) {
+			throw new NotFoundError(`Workflow run not found: ${parent.workflowRunId}`);
+		}
+		if (parentRun.revision !== parent.expectedRevision) {
+			throw new WorkflowRunRevisionConflictError(parent.workflowRunId as WorkflowRunId, parent.expectedRevision);
+		}
+	}
 
 	const workflow = await txRepos.workflow.getOrCreate({ namespaceId, name, versionId, source: "user" });
 
@@ -457,7 +466,7 @@ async function createWorkflowRunInTx(
 		id: runId,
 		namespaceId,
 		workflowId: workflow.id,
-		parentWorkflowRunId,
+		parentWorkflowRunId: parent?.workflowRunId,
 		status: "scheduled",
 		input,
 		inputHash,

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -399,6 +399,6 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 	}
 }
 
-function isWorkflowRunRevisionConflictError(err: unknown): boolean {
+export function isWorkflowRunRevisionConflictError(err: unknown): boolean {
 	return err != null && typeof err === "object" && "code" in err && err.code === "WORKFLOW_RUN_REVISION_CONFLICT";
 }

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -740,7 +740,7 @@ describe("creating a workflow run", () => {
 						versionId: "1.0.0",
 						input: "payload",
 						inputHash,
-						parentWorkflowRunId: parentRunRecord.id,
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},
 					{ id: childRunRecord.id }
@@ -750,6 +750,32 @@ describe("creating a workflow run", () => {
 				const childHandle = await childWorkflow.startAsChild(parentRun, "payload");
 
 				expect(childHandle.run.id).toBe(childRunRecord.id);
+			}));
+
+		test("throws WorkflowRunRevisionConflictError when the parent revision is stale", () =>
+			withFakeClient(async (client) => {
+				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
+					async handler(_run, payload: string) {
+						return payload;
+					},
+				});
+				const parentRunRecord = runningWorkflowRunRecordFactory.build();
+				const parentRun = createTestWorkflowRun(client, parentRunRecord);
+				const inputHash = await hashInput("payload");
+
+				client.api.workflowRun.createV1.rejectsOnce(
+					{
+						name: "child-workflow",
+						versionId: "1.0.0",
+						input: "payload",
+						inputHash,
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
+						options: {},
+					},
+					Object.assign(new Error("Revision conflict"), { code: "WORKFLOW_RUN_REVISION_CONFLICT" })
+				);
+
+				expect(childWorkflow.startAsChild(parentRun, "payload")).rejects.toThrow(WorkflowRunRevisionConflictError);
 			}));
 
 		test("propagates the parent's pool to the child run", () =>
@@ -770,7 +796,7 @@ describe("creating a workflow run", () => {
 						versionId: "1.0.0",
 						input: "payload",
 						inputHash,
-						parentWorkflowRunId: parentRunRecord.id,
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: { pool: "eu-west" },
 					},
 					{ id: childRunRecord.id }
@@ -894,7 +920,7 @@ describe("creating a workflow run", () => {
 						versionId: "1.0.0",
 						input: "PAYLOAD",
 						inputHash,
-						parentWorkflowRunId: parentRunRecord.id,
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},
 					{ id: childRunRecord.id }

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -35,7 +35,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 import type { WorkflowRun } from "./run";
 import { createEventMulticasters, type EventMulticasters, type EventsDefinition } from "./run/event";
-import { type WorkflowRunHandle, workflowRunHandle } from "./run/handle";
+import { isWorkflowRunRevisionConflictError, type WorkflowRunHandle, workflowRunHandle } from "./run/handle";
 import { type ChildWorkflowRunHandle, childWorkflowRunHandle } from "./run/handle-child";
 import { validateWithSchema } from "./run/schema-validation";
 
@@ -213,14 +213,23 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		}
 
 		const pool = parentRun.options.pool;
-		const { id: newRunId } = await client.api.workflowRun.createV1({
-			name: this.name,
-			versionId: this.versionId,
-			input,
-			inputHash,
-			parentWorkflowRunId: parentRun.id,
-			options: pool === undefined ? startOptions : { ...startOptions, pool },
-		});
+		let newRunId: string | undefined;
+		try {
+			const response = await client.api.workflowRun.createV1({
+				name: this.name,
+				versionId: this.versionId,
+				input,
+				inputHash,
+				parent: { workflowRunId: parentRun.id, expectedRevision: parentRunHandle.run.revision },
+				options: pool === undefined ? startOptions : { ...startOptions, pool },
+			});
+			newRunId = response.id;
+		} catch (err) {
+			if (isWorkflowRunRevisionConflictError(err)) {
+				throw new WorkflowRunRevisionConflictError(parentRun.id);
+			}
+			throw err;
+		}
 		const { run: newRun } = await client.api.workflowRun.getByIdV1({ id: newRunId });
 
 		const logger = parentRun.logger.child({

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -105,7 +105,10 @@ export interface WorkflowRunCreateRequestV1 {
 	versionId: string;
 	input?: unknown;
 	inputHash: string;
-	parentWorkflowRunId?: string;
+	parent?: {
+		workflowRunId: string;
+		expectedRevision: number;
+	};
 	options?: WorkflowStartOptions;
 }
 


### PR DESCRIPTION
## Problem

The run revision is a worker's proof that it still owns the run. Every state write presents the revision the worker claimed the run at, and the server rejects the write if the row has moved — a cancel, a recovery release, or a redelivery bumps it and silently revokes the old worker.

However, there were gaps.

Starting a child workflow was a plain create call. It sent no revision, and the server never looked at the parent row. So a worker that had already lost the run could still create children.

Task transitions did send the revision, but the server only checked it at the start of the transaction. The run could change between the check and the commit.

## Solution

Creating a child now presents the parent's revision. The request's parent link is one object, so naming a parent without proving your view of it does not typecheck:

```ts
parentWorkflowRunId?: string;                                  // before
parent?: { workflowRunId: string; expectedRevision: number };  // after
```

The server compares and rejects with the usual revision conflict. The SDK sends the handle's live revision and throws the same typed error as any other revoked write.

Every write that checks the revision without incrementing it — task transitions, child creation — now holds a share lock on the run row until commit. The share lock does not block other checkers, so parallel task writes in one session proceed together. It only blocks a run transition, which writes the run row exclusively.

Setting task state by hand moved from the exclusive lock to the same share lock. Its writes carry the task's read-time state, so the task row's own guard decides races, and resolving a task from the dashboard no longer blocks the run's in-flight task writes.

## Breaking changes

The create request's `parentWorkflowRunId` field becomes `parent: { workflowRunId, expectedRevision }`.