### PR TITLE
Move schedule input hashing to producer

### DIFF
--- a/sdk/server/src/contract/procedure/schedule.ts
+++ b/sdk/server/src/contract/procedure/schedule.ts
@@ -32,6 +32,7 @@ const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateR
 			workflowName: "string > 0",
 			workflowVersionId: "string > 0",
 			"workflowRunInput?": "unknown",
+			workflowRunInputHash: "string > 0",
 			spec: scheduleSpecSchema,
 			"options?": scheduleActivateOptionsSchema.or("undefined"),
 			"workflowRunOptions?": workflowRunOptionsSchema.or("undefined"),

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -1,3 +1,5 @@
+import { hashInput } from "@aikirun/lib/crypto";
+
 import { createScheduleService } from "./schedule";
 import { describe, expect, test } from "bun:test";
 import { createServiceHarness } from "../testing/harness";
@@ -8,10 +10,12 @@ describe("ScheduleService activateSchedule", () => {
 	test("persists the cron timezone", () =>
 		withHarness(async ({ context, repos }) => {
 			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
 			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, {
 				workflowName: "send-invoices",
 				workflowVersionId: "v1",
-				workflowRunInput: { region: "eu-west" },
+				workflowRunInput,
+				workflowRunInputHash: await hashInput(workflowRunInput),
 				spec: { type: "cron", expression: "0 9 * * *", timezone: "Europe/Berlin" },
 			});
 

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -1,5 +1,5 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
-import { hashInput, sha256Async } from "@aikirun/lib/crypto";
+import { sha256Async } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
 import { stableStringify } from "@aikirun/lib/json";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
@@ -121,20 +121,17 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		namespaceId: NamespaceId,
 		request: ScheduleActivateRequestV1
 	): Promise<{ schedule: Schedule }> {
-		const { workflowName, workflowVersionId, workflowRunInput, workflowRunOptions, spec } = request;
-		const workflowRunInputHash = await hashInput(workflowRunInput);
+		const { workflowName, workflowVersionId, workflowRunInputHash, workflowRunOptions, spec } = request;
 		const definitionHash = await sha256Async(
 			stableStringify({
 				workflowName,
 				workflowVersionId,
 				spec,
-				workflowRunInput,
+				workflowRunInputHash,
 				workflowRunOptions,
 			})
 		);
-		return repos.transaction(async (txRepos) =>
-			activateScheduleInTx(namespaceId, request, { workflowRunInputHash, definitionHash }, txRepos)
-		);
+		return repos.transaction(async (txRepos) => activateScheduleInTx(namespaceId, request, definitionHash, txRepos));
 	},
 
 	async getScheduleById(namespaceId: NamespaceId, id: string) {
@@ -224,14 +221,11 @@ export type ScheduleService = ReturnType<typeof createScheduleService>;
 async function activateScheduleInTx(
 	namespaceId: NamespaceId,
 	request: ScheduleActivateRequestV1,
-	hashes: {
-		workflowRunInputHash: string;
-		definitionHash: string;
-	},
+	definitionHash: string,
 	txRepos: TxRepositories
 ) {
-	const { workflowName, workflowVersionId, workflowRunInput, workflowRunOptions, spec, options } = request;
-	const { workflowRunInputHash, definitionHash } = hashes;
+	const { workflowName, workflowVersionId, workflowRunInput, workflowRunInputHash, workflowRunOptions, spec, options } =
+		request;
 
 	const referenceId = options?.reference?.id;
 	const conflictPolicy = options?.reference?.conflictPolicy ?? "error";

--- a/sdk/server/src/testing/seed/schedule.ts
+++ b/sdk/server/src/testing/seed/schedule.ts
@@ -1,3 +1,5 @@
+import { hashInput } from "@aikirun/lib/crypto";
+
 import type { Repositories } from "../../infra/db/types";
 import type { NamespaceRequestContext } from "../../middleware/context";
 import { createScheduleService } from "../../service/schedule";
@@ -21,6 +23,7 @@ export async function seedActiveSchedule(
 	const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
 		...seededSchedule,
 		workflowName: overrides?.workflowName ?? seededSchedule.workflowName,
+		workflowRunInputHash: await hashInput(seededSchedule.workflowRunInput),
 	});
 
 	return { schedule };

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -1,3 +1,4 @@
+import { hashInput } from "@aikirun/lib/crypto";
 import { withFakeClient } from "@aikirun/testing/client";
 import {
 	cronScheduleActivateRequestFactory,
@@ -14,15 +15,20 @@ const syncInventoryWorkflow = workflow({ name: "sync-inventory" }).v<{ warehouse
 	handler: async () => {},
 });
 
+const workflowRunInput = { warehouseId: "wh-1" };
+const workflowRunInputHash = await hashInput(workflowRunInput);
+
 const intervalScheduleActivateRequest = intervalScheduleActivateRequestFactory.params({
 	workflowName: syncInventoryWorkflow.name,
 	workflowVersionId: syncInventoryWorkflow.versionId,
-	workflowRunInput: { warehouseId: "wh-1" },
+	workflowRunInput,
+	workflowRunInputHash,
 });
 const cronScheduleActivateRequest = cronScheduleActivateRequestFactory.params({
 	workflowName: syncInventoryWorkflow.name,
 	workflowVersionId: syncInventoryWorkflow.versionId,
-	workflowRunInput: { warehouseId: "wh-1" },
+	workflowRunInput,
+	workflowRunInputHash,
 });
 
 describe("schedule", () => {

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -1,3 +1,4 @@
+import { hashInput } from "@aikirun/lib/crypto";
 import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
@@ -66,6 +67,7 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 		...args: Input extends void ? [] : [Input]
 	): Promise<ScheduleHandle> {
 		const workflowRunInput = args[0];
+		const workflowRunInputHash = await hashInput(workflowRunInput);
 		const { workflowRun: workflowRunOptions, ...scheduleOptions } = options;
 
 		let scheduleSpec: ScheduleSpec;
@@ -84,6 +86,7 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 			workflowVersionId: workflow.versionId,
 			spec: scheduleSpec,
 			workflowRunInput,
+			workflowRunInputHash,
 			options: scheduleOptions,
 			workflowRunOptions,
 		});

--- a/testing/src/data-factory/api/schedule.ts
+++ b/testing/src/data-factory/api/schedule.ts
@@ -7,6 +7,7 @@ export const intervalScheduleActivateRequestFactory = Factory.define<
 >(() => ({
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
+	workflowRunInputHash: "hash",
 	options: {},
 	workflowRunOptions: {},
 	spec: { type: "interval", everyMs: 1_000 },
@@ -17,6 +18,7 @@ export const cronScheduleActivateRequestFactory = Factory.define<
 >(() => ({
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
+	workflowRunInputHash: "hash",
 	options: {},
 	workflowRunOptions: {},
 	spec: { type: "cron", expression: "* * * * *" },

--- a/types/src/api/schedule.ts
+++ b/types/src/api/schedule.ts
@@ -16,6 +16,7 @@ export interface ScheduleActivateRequestV1 {
 	workflowName: string;
 	workflowVersionId: string;
 	workflowRunInput?: unknown;
+	workflowRunInputHash: string;
 	spec: ScheduleSpec;
 	options?: ScheduleActivateOptions;
 	workflowRunOptions?: WorkflowRunOptions;


### PR DESCRIPTION
It's a preparation step for introducing a custom hasher to support on-demand enhanced payload encryption.