### PR TITLE
Restore the output key on completed task reads

### DIFF
--- a/sdk/server/src/infra/db/pg/repository/state-transition.ts
+++ b/sdk/server/src/infra/db/pg/repository/state-transition.ts
@@ -110,9 +110,6 @@ export function toWorkflowRunState(raw: unknown): WorkflowRunState {
 
 export function toTaskState(raw: unknown): TaskState {
 	const state = raw as Record<string, unknown>;
-	if (state.status === "running" && !("input" in state)) {
-		state.input = undefined;
-	}
 	if (state.status === "completed" && !("output" in state)) {
 		state.output = undefined;
 	}

--- a/sdk/server/src/infra/db/pg/repository/task.ts
+++ b/sdk/server/src/infra/db/pg/repository/task.ts
@@ -51,7 +51,8 @@ export const createTaskRepository = (db: PgDb) => ({
 			.where(and(eq(workflowRun.namespaceId, namespaceId), eq(task.id, id)))
 			.limit(1);
 
-		return result[0] ?? null;
+		const row = result[0];
+		return row ? { ...row, state: toTaskState(row.state) } : null;
 	},
 
 	async update(

--- a/sdk/server/src/infra/db/task.integration.test.ts
+++ b/sdk/server/src/infra/db/task.integration.test.ts
@@ -5,6 +5,25 @@ import { seedCompletedTask, seedRunningTask } from "../../testing/seed/task";
 
 const withHarness = createServiceHarness();
 
+describe("task repository state reads", () => {
+	test("getByIdWithState returns a completed state carrying the output key", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { taskInfo } = await seedCompletedTask(
+				{
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				},
+				{ output: undefined }
+			);
+
+			const row = await repos.task.getByIdWithState(context.namespaceId, taskInfo.id);
+
+			expect(row?.state).toContainKey("output");
+			expect(row?.state).toEqual({ status: "completed", attempts: 1, output: undefined });
+		}));
+});
+
 describe("task repository compare-and-swap guards", () => {
 	test("update leaves the task untouched when the expected status does not match", () =>
 		withHarness(async ({ context, repos, publisher }) => {

--- a/sdk/server/src/infra/db/workflow-run.integration.test.ts
+++ b/sdk/server/src/infra/db/workflow-run.integration.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { createServiceHarness } from "../../testing/harness";
+import { seedCompletedRun } from "../../testing/seed/run";
+
+const withHarness = createServiceHarness();
+
+describe("workflow run repository state reads", () => {
+	test("getByIdWithWorkflowAndState returns a completed state carrying the output key", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedCompletedRun(
+				{
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				},
+				{ output: undefined }
+			);
+
+			const row = await repos.workflowRun.getByIdWithWorkflowAndState({ namespaceId: context.namespaceId, id: runId });
+
+			expect(row?.state).toContainKey("output");
+			expect(row?.state).toEqual({ status: "completed", output: undefined });
+		}));
+
+	test("getByIdWithState returns a completed state carrying the output key", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedCompletedRun(
+				{
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				},
+				{ output: undefined }
+			);
+
+			const row = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+
+			expect(row?.state).toContainKey("output");
+			expect(row?.state).toEqual({ status: "completed", output: undefined });
+		}));
+
+	test("getByReferenceWithWorkflowAndState returns a completed state carrying the output key", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const referenceId = "order-7-ref";
+			const { workflowName, workflowVersionId, workflowSource } = await seedCompletedRun(
+				{
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				},
+				{ output: undefined, options: { reference: { id: referenceId } } }
+			);
+
+			const row = await repos.workflowRun.getByReferenceWithWorkflowAndState({
+				namespaceId: context.namespaceId,
+				name: workflowName,
+				versionId: workflowVersionId,
+				source: workflowSource,
+				referenceId,
+			});
+
+			expect(row?.state).toContainKey("output");
+			expect(row?.state).toEqual({ status: "completed", output: undefined });
+		}));
+});

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -33,7 +33,7 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 			input: task.input,
 			inputHash: task.inputHash,
 			options: task.options !== null ? task.options : undefined,
-			state: task.state as TaskState,
+			state: task.state,
 		};
 	},
 

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -1,6 +1,7 @@
 import { hashInput } from "@aikirun/lib/crypto";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { FakePublisher } from "@aikirun/testing/infra/queue";
+import type { WorkflowStartOptions } from "@aikirun/types/workflow/run";
 
 import { defaultServerRuntimeConfig } from "../../config/runtime";
 import { processImminentScheduledRuns } from "../../daemon/imminent-scheduled-runs";
@@ -15,6 +16,8 @@ import { withFakeClock } from "../clock";
 import { daemonContextFactory, namespaceRequestContextFactory } from "../data-factory/middleware/context";
 
 const seededWorkflow = { source: "user", name: "ship-orders", versionId: "v2" } as const;
+
+const seededRunOutput = { receiptId: "rcp-3" } as const;
 
 const publishPendingOutboxEntriesDaemonConfig = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
 
@@ -35,19 +38,19 @@ export interface SeedRunDeps {
 	namespaceRequestContext?: NamespaceRequestContext;
 }
 
-export async function seedScheduledRun(deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">) {
-	return _seedScheduledRun(deps, undefined);
+interface SeedRunOverrides {
+	options?: WorkflowStartOptions;
 }
 
 export async function seedPooledScheduledRun(deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">) {
 	const pool = "warehouse-eu";
-	const seeded = await _seedScheduledRun(deps, pool);
+	const seeded = await seedScheduledRun(deps, { options: { pool } });
 	return { ...seeded, pool };
 }
 
-async function _seedScheduledRun(
+export async function seedScheduledRun(
 	deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">,
-	pool: string | undefined
+	overrides?: SeedRunOverrides
 ) {
 	const { repos } = deps;
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
@@ -59,27 +62,23 @@ async function _seedScheduledRun(
 		versionId: seededWorkflow.versionId,
 		input,
 		inputHash: await hashInput(input),
-		options: pool ? { pool } : undefined,
+		options: overrides?.options,
 	});
 
 	return { runId, revisionWhenScheduled: 0, attemptsWhenScheduled: 1 };
 }
 
-export async function seedQueuedRun(deps: SeedRunDeps) {
-	return _seedQueuedRun(deps, undefined);
-}
-
 export async function seedPooledQueuedRun(deps: SeedRunDeps) {
 	const pool = "warehouse-eu";
-	const seeded = await _seedQueuedRun(deps, pool);
+	const seeded = await seedQueuedRun(deps, { options: { pool } });
 	return { ...seeded, pool };
 }
 
-async function _seedQueuedRun(deps: SeedRunDeps, pool: string | undefined) {
+export async function seedQueuedRun(deps: SeedRunDeps, overrides?: SeedRunOverrides) {
 	const { repos } = deps;
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
 
-	const { runId } = await _seedScheduledRun({ repos, namespaceRequestContext }, pool);
+	const { runId } = await seedScheduledRun({ repos, namespaceRequestContext }, overrides);
 
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 
@@ -125,16 +124,37 @@ export async function claimRun(deps: { context: NamespaceRequestContext; repos: 
 	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };
 }
 
-export async function seedClaimedRun(deps: SeedRunDeps & { publisher: FakePublisher }) {
+export async function seedClaimedRun(deps: SeedRunDeps & { publisher: FakePublisher }, overrides?: SeedRunOverrides) {
 	const { repos, publisher } = deps;
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
-	const seeded = await seedQueuedRun(deps);
+	const seeded = await seedQueuedRun(deps, overrides);
 
 	await publishPendingOutboxEntries(daemonContext, { repos, publisher }, publishPendingOutboxEntriesDaemonConfig);
 
 	const claim = await claimRun({ context: namespaceRequestContext, repos, runId: seeded.runId });
 	return { ...seeded, ...claim };
+}
+
+export async function seedCompletedRun(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	overrides?: SeedRunOverrides & { output?: unknown }
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedClaimedRun({ ...deps, namespaceRequestContext }, overrides);
+
+	const output = overrides && "output" in overrides ? overrides.output : seededRunOutput;
+
+	const services = createServices(repos);
+	await services.workflowRunStateMachine.transitionState(namespaceRequestContext, {
+		type: "optimistic",
+		id: seeded.runId,
+		state: { status: "completed", output },
+		expectedRevision: seeded.revisionWhenClaimed,
+	});
+
+	return { ...seeded, runOutput: output };
 }
 
 export async function seedPublishedRun(deps: SeedRunDeps & { publisher: FakePublisher }) {

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -29,18 +29,23 @@ export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePubli
 	return { ...seeded, taskInfo, taskInput: seededTask.input };
 }
 
-export async function seedCompletedTask(deps: SeedRunDeps & { publisher: FakePublisher }) {
+export async function seedCompletedTask(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	overrides?: { output: unknown }
+) {
 	const { repos } = deps;
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
 	const seeded = await seedRunningTask({ ...deps, namespaceRequestContext });
+
+	const output = overrides ? overrides.output : seededTask.output;
 
 	const taskStateMachine = createTaskStateMachine({ repos });
 	const taskInfo = await taskStateMachine.transitionState(namespaceRequestContext, {
 		id: seeded.taskInfo.id,
 		workflowRunId: seeded.runId,
 		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
-		taskState: { status: "completed", attempts: 1, output: seededTask.output },
+		taskState: { status: "completed", attempts: 1, output },
 	});
 
-	return { ...seeded, taskInfo };
+	return { ...seeded, taskInfo, taskOutput: output };
 }


### PR DESCRIPTION
## Problem

Task and workflow run state is stored as JSONB on the row recording the latest state transition. JSONB cannot represent `undefined`, so a key holding it is dropped on write. A task that completes without returning a value is written as `{ status: "completed", attempts: 1, output: undefined }` and read back as `{ status: "completed", attempts: 1 }`.

`toTaskState` and `toWorkflowRunState` put those keys back on read, so state leaving the repository matches its domain type. Every read that returns state runs one of them, apart from the task record read, which returned the query row unchanged and was cast to the domain type by the service above it.

The task record's response schema requires `output` on a completed state, and a required key fails validation when it is absent — even where the declared type is `unknown`. So loading a task that completed with no output failed response validation and returned a 500. In the dashboard that read backs the task card dropdown, which fetches a single task by id. The three workflow run reads all normalize, so runs were never affected.

## Solution

The task record read normalizes its state like every other read, which also drops the cast in the service.

`toTaskState` additionally restored an `input` key on running task states. A running task state carries no `input` — not in the type, not in the schema — so that branch is gone.