### PR TITLE
Eager creation-time promotion of imminent runs

### DIFF
--- a/app/server/src/serve.ts
+++ b/app/server/src/serve.ts
@@ -20,6 +20,7 @@ export async function startAppServer({ config }: { config: AppServerConfig }): P
 	const aiki = server({
 		db,
 		logger,
+		timerPriorityQueue: redis ? redisTimerPriorityQueue(redis.client, "aiki:timers") : inMemoryTimerPriorityQueue(),
 		handler: {
 			cache,
 			iam:
@@ -35,7 +36,6 @@ export async function startAppServer({ config }: { config: AppServerConfig }): P
 		},
 		runtime: {
 			publisher: redis ? redisPublisher(redis.client) : undefined,
-			timerPriorityQueue: redis ? redisTimerPriorityQueue(redis.client, "aiki:timers") : inMemoryTimerPriorityQueue(),
 		},
 	});
 

--- a/app/website/content/docs/architecture/server.md
+++ b/app/website/content/docs/architecture/server.md
@@ -50,23 +50,25 @@ The runtime's daemons drive workflow state transitions:
 
 The publish daemon runs only when a publisher is configured; without one, workers claim work directly from the outbox. Recovery runs unconditionally — a crashed worker's claim is released after `claimIdleTimeoutMs` either way (see [Workflow Run Claims](./workflow-run-claims.md)).
 
-By default, due work is detected by periodic database scans. Configuring a **timer priority queue** (`@aikirun/redis`) promotes near-term timers into a sorted queue that fires them with sub-second precision. The bundled standalone server always runs one: in-process by default, Redis-backed when `REDIS_URL` is set. With multiple server instances, prefer Redis — the shared queue hands each timer to exactly one instance, where per-instance in-process queues wake every instance for every timer (correctness is not affected, but work is duplicated). The queue is disposable acceleration state — the database keeps every deadline, and the scans repopulate the queue after a restart.
+By default, due work is detected by periodic database scans, so pickup latency is the scan interval. Configuring a **timer priority queue** (`@aikirun/memory` in-process, `@aikirun/redis` shared) promotes near-term timers into a sorted queue that fires them with sub-second precision — embedded servers should configure at least the in-process one. The request path feeds the queue too: creating a run — or waking a parked one — enqueues its timer immediately when the run is due soon, so a run meant to start now doesn't wait for the next scan. The bundled standalone server always runs one: in-process by default, Redis-backed when `REDIS_URL` is set. With multiple server instances, prefer Redis — the shared queue hands each timer to exactly one instance, where per-instance in-process queues wake every instance for every timer (correctness is not affected, but work is duplicated). The queue is disposable acceleration state — the database keeps every deadline, and the scans repopulate the queue after a restart.
 
 ## Configuration
 
 Embedded, the server is configured by composition:
 
 ```typescript
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import { database, server } from "@aikirun/server";
 
 const aikiServer = server({
   db: database({ provider: "pg", url: databaseUrl }),
+  timerPriorityQueue: inMemoryTimerPriorityQueue(),
 });
 
 const runtimeHandle = aikiServer.runtime.start();
 ```
 
-Optional pieces plug in the same way — `cache`, `iam` (multi-tenancy and auth), and the Redis-backed runtime adapters:
+Optional pieces plug in the same way — `cache`, `iam` (multi-tenancy and auth), and the Redis-backed adapters:
 
 ```typescript
 import { redisPublisher, redisTimerPriorityQueue } from "@aikirun/redis";
@@ -76,9 +78,9 @@ const redis = new Redis("redis://localhost:6379");
 
 const aikiServer = server({
   db: database({ provider: "pg", url: databaseUrl }),
+  timerPriorityQueue: redisTimerPriorityQueue(redis, "aiki:timers"),
   runtime: {
     publisher: redisPublisher(redis),
-    timerPriorityQueue: redisTimerPriorityQueue(redis, "aiki:timers"),
   },
 });
 ```

--- a/examples/src/runner.ts
+++ b/examples/src/runner.ts
@@ -84,7 +84,8 @@ async function setup(): Promise<Setup> {
 
 		const aiki = server({
 			db: database(loadDatabaseConfig()),
-			runtime: { publisher: queue.publisher, timerPriorityQueue },
+			timerPriorityQueue,
+			runtime: { publisher: queue.publisher },
 		});
 		const runtimeHandle = aiki.runtime.start();
 

--- a/sdk/adapter/memory/src/timer/priority-queue.ts
+++ b/sdk/adapter/memory/src/timer/priority-queue.ts
@@ -37,7 +37,7 @@ function compareTimerItems(a: TimerHeapItem, b: TimerHeapItem): number {
 /**
  * In-process TimerPriorityQueue backed by a min-heap and an internal signal queue.
  *
- * Returns a factory for creating the sorted set.
+ * Returns a factory for creating the queue.
  *
  * State is allocated once per call to `inMemoryTimerPriorityQueue()` and persists
  * for the lifetime of the returned factory. Every factory invocation returns a

--- a/sdk/server/src/config/handler.ts
+++ b/sdk/server/src/config/handler.ts
@@ -1,0 +1,15 @@
+import type { DeepPartial } from "@aikirun/lib/object";
+
+export interface ServerHandlerConfig {
+	imminentRuns: {
+		lookaheadWindowMs: number;
+	};
+}
+
+export type ServerHandlerConfigOverrides = DeepPartial<ServerHandlerConfig>;
+
+export const defaultServerHandlerConfig: ServerHandlerConfig = {
+	imminentRuns: {
+		lookaheadWindowMs: 30_000,
+	},
+};

--- a/sdk/server/src/config/index.ts
+++ b/sdk/server/src/config/index.ts
@@ -1,2 +1,3 @@
+export * from "./handler";
 export * from "./provider";
 export * from "./runtime";

--- a/sdk/server/src/config/runtime.ts
+++ b/sdk/server/src/config/runtime.ts
@@ -46,42 +46,42 @@ export type ServerRuntimeConfigOverrides = DeepPartial<ServerRuntimeConfig>;
 export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 	daemons: {
 		imminentScheduledRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentSleepElapsedRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentRetryableRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentRetryableTasks: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentEventWaitTimedOutRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentChildRunWaitTimedOutRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		imminentRecurringRuns: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
-			lookaheadWindowMs: 3_000,
+			lookaheadWindowMs: 30_000,
 		},
 		publishPendingOutboxEntries: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
 			leaseDurationMs: 5_000,
 			republishBackoff: {
@@ -91,7 +91,7 @@ export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 			},
 		},
 		recoverOverdueOutboxEntries: {
-			intervalMs: 1_000,
+			intervalMs: 10_000,
 			limit: 1_000,
 			claimIdleTimeoutMs: DEFAULT_CLAIM_IDLE_TIMEOUT_MS,
 		},

--- a/sdk/server/src/handler.ts
+++ b/sdk/server/src/handler.ts
@@ -1,15 +1,20 @@
+import { asConfigProvider, type ConfigProvider, type CreatePassiveConfigProvider } from "@aikirun/lib/config";
 import { UnauthorizedError } from "@aikirun/lib/error";
 import { SENTINEL_ULID } from "@aikirun/lib/id";
 import type { Logger } from "@aikirun/lib/logger";
+import { merge } from "@aikirun/lib/object";
 import type { ApiAuthorizer, Iam, IamContext } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
 import type { Database } from "@aikirun/types/infra/db";
+import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { OrganizationId } from "@aikirun/types/organization";
 import { RPCHandler } from "@orpc/server/fetch";
 
 import type { Capabilities } from "./capabilities";
+import { defaultServerHandlerConfig, type ServerHandlerConfig, type ServerHandlerConfigOverrides } from "./config";
 import { createRepos } from "./infra/db/repo";
+import { createImminentRunTimerQueue } from "./infra/timer/imminent-run-timer-queue";
 import { createNamespaceRequestContext, type NamespaceRequestContext } from "./middleware/context";
 import { createNamespaceAuthedRouter } from "./router/index";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
@@ -27,12 +32,34 @@ export interface CreateHandlerParams {
 	logger: Logger;
 	iam?: Iam;
 	cache?: CreateCache;
+	timerPriorityQueue?: CreateTimerPriorityQueue;
+	config?: ServerHandlerConfigOverrides | CreatePassiveConfigProvider<ServerHandlerConfig>;
 }
 
 export async function createHandler(params: CreateHandlerParams) {
-	const { logger, iam } = params;
+	const { logger, iam, config: configParam } = params;
 	const repos = await createRepos(params.db);
-	const childRunCanceller = createChildRunCanceller();
+
+	let configProvider: ConfigProvider<ServerHandlerConfig>;
+	if (typeof configParam === "function") {
+		configProvider = configParam({ logger: logger.child({ "aiki.component": "config-provider" }) });
+	} else {
+		const config = merge(defaultServerHandlerConfig, configParam);
+		configProvider = asConfigProvider(() => config);
+	}
+
+	const timerPriorityQueue = params.timerPriorityQueue?.({
+		logger: logger.child({ "aiki.component": "timer-priority-queue" }),
+	});
+	const imminentRunTimerQueue =
+		timerPriorityQueue &&
+		createImminentRunTimerQueue({
+			timerPriorityQueue,
+			configProvider: configProvider.scope("imminentRuns"),
+			logger,
+		});
+
+	const childRunCanceller = createChildRunCanceller(imminentRunTimerQueue);
 
 	const apiAuthorizer = (iam?.api ?? noopApiAuthorizer)({ logger });
 	const dashboardIam = iam?.dashboard?.({ logger });
@@ -40,12 +67,14 @@ export async function createHandler(params: CreateHandlerParams) {
 	const workflowRunStateMachine = createWorkflowRunStateMachine({
 		repos,
 		childRunCanceller,
+		imminentRunTimerQueue,
 	});
 	const taskStateMachine = createTaskStateMachine({ repos });
 	const workflowRunService = createWorkflowRunService({
 		repos,
 		childRunCanceller,
 		workflowRunStateMachine,
+		imminentRunTimerQueue,
 	});
 	const workflowService = createWorkflowService({ repos });
 	const scheduleService = createScheduleService({ repos });

--- a/sdk/server/src/infra/db/pg/index.ts
+++ b/sdk/server/src/infra/db/pg/index.ts
@@ -27,7 +27,19 @@ export function createPgRepos(client: PgClient): Repositories {
 	return {
 		...createRepos(db),
 		async transaction<T>(fn: (txRepos: TxRepositories) => Promise<T>): Promise<T> {
-			return db.transaction(async (tx) => fn(createRepos(tx) as TxRepositories));
+			const effects: Array<() => void> = [];
+			const result = await db.transaction(async (tx) => {
+				const txRepos = Object.assign(createRepos(tx), {
+					onCommit: (effect: () => void): void => {
+						effects.push(effect);
+					},
+				}) as TxRepositories;
+				return fn(txRepos);
+			});
+			for (const effect of effects) {
+				effect();
+			}
+			return result;
 		},
 	};
 }

--- a/sdk/server/src/infra/db/transaction.integration.test.ts
+++ b/sdk/server/src/infra/db/transaction.integration.test.ts
@@ -1,0 +1,54 @@
+import type { TxRepositories } from "./types";
+import { describe, expect, test } from "bun:test";
+import { withRepos } from "../../testing/harness";
+
+describe("transaction onCommit", () => {
+	test("runs effects after the transaction body, before the transaction call resolves", () =>
+		withRepos(async (repos) => {
+			const events: string[] = [];
+
+			await repos.transaction(async (txRepos) => {
+				txRepos.onCommit(() => {
+					events.push("effect");
+				});
+				events.push("body done");
+			});
+			events.push("transaction resolved");
+
+			expect(events).toEqual(["body done", "effect", "transaction resolved"]);
+		}));
+
+	test("drops effects when the transaction rolls back", () =>
+		withRepos(async (repos) => {
+			const events: string[] = [];
+
+			const transactionPromise = repos.transaction(async (txRepos) => {
+				txRepos.onCommit(() => {
+					events.push("effect");
+				});
+				throw new Error("rollback");
+			});
+
+			expect(transactionPromise).rejects.toThrow("rollback");
+			expect(events).toEqual([]);
+		}));
+
+	test("effects registered by nested calls all fire at the one commit", () =>
+		withRepos(async (repos) => {
+			const events: string[] = [];
+			const registerFromNestedCall = async (txRepos: TxRepositories) => {
+				txRepos.onCommit(() => {
+					events.push("nested effect");
+				});
+			};
+
+			await repos.transaction(async (txRepos) => {
+				txRepos.onCommit(() => {
+					events.push("owner effect");
+				});
+				await registerFromNestedCall(txRepos);
+			});
+
+			expect(events).toEqual(["owner effect", "nested effect"]);
+		}));
+});

--- a/sdk/server/src/infra/db/types/index.ts
+++ b/sdk/server/src/infra/db/types/index.ts
@@ -25,4 +25,9 @@ declare const inTransaction: unique symbol;
 
 export type TxRepositories = Omit<Repositories, "transaction"> & {
 	readonly [inTransaction]: true;
+	/**
+	 * Runs `effect` after this transaction commits; a rollback drops it without
+	 * running.
+	 */
+	onCommit(effect: () => void): void;
 };

--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
@@ -1,0 +1,44 @@
+import { asConfigProvider } from "@aikirun/lib/config";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+import { createImminentRunTimerQueue } from "./imminent-run-timer-queue";
+import { describe, expect, test } from "bun:test";
+import { computeRank } from "../../lib/rank";
+
+function createQueues(lookaheadWindowMs: number) {
+	const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+	return {
+		timerPriorityQueue,
+		imminentRunTimerQueue: createImminentRunTimerQueue({
+			timerPriorityQueue,
+			configProvider: asConfigProvider(() => ({ lookaheadWindowMs })),
+			logger: noopLogger,
+		}),
+	};
+}
+
+describe("ImminentRunTimerQueue", () => {
+	test("adds a scheduled timer for a run due within the window", async () => {
+		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
+
+		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0 }]);
+
+		expect(await timerPriorityQueue.popDue({ maxRank: computeRank({ dueAt: 0 }), limit: 10 })).toEqual([
+			{ type: "scheduled", id: "run-1", rank: computeRank({ dueAt: 0 }) },
+		]);
+	});
+
+	test("skips runs due beyond the window", async () => {
+		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
+
+		imminentRunTimerQueue.add([
+			{ id: "run-due", scheduledAt: 0 },
+			{ id: "run-far", scheduledAt: Number.MAX_SAFE_INTEGER },
+		]);
+
+		expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+			{ type: "scheduled", id: "run-due", rank: computeRank({ dueAt: 0 }) },
+		]);
+	});
+});

--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
@@ -1,0 +1,49 @@
+import { fireAndForget } from "@aikirun/lib/async";
+import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import type { ConfigProvider } from "@aikirun/lib/config";
+import type { Logger } from "@aikirun/lib/logger";
+import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
+
+import { computeRank } from "../../lib/rank";
+
+export interface ImminentRunTimerQueueDeps {
+	timerPriorityQueue: TimerPriorityQueue;
+	configProvider: ConfigProvider<{ lookaheadWindowMs: number }>;
+	logger: Logger;
+}
+
+export const createImminentRunTimerQueue = ({
+	timerPriorityQueue,
+	configProvider,
+	logger,
+}: ImminentRunTimerQueueDeps) => ({
+	/**
+	 * Adds a "scheduled" timer for each run due within the lookahead window, so
+	 * the due-timers consumer picks the run up without waiting for the next
+	 * promoter poll. Failures are logged and dropped: the poll is the backstop,
+	 * so a missed timer costs latency, never the run.
+	 */
+	add(runs: NonEmptyArray<{ id: string; scheduledAt: number }>): void {
+		const dueBefore = Date.now() + configProvider.config.lookaheadWindowMs;
+		const timers: TimerEntry[] = [];
+		for (const { id, scheduledAt } of runs) {
+			if (scheduledAt <= dueBefore) {
+				timers.push({ type: "scheduled", id, rank: computeRank({ dueAt: scheduledAt }) });
+			}
+		}
+		if (!isNonEmptyArray(timers)) {
+			return;
+		}
+
+		fireAndForget(
+			timerPriorityQueue.add(timers).then((result) => {
+				if (result.status === "failed") {
+					logger.debug("Failed to add imminent run timers", { "aiki.count": timers.length });
+				}
+			}),
+			(err) => logger.debug("Failed to add imminent run timers", { err, "aiki.count": timers.length })
+		);
+	},
+});
+
+export type ImminentRunTimerQueue = ReturnType<typeof createImminentRunTimerQueue>;

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -8,6 +8,7 @@ import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 import { defaultServerRuntimeConfig, type ServerRuntimeConfig, type ServerRuntimeConfigOverrides } from "./config";
 import { startDaemons } from "./daemon";
 import { createRepos } from "./infra/db/repo";
+import { createImminentRunTimerQueue } from "./infra/timer/imminent-run-timer-queue";
 import { createChildRunCanceller } from "./service/cancel-child-runs";
 
 export interface StartRuntimeParams {
@@ -26,7 +27,6 @@ export interface StartedRuntime {
 
 export async function startRuntime(params: StartRuntimeParams): Promise<StartedRuntime> {
 	const { logger, signal, config: configParam } = params;
-	const childRunCanceller = createChildRunCanceller();
 
 	let configProvider: ConfigProvider<ServerRuntimeConfig>;
 	if (typeof configParam === "function") {
@@ -35,6 +35,22 @@ export async function startRuntime(params: StartRuntimeParams): Promise<StartedR
 		const config = merge(defaultServerRuntimeConfig, configParam);
 		configProvider = asConfigProvider(() => config);
 	}
+
+	const timerPriorityQueue = params.timerPriorityQueue?.({
+		logger: logger.child({ "aiki.component": "timer-priority-queue" }),
+		signal,
+	});
+
+	const childRunCanceller = createChildRunCanceller(
+		timerPriorityQueue &&
+			createImminentRunTimerQueue({
+				timerPriorityQueue,
+				configProvider: asConfigProvider(() => ({
+					lookaheadWindowMs: configProvider.config.daemons.imminentScheduledRuns.lookaheadWindowMs,
+				})),
+				logger,
+			})
+	);
 
 	const repos = await createRepos(params.db);
 
@@ -46,10 +62,7 @@ export async function startRuntime(params: StartRuntimeParams): Promise<StartedR
 			logger: logger.child({ "aiki.component": "publisher" }),
 			signal,
 		}),
-		timerPriorityQueue: params.timerPriorityQueue?.({
-			logger: logger.child({ "aiki.component": "timer-priority-queue" }),
-			signal,
-		}),
+		timerPriorityQueue,
 		childRunCanceller,
 	});
 

--- a/sdk/server/src/server.ts
+++ b/sdk/server/src/server.ts
@@ -1,5 +1,5 @@
 import { settleWithin } from "@aikirun/lib/async";
-import type { CreateConfigProvider } from "@aikirun/lib/config";
+import type { CreateConfigProvider, CreatePassiveConfigProvider } from "@aikirun/lib/config";
 import { createConsoleLogger, type Logger } from "@aikirun/lib/logger";
 import type { Iam } from "@aikirun/types/iam";
 import type { CreateCache } from "@aikirun/types/infra/cache";
@@ -8,22 +8,28 @@ import type { CreatePublisher } from "@aikirun/types/infra/queue";
 import type { CreateTimerPriorityQueue } from "@aikirun/types/infra/timer";
 import { ulid } from "ulidx";
 
-import type { ServerRuntimeConfig, ServerRuntimeConfigOverrides } from "./config";
+import type {
+	ServerHandlerConfig,
+	ServerHandlerConfigOverrides,
+	ServerRuntimeConfig,
+	ServerRuntimeConfigOverrides,
+} from "./config";
 
 export interface ServerHandlerParams {
 	iam?: Iam;
 	cache?: CreateCache;
+	config?: ServerHandlerConfigOverrides | CreatePassiveConfigProvider<ServerHandlerConfig>;
 }
 
 export interface ServerRuntimeParams {
 	publisher?: CreatePublisher;
-	timerPriorityQueue?: CreateTimerPriorityQueue;
 	config?: ServerRuntimeConfigOverrides | CreateConfigProvider<ServerRuntimeConfig>;
 }
 
 export interface ServerParams {
 	db: CreateDatabase;
 	logger?: Logger;
+	timerPriorityQueue?: CreateTimerPriorityQueue;
 	handler?: ServerHandlerParams;
 	runtime?: ServerRuntimeParams;
 }
@@ -55,7 +61,14 @@ export function server(params: ServerParams): Server {
 				createHandlerPromise ??= (async () => {
 					const db = await params.db();
 					const { createHandler } = await import("./handler");
-					return createHandler({ db, logger, iam: params.handler?.iam, cache: params.handler?.cache });
+					return createHandler({
+						db,
+						logger,
+						iam: params.handler?.iam,
+						cache: params.handler?.cache,
+						timerPriorityQueue: params.timerPriorityQueue,
+						config: params.handler?.config,
+					});
 				})();
 				handler = await createHandlerPromise;
 				return handler(request);
@@ -63,7 +76,12 @@ export function server(params: ServerParams): Server {
 		},
 		runtime: {
 			start(): ServerRuntimeHandle {
-				return createRuntimeHandle({ db: params.db, logger, runtime: params.runtime });
+				return createRuntimeHandle({
+					db: params.db,
+					logger,
+					timerPriorityQueue: params.timerPriorityQueue,
+					runtime: params.runtime,
+				});
 			},
 		},
 	};
@@ -72,6 +90,7 @@ export function server(params: ServerParams): Server {
 function createRuntimeHandle(params: {
 	db: CreateDatabase;
 	logger: Logger;
+	timerPriorityQueue?: CreateTimerPriorityQueue;
 	runtime?: ServerRuntimeParams;
 }): ServerRuntimeHandle {
 	const { logger } = params;
@@ -86,7 +105,7 @@ function createRuntimeHandle(params: {
 				logger,
 				signal: abortController.signal,
 				publisher: params.runtime?.publisher,
-				timerPriorityQueue: params.runtime?.timerPriorityQueue,
+				timerPriorityQueue: params.timerPriorityQueue,
 				config: params.runtime?.config,
 			});
 		} catch (err) {

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import { asNonEmptyArray, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import { hashInput } from "@aikirun/lib/crypto";
 import type { Logger } from "@aikirun/lib/logger";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
@@ -16,6 +16,7 @@ import type { TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRowInsert } from "../infra/db/types/workflow";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
+import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 
 export interface CancelledRunMeta {
 	namespaceId: NamespaceId;
@@ -23,7 +24,7 @@ export interface CancelledRunMeta {
 	pool: string | undefined;
 }
 
-export const createChildRunCanceller = () => ({
+export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimerQueue) => ({
 	async cancel(runs: NonEmptyArray<CancelledRunMeta>, txRepos: TxRepositories, logger: Logger): Promise<void> {
 		if (!isNonEmptyArray(NON_TERMINAL_WORKFLOW_RUN_STATUSES)) {
 			return;
@@ -117,6 +118,11 @@ export const createChildRunCanceller = () => ({
 		if (isNonEmptyArray(workflowRunEntries) && isNonEmptyArray(stateTransitionEntries)) {
 			await txRepos.workflowRun.insert(workflowRunEntries);
 			await txRepos.stateTransition.appendBatch(stateTransitionEntries);
+
+			if (imminentRunTimerQueue) {
+				const imminentRuns = workflowRunEntries.map((entry) => ({ id: entry.id, scheduledAt: now }));
+				txRepos.onCommit(() => imminentRunTimerQueue.add(asNonEmptyArray(imminentRuns)));
+			}
 		}
 	},
 });

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -1,4 +1,7 @@
+import { asConfigProvider } from "@aikirun/lib/config";
 import { NotFoundError } from "@aikirun/lib/error";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 
 import { createWorkflowRunStateMachine } from "./workflow-run";
 import { describe, expect, test } from "bun:test";
@@ -6,6 +9,8 @@ import { processImminentScheduledRuns } from "../../daemon/imminent-scheduled-ru
 import { processImminentSleepElapsedRuns } from "../../daemon/imminent-sleep-elapsed-runs";
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../../errors";
 import type { Repositories } from "../../infra/db/types";
+import { createImminentRunTimerQueue, type ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
+import { computeRank } from "../../lib/rank";
 import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../../testing/harness";
@@ -16,8 +21,8 @@ const withHarness = createServiceHarness();
 
 const daemonContext = daemonContextFactory.build();
 
-function createStateMachine(repos: Repositories) {
-	return createWorkflowRunStateMachine({ repos, childRunCanceller: createChildRunCanceller() });
+function createStateMachine(repos: Repositories, imminentRunTimerQueue?: ImminentRunTimerQueue) {
+	return createWorkflowRunStateMachine({ repos, childRunCanceller: createChildRunCanceller(), imminentRunTimerQueue });
 }
 
 describe("WorkflowRunStateMachine transition preconditions", () => {
@@ -592,5 +597,35 @@ describe("WorkflowRunStateMachine redelivery", () => {
 					state: { status: "scheduled", scheduledInMs: 0, reason: "resumption" },
 				})
 			).rejects.toThrow(InvalidWorkflowRunStateTransitionError);
+		}));
+});
+
+describe("WorkflowRunStateMachine imminent run timers", () => {
+	test("a transition into scheduled adds the run's timer to the priority queue", () =>
+		withHarness(async ({ context, repos }) => {
+			const { runId } = await seedStalledRun({ namespaceRequestContext: context, repos });
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const redeliveredAtMs = Date.now();
+			await withFakeClock(redeliveredAtMs, () =>
+				stateMachine.transitionState(context, {
+					type: "pessimistic",
+					id: runId,
+					state: { status: "scheduled", scheduledInMs: 0, reason: "redelivery" },
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: redeliveredAtMs }) },
+			]);
 		}));
 });

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -18,6 +18,7 @@ import { ulid } from "ulidx";
 
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../../errors";
 import type { Repositories, TxRepositories } from "../../infra/db/types";
+import type { ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../../middleware/context";
 import type { ChildRunCanceller } from "../cancel-child-runs";
 import { discardStaleTasks } from "../discard-stale-tasks";
@@ -187,18 +188,23 @@ export function assertIsValidWorkflowRunStateTransition(
 export interface WorkflowRunStateMachineDeps {
 	repos: Repositories;
 	childRunCanceller: ChildRunCanceller;
+	imminentRunTimerQueue?: ImminentRunTimerQueue;
 }
 
-export const createWorkflowRunStateMachine = ({ repos, childRunCanceller }: WorkflowRunStateMachineDeps) => ({
+export const createWorkflowRunStateMachine = ({
+	repos,
+	childRunCanceller,
+	imminentRunTimerQueue,
+}: WorkflowRunStateMachineDeps) => ({
 	async transitionState(
 		context: NamespaceRequestContext,
 		request: WorkflowRunTransitionStateRequestV1,
 		txRepos?: TxRepositories
 	): Promise<WorkflowRunTransitionStateResponseV1> {
 		const response = txRepos
-			? await transitionStateInTx(context, request, childRunCanceller, txRepos)
+			? await transitionStateInTx(context, request, childRunCanceller, txRepos, imminentRunTimerQueue)
 			: await repos.transaction(async (newTxRepos) =>
-					transitionStateInTx(context, request, childRunCanceller, newTxRepos)
+					transitionStateInTx(context, request, childRunCanceller, newTxRepos, imminentRunTimerQueue)
 				);
 		context.logger.info("Workflow state transition", {
 			"aiki.runId": request.id,
@@ -215,7 +221,8 @@ async function transitionStateInTx(
 	context: NamespaceRequestContext,
 	request: WorkflowRunTransitionStateRequestV1,
 	childRunCanceller: ChildRunCanceller,
-	txRepos: TxRepositories
+	txRepos: TxRepositories,
+	imminentRunTimerQueue?: ImminentRunTimerQueue
 ): Promise<WorkflowRunTransitionStateResponseV1> {
 	const namespaceId = context.namespaceId;
 	const runId = request.id as WorkflowRunId;
@@ -297,6 +304,10 @@ async function transitionStateInTx(
 	});
 
 	const newRevision = await updateWorkflowRun(context, runId, request, toState, stateTransitionId, attempts, txRepos);
+
+	if (imminentRunTimerQueue && toState.status === "scheduled") {
+		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt: toState.scheduledAt }]));
+	}
 
 	if (toState.status === "cancelled") {
 		await discardStaleTasks(runId, ["running", "awaiting_retry"], txRepos);

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -1,5 +1,9 @@
+import { asConfigProvider } from "@aikirun/lib/config";
 import { hashInput } from "@aikirun/lib/crypto";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import type { WorkflowRunTransitionStateResponseV1 } from "@aikirun/types/api/workflow-run";
+import type { TimerPriorityQueue } from "@aikirun/types/infra/timer";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
 
@@ -8,6 +12,8 @@ import { createWorkflowRunStateMachine, type WorkflowRunStateMachine } from "./s
 import { describe, expect, test } from "bun:test";
 import { WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
+import { createImminentRunTimerQueue, type ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
+import { computeRank } from "../lib/rank";
 import type { NamespaceRequestContext } from "../middleware/context";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
 import { createWorkflowRunService } from "../service/workflow-run";
@@ -19,13 +25,37 @@ import { seedRunningTask } from "../testing/seed/task";
 
 const withHarness = createServiceHarness();
 
-function createService(repos: Repositories) {
-	const childRunCanceller = createChildRunCanceller();
-	const workflowRunStateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller });
+function createService(repos: Repositories, imminentRunTimerQueue?: ImminentRunTimerQueue) {
+	const childRunCanceller = createChildRunCanceller(imminentRunTimerQueue);
+	const workflowRunStateMachine = createWorkflowRunStateMachine({
+		repos,
+		childRunCanceller,
+		imminentRunTimerQueue,
+	});
 	return {
-		service: createWorkflowRunService({ repos, childRunCanceller, workflowRunStateMachine }),
+		service: createWorkflowRunService({
+			repos,
+			childRunCanceller,
+			workflowRunStateMachine,
+			imminentRunTimerQueue,
+		}),
 		stateMachine: workflowRunStateMachine,
 	};
+}
+
+function createTimerPriorityQueue() {
+	return inMemoryTimerPriorityQueue()({ logger: noopLogger });
+}
+
+function createTestImminentRunTimerQueue(params: {
+	timerPriorityQueue: TimerPriorityQueue;
+	lookaheadWindowMs: number;
+}): ImminentRunTimerQueue {
+	return createImminentRunTimerQueue({
+		timerPriorityQueue: params.timerPriorityQueue,
+		configProvider: asConfigProvider(() => ({ lookaheadWindowMs: params.lookaheadWindowMs })),
+		logger: noopLogger,
+	});
 }
 
 describe("WorkflowRunService getWorkflowRunById", () => {
@@ -418,6 +448,127 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 					taskId: taskInfo.id,
 					taskState: { status: "running", attempts: 2 },
 				},
+			]);
+		}));
+});
+
+describe("WorkflowRunService imminent run timers", () => {
+	test("creating a due run adds its timer to the priority queue", () =>
+		withHarness(async ({ context, repos }) => {
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			const input = { orderId: "order-1" };
+			const inputHash = await hashInput(input);
+			const createdAtMs = Date.now();
+			const runId = await withFakeClock(createdAtMs, () =>
+				service.createWorkflowRun(context, {
+					name: "checkout",
+					versionId: "v1",
+					input,
+					inputHash,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: createdAtMs }) },
+			]);
+		}));
+
+	test("a run due beyond the lookahead window adds no timer", () =>
+		withHarness(async ({ context, repos }) => {
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			const input = { orderId: "order-1" };
+			await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash: await hashInput(input),
+				options: { trigger: { type: "delayed", delayMs: 60_000 } },
+			});
+
+			expect(await timerPriorityQueue.peekNext()).toBeNull();
+		}));
+
+	test("returning an existing run from a reference adds no timer", () =>
+		withHarness(async ({ context, repos }) => {
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			const input = { orderId: "order-1" };
+			const inputHash = await hashInput(input);
+			const request = {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash,
+				options: { reference: { id: "order-ref-1" } },
+			};
+			const createdAtMs = Date.now();
+			const runId = await withFakeClock(createdAtMs, () => service.createWorkflowRun(context, request));
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: createdAtMs }) },
+			]);
+
+			const existingRunId = await service.createWorkflowRun(context, request);
+			expect(existingRunId).toBe(runId);
+
+			expect(await timerPriorityQueue.peekNext()).toBeNull();
+		}));
+
+	test("cancelling a parent with a live child adds the cancellation run's timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			const childInput = { orderId: "order-9" };
+			const childInputHash = await hashInput(childInput);
+			const childCreatedAtMs = Date.now();
+			const childRunId = await withFakeClock(childCreatedAtMs, () =>
+				service.createWorkflowRun(context, {
+					name: parent.workflowName,
+					versionId: parent.workflowVersionId,
+					input: childInput,
+					inputHash: childInputHash,
+					parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
+				})
+			);
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: childRunId, rank: computeRank({ dueAt: childCreatedAtMs }) },
+			]);
+
+			const cancelledAtMs = childCreatedAtMs + 5;
+			await withFakeClock(cancelledAtMs, () => service.cancelByIds(context, { ids: [parent.runId] }));
+
+			const scheduledRuns = await repos.workflowRun.listByFilters(
+				{ namespaceId: context.namespaceId, status: ["scheduled"] },
+				10,
+				0,
+				{ order: "asc" }
+			);
+			const cancellationRun = scheduledRuns.rows.find((row) => row.id !== childRunId);
+			if (!cancellationRun) {
+				throw new Error("cancel-child-runs run was not scheduled");
+			}
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: cancellationRun.id, rank: computeRank({ dueAt: cancelledAtMs }) },
 			]);
 		}));
 });

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -38,6 +38,7 @@ import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { EventWaitRow, EventWaitRowInsert } from "../infra/db/types/event-wait";
 import type { SleepRow } from "../infra/db/types/sleep";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../middleware/context";
 import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
@@ -46,18 +47,22 @@ export interface WorkflowRunServiceDeps {
 	repos: Repositories;
 	childRunCanceller: ChildRunCanceller;
 	workflowRunStateMachine: WorkflowRunStateMachine;
+	imminentRunTimerQueue?: ImminentRunTimerQueue;
 }
 
 export const createWorkflowRunService = ({
 	repos,
 	childRunCanceller,
 	workflowRunStateMachine,
+	imminentRunTimerQueue,
 }: WorkflowRunServiceDeps) => ({
 	async createWorkflowRun(
 		context: NamespaceRequestContext,
 		request: WorkflowRunCreateRequestV1
 	): Promise<WorkflowRunId> {
-		return repos.transaction(async (txRepos) => createWorkflowRunInTx(context, request, txRepos));
+		return repos.transaction(async (txRepos) =>
+			createWorkflowRunInTx(context, request, txRepos, imminentRunTimerQueue)
+		);
 	},
 
 	async getWorkflowRunById(context: NamespaceRequestContext, id: string): Promise<WorkflowRunRecord> {
@@ -318,7 +323,8 @@ export type WorkflowRunService = ReturnType<typeof createWorkflowRunService>;
 async function createWorkflowRunInTx(
 	{ namespaceId, logger }: NamespaceRequestContext,
 	request: WorkflowRunCreateRequestV1,
-	txRepos: TxRepositories
+	txRepos: TxRepositories,
+	imminentRunTimerQueue?: ImminentRunTimerQueue
 ): Promise<WorkflowRunId> {
 	const name = request.name as WorkflowName;
 	const versionId = request.versionId as WorkflowVersionId;
@@ -399,6 +405,10 @@ async function createWorkflowRunInTx(
 		attempt: 1,
 		state,
 	});
+
+	if (imminentRunTimerQueue) {
+		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt }]));
+	}
 
 	logger.info("Created workflow run", {
 		"aiki.workflowName": name,

--- a/types/src/infra/timer.ts
+++ b/types/src/infra/timer.ts
@@ -43,7 +43,7 @@ export interface TimerPriorityQueue {
 
 export interface TimerPriorityQueueContext {
 	logger: Logger;
-	signal: AbortSignal;
+	signal?: AbortSignal;
 }
 
 export type CreateTimerPriorityQueue = (context: TimerPriorityQueueContext) => TimerPriorityQueue;


### PR DESCRIPTION
## Background

`scheduled` state is where the request path parks a run until its `scheduledAt`: creation inserts new runs there (due now or after a delay), and a request that wakes a parked run — resume, early wakeup, event, child completion, requeue — moves it there too. The scheduled-runs promoter daemon polls for due ones and moves them to `queued`. Clock-driven wakes — sleep elapsed, retry due, wait timeouts — skip `scheduled` and move straight to `queued`.

With a timer priority queue configured, promoter daemons also enqueue near-term timers and a consumer fires each at its due time — but only the promoters feed the queue, so a newly created due-now run still waits for a poll tick before it gets `queued`.

## Problem

```
t=0        createV1 → run inserted, scheduled, due now
t=0..1s    nothing — waiting for the poll
t=~1s      poll: scheduled → queued → published → worker starts
```

The poll was the only thing watching for these entries, so its 1s interval *was* the pickup latency — and it couldn't relax without making things worse.

## Solution

The request that parks a due-soon run already knows everything the poll would later rediscover. So the parking write now hands the timer to the priority queue itself, and the poll becomes a backstop:

```
t=0        createV1 → run inserted, scheduled, due now → commit
t=0        onCommit → timer added → consumer wakes
t<100ms    consumer: scheduled → queued → published → worker starts
```

Three code sites cover every entry into `scheduled`: creation, the state machine, and the child-run canceller. The add happens strictly after commit — a rolled-back run must not wake the consumer, and some of these sites run inside transactions they don't own — so transactions gain an `onCommit` hook:

```ts
txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt }]));
```

Runs due beyond a lookahead window are skipped, and the add is fired without awaiting: a failed add costs latency only, because the poll still catches the run.

Two wiring consequences. `timerPriorityQueue` moves from the runtime params to the top of `server()`, so the handler can enqueue too and both halves share one queue. The handler gains a small config holding the lookahead window (default 30s). And with the request path carrying the latency, the polls relax: daemon intervals 1s → 10s, promoter lookaheads 3s → 30s.

## Breaking changes

`timerPriorityQueue` moved from `ServerRuntimeParams` to `ServerParams`. `ServerHandlerParams` gains an optional `config` (`ServerHandlerConfig` with `imminentRuns.lookaheadWindowMs`). Default polling cadence changed (1s → 10s intervals, 3s → 30s lookaheads) — deployments without a timer priority queue see slower default pickup; configure a queue or tighten the intervals. `TimerPriorityQueueContext.signal` is now optional.