### PR TITLE
Introduce a custom hasher to support encryption

### DIFF
--- a/lib/src/crypto/hash.test.ts
+++ b/lib/src/crypto/hash.test.ts
@@ -1,4 +1,4 @@
-import { hashInput, sha256, sha256Async } from "./hash";
+import { hashInput, plainHasher, sha256, sha256Async } from "./hash";
 import { describe, expect, test } from "bun:test";
 
 const helloHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
@@ -41,5 +41,18 @@ describe("hashInput", () => {
 		const result1 = await hashInput({ name: "alice" });
 		const result2 = await hashInput({ name: "bob" });
 		expect(result1).not.toBe(result2);
+	});
+});
+
+describe("plainHasher", () => {
+	test("wraps hashInput as an InputHash value", async () => {
+		const input = { name: "alice" };
+		const expectedValue = await hashInput(input);
+		expect(await plainHasher(input)).toEqual({ value: expectedValue });
+	});
+
+	test("for always returns hashInput", async () => {
+		expect(await plainHasher.for("any-stored-hash")).toBe(hashInput);
+		expect(await plainHasher.for("another-stored-hash")).toBe(hashInput);
 	});
 });

--- a/lib/src/crypto/hash.ts
+++ b/lib/src/crypto/hash.ts
@@ -28,3 +28,9 @@ export async function sha256Async(input: string): Promise<string> {
 export async function hashInput(input: unknown): Promise<string> {
 	return sha256Async(stableStringify({ input }));
 }
+
+export async function plainHasher(input: unknown): Promise<{ value: string }> {
+	return { value: await hashInput(input) };
+}
+
+plainHasher.for = async (_hash: string) => hashInput;

--- a/sdk/client/src/client.ts
+++ b/sdk/client/src/client.ts
@@ -1,3 +1,4 @@
+import { plainHasher } from "@aikirun/lib/crypto";
 import { createConsoleLogger } from "@aikirun/lib/logger";
 import type { ApiClient, Client, ClientParams, EmbeddedClientParams, RemoteClientParams } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
@@ -35,6 +36,7 @@ export function client<Context = null>(params: RemoteClientParams<Context>): Cli
 export function client<Context = null>(params: EmbeddedClientParams<Context>): Client<Context>;
 export function client<Context = null>(params: ClientParams<Context>): Client<Context> {
 	const logger = params.logger ?? createConsoleLogger();
+	const hasher = params.hasher?.({ logger }) ?? plainHasher;
 
 	const rpcLink = isEmbeddedParams(params)
 		? new RPCLink({
@@ -64,6 +66,7 @@ export function client<Context = null>(params: ClientParams<Context>): Client<Co
 		logger,
 		[INTERNAL]: {
 			context: params.context,
+			hasher,
 		},
 	};
 }

--- a/sdk/server/src/contract/procedure/schedule.ts
+++ b/sdk/server/src/contract/procedure/schedule.ts
@@ -17,6 +17,7 @@ import { oc } from "@orpc/contract";
 import { type } from "arktype";
 
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
+import { inputHashSchema } from "../schema/hash";
 import {
 	scheduleActivateOptionsSchema,
 	scheduleSchema,
@@ -32,10 +33,7 @@ const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateR
 			workflowName: "string > 0",
 			workflowVersionId: "string > 0",
 			"workflowRunInput?": "unknown",
-			workflowRunInputHash: {
-				value: "string > 0",
-				"deprecatedValues?": type("string > 0").array().or("undefined"),
-			},
+			workflowRunInputHash: inputHashSchema,
 			spec: scheduleSpecSchema,
 			"options?": scheduleActivateOptionsSchema.or("undefined"),
 			"workflowRunOptions?": workflowRunOptionsSchema.or("undefined"),

--- a/sdk/server/src/contract/procedure/schedule.ts
+++ b/sdk/server/src/contract/procedure/schedule.ts
@@ -32,7 +32,10 @@ const activateV1: ContractProcedure<ScheduleActivateRequestV1, ScheduleActivateR
 			workflowName: "string > 0",
 			workflowVersionId: "string > 0",
 			"workflowRunInput?": "unknown",
-			workflowRunInputHash: "string > 0",
+			workflowRunInputHash: {
+				value: "string > 0",
+				"deprecatedValues?": type("string > 0").array().or("undefined"),
+			},
 			spec: scheduleSpecSchema,
 			"options?": scheduleActivateOptionsSchema.or("undefined"),
 			"workflowRunOptions?": workflowRunOptionsSchema.or("undefined"),

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -32,6 +32,7 @@ import { oc } from "@orpc/contract";
 import { type } from "arktype";
 
 import type { ContractProcedure, ContractProcedureToApi } from "./helper";
+import { inputHashSchema } from "../schema/hash";
 import { stateTransitionSchema } from "../schema/state-transition";
 import { workflowSourceSchema } from "../schema/workflow";
 import {
@@ -156,7 +157,7 @@ const createV1: ContractProcedure<WorkflowRunCreateRequestV1, WorkflowRunCreateR
 			name: "string > 0",
 			versionId: "string > 0",
 			"input?": "unknown",
-			inputHash: "string > 0",
+			inputHash: inputHashSchema,
 			"parent?": type({ workflowRunId: "string > 0", expectedRevision: "number.integer >= 0" }).or("undefined"),
 			"options?": workflowStartOptionsSchema,
 		})

--- a/sdk/server/src/contract/schema/hash.ts
+++ b/sdk/server/src/contract/schema/hash.ts
@@ -1,0 +1,6 @@
+import { type } from "arktype";
+
+export const inputHashSchema = type({
+	value: "string > 0",
+	"deprecatedValues?": type("string > 0").array().or("undefined"),
+});

--- a/sdk/server/src/contract/schema/task.ts
+++ b/sdk/server/src/contract/schema/task.ts
@@ -63,6 +63,7 @@ export const taskSetStateRequestSchema = type({
 	workflowRunId: "string > 0",
 	taskName: "string > 0",
 	"input?": "unknown",
+	inputHash: "string > 0",
 	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),
 }).or({
 	type: "'existing'",

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -99,15 +99,15 @@ export const createScheduleRepository = (db: PgDb) => ({
 
 	async get(
 		namespaceId: NamespaceId,
-		filter: { id?: string; definitionHash?: string; referenceId?: string | null }
+		filter: { id?: string; definitionHashes?: string[]; referenceId?: string | null }
 	): Promise<ScheduleRow | null> {
 		const conditions = [eq(schedule.namespaceId, namespaceId)];
 
 		if (filter.id) {
 			conditions.push(eq(schedule.id, filter.id));
 		}
-		if (filter.definitionHash) {
-			conditions.push(eq(schedule.definitionHash, filter.definitionHash));
+		if (filter.definitionHashes && filter.definitionHashes.length > 0) {
+			conditions.push(inArray(schedule.definitionHash, filter.definitionHashes));
 		}
 		if (filter.referenceId !== undefined) {
 			if (filter.referenceId === null) {
@@ -122,6 +122,7 @@ export const createScheduleRepository = (db: PgDb) => ({
 			.from(schedule)
 			.where(and(...conditions))
 			.limit(1);
+
 		return result[0] ?? null;
 	},
 

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -142,4 +142,38 @@ describe("ScheduleService activateSchedule", () => {
 
 			expect(matched.id).toBe(created.id);
 		}));
+
+	test("stores the current input hash after matching a referenced schedule via a deprecated value", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const spec = { type: "interval" as const, everyMs: 60_000 };
+			const previousHash = "previous-hash";
+			const currentHash = await hashInput(workflowRunInput);
+			const options = { reference: { id: "invoices-eu-west" } };
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: previousHash },
+				spec,
+				options,
+			});
+			const stored = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			expect(stored).toEqual(expect.objectContaining({ workflowRunInputHash: previousHash }));
+
+			await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: currentHash, deprecatedValues: [previousHash] },
+				spec,
+				options,
+			});
+
+			const migrated = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			expect(migrated).toEqual(expect.objectContaining({ id: schedule.id, workflowRunInputHash: currentHash }));
+			expect(migrated?.definitionHash).not.toBe(stored?.definitionHash);
+		}));
 });

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -15,7 +15,7 @@ describe("ScheduleService activateSchedule", () => {
 				workflowName: "send-invoices",
 				workflowVersionId: "v1",
 				workflowRunInput,
-				workflowRunInputHash: await hashInput(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
 				spec: { type: "cron", expression: "0 9 * * *", timezone: "Europe/Berlin" },
 			});
 
@@ -26,5 +26,120 @@ describe("ScheduleService activateSchedule", () => {
 				timezone: "Europe/Berlin",
 				overlapPolicy: undefined,
 			});
+		}));
+
+	test("matches an existing schedule by a deprecated input hash", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const spec = { type: "interval" as const, everyMs: 60_000 };
+			const previousHash = "previous-hash";
+
+			const { schedule: created } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: previousHash },
+				spec,
+			});
+
+			const { schedule: matched } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: {
+					value: await hashInput(workflowRunInput),
+					deprecatedValues: [previousHash],
+				},
+				spec,
+			});
+
+			expect(matched.id).toBe(created.id);
+		}));
+
+	test("stores the current input hash after matching via a deprecated value", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const spec = { type: "interval" as const, everyMs: 60_000 };
+			const previousHash = "previous-hash";
+			const currentHash = await hashInput(workflowRunInput);
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: previousHash },
+				spec,
+			});
+			const stored = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			expect(stored).toEqual(expect.objectContaining({ workflowRunInputHash: previousHash }));
+
+			await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: currentHash, deprecatedValues: [previousHash] },
+				spec,
+			});
+
+			const migrated = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			expect(migrated).toEqual(expect.objectContaining({ id: schedule.id, workflowRunInputHash: currentHash }));
+			expect(migrated?.definitionHash).not.toBe(stored?.definitionHash);
+		}));
+
+	test("creates a distinct schedule when the input hash is new and has no deprecated values", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const spec = { type: "interval" as const, everyMs: 60_000 };
+
+			const { schedule: previous } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: "previous-hash" },
+				spec,
+			});
+			const { schedule: current } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				spec,
+			});
+
+			expect(current.id).not.toBe(previous.id);
+		}));
+
+	test("treats a referenced schedule as the same definition when the stored hash is deprecated", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const spec = { type: "interval" as const, everyMs: 60_000 };
+			const previousHash = "previous-hash";
+			const options = { reference: { id: "invoices-eu-west" } };
+
+			const { schedule: created } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: previousHash },
+				spec,
+				options,
+			});
+			const { schedule: matched } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: {
+					value: await hashInput(workflowRunInput),
+					deprecatedValues: [previousHash],
+				},
+				spec,
+				options,
+			});
+
+			expect(matched.id).toBe(created.id);
 		}));
 });

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -1,11 +1,10 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
-import { sha256Async } from "@aikirun/lib/crypto";
+import { hashInput } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
-import { stableStringify } from "@aikirun/lib/json";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { ScheduleActivateRequestV1, ScheduleListRequestV1 } from "@aikirun/types/api/schedule";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type { Schedule, ScheduleId, ScheduleSpec, ScheduleStatus } from "@aikirun/types/schedule";
+import type { Schedule, ScheduleSpec, ScheduleStatus } from "@aikirun/types/schedule";
 import type { WorkflowName, WorkflowSource, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 import CronExpressionParser from "cron-parser";
@@ -121,17 +120,8 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		namespaceId: NamespaceId,
 		request: ScheduleActivateRequestV1
 	): Promise<{ schedule: Schedule }> {
-		const { workflowName, workflowVersionId, workflowRunInputHash, workflowRunOptions, spec } = request;
-		const definitionHash = await sha256Async(
-			stableStringify({
-				workflowName,
-				workflowVersionId,
-				spec,
-				workflowRunInputHash,
-				workflowRunOptions,
-			})
-		);
-		return repos.transaction(async (txRepos) => activateScheduleInTx(namespaceId, request, definitionHash, txRepos));
+		const definition = await hashScheduleDefinitions(request);
+		return repos.transaction(async (txRepos) => activateScheduleInTx(namespaceId, request, definition, txRepos));
 	},
 
 	async getScheduleById(namespaceId: NamespaceId, id: string) {
@@ -218,14 +208,38 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 
 export type ScheduleService = ReturnType<typeof createScheduleService>;
 
+async function hashScheduleDefinitions(request: ScheduleActivateRequestV1): Promise<{
+	currentHash: string;
+	candidateHashes: string[];
+}> {
+	const { workflowName, workflowVersionId, workflowRunInputHash, workflowRunOptions, spec } = request;
+	const hashDefinition = (inputHash: string) =>
+		hashInput({
+			workflowName,
+			workflowVersionId,
+			spec,
+			workflowRunInputHash: inputHash,
+			workflowRunOptions,
+		});
+
+	const [currentHash, ...deprecatedHashes] = await Promise.all([
+		hashDefinition(workflowRunInputHash.value),
+		...(workflowRunInputHash.deprecatedValues ?? []).map(hashDefinition),
+	]);
+
+	return { currentHash, candidateHashes: Array.from(new Set([currentHash].concat(deprecatedHashes))) };
+}
+
 async function activateScheduleInTx(
 	namespaceId: NamespaceId,
 	request: ScheduleActivateRequestV1,
-	definitionHash: string,
+	definition: { currentHash: string; candidateHashes: string[] },
 	txRepos: TxRepositories
 ) {
 	const { workflowName, workflowVersionId, workflowRunInput, workflowRunInputHash, workflowRunOptions, spec, options } =
 		request;
+	const definitionHash = definition.currentHash;
+	const workflowRunInputHashValue = workflowRunInputHash.value;
 
 	const referenceId = options?.reference?.id;
 	const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
@@ -242,22 +256,24 @@ async function activateScheduleInTx(
 	const nextRunAt = getNextOccurrence(spec, now) as TimestampMs;
 
 	if (!referenceId) {
-		const existingScheduleByDefinition = await txRepos.schedule.get(namespaceId, { definitionHash });
+		const existingScheduleByDefinition = await txRepos.schedule.get(namespaceId, {
+			definitionHashes: definition.candidateHashes,
+		});
 
 		const schedule = existingScheduleByDefinition
-			? existingScheduleByDefinition.status === "active"
-				? existingScheduleByDefinition
-				: await reactivateSchedule(txRepos.schedule, {
-						namespaceId,
-						scheduleId: existingScheduleByDefinition.id as ScheduleId,
-						nextRunAt,
-					})
+			? await reuseSchedule(txRepos.schedule, {
+					namespaceId,
+					existing: existingScheduleByDefinition,
+					workflowRunInputHash: workflowRunInputHashValue,
+					definitionHash,
+					nextRunAt,
+				})
 			: await createSchedule(txRepos.schedule, {
 					namespaceId,
 					workflowId: workflowRow.id,
 					spec,
 					workflowRunInput,
-					workflowRunInputHash,
+					workflowRunInputHash: workflowRunInputHashValue,
 					definitionHash,
 					referenceId: undefined,
 					workflowRunOptions,
@@ -269,7 +285,7 @@ async function activateScheduleInTx(
 
 	const existingScheduleByReference = await txRepos.schedule.get(namespaceId, { referenceId });
 	if (existingScheduleByReference) {
-		if (existingScheduleByReference.definitionHash !== definitionHash) {
+		if (!definition.candidateHashes.includes(existingScheduleByReference.definitionHash)) {
 			if (conflictPolicy === "error") {
 				throw new ScheduleConflictError({ definitionHash, referenceId });
 			}
@@ -277,23 +293,23 @@ async function activateScheduleInTx(
 			return { schedule: scheduleRowToDomain(existingScheduleByReference, workflowInfo) };
 		}
 
-		const schedule =
-			existingScheduleByReference.status === "active"
-				? existingScheduleByReference
-				: await reactivateSchedule(txRepos.schedule, {
-						namespaceId,
-						scheduleId: existingScheduleByReference.id as ScheduleId,
-						nextRunAt,
-					});
+		const schedule = await reuseSchedule(txRepos.schedule, {
+			namespaceId,
+			existing: existingScheduleByReference,
+			workflowRunInputHash: workflowRunInputHashValue,
+			definitionHash,
+			nextRunAt,
+		});
 
 		return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 	}
 
 	// Reference id is free, but the definition may already exist.
 	const existingNonReferencedSchedule = await txRepos.schedule.get(namespaceId, {
-		definitionHash,
+		definitionHashes: definition.candidateHashes,
 		referenceId: null,
 	});
+
 	if (existingNonReferencedSchedule) {
 		const schedule = await txRepos.schedule.update(
 			namespaceId,
@@ -302,8 +318,11 @@ async function activateScheduleInTx(
 				referenceId,
 				status: "active",
 				nextRunAt,
+				workflowRunInputHash: workflowRunInputHashValue,
+				definitionHash,
 			}
 		);
+
 		if (schedule) {
 			return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 		}
@@ -314,30 +333,58 @@ async function activateScheduleInTx(
 		workflowId: workflowRow.id,
 		spec,
 		workflowRunInput,
-		workflowRunInputHash,
+		workflowRunInputHash: workflowRunInputHashValue,
 		definitionHash,
 		referenceId,
 		workflowRunOptions,
 		nextRunAt,
 	});
+
 	return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 }
 
-async function reactivateSchedule(
+async function reuseSchedule(
 	repo: Repositories["schedule"],
-	params: { namespaceId: NamespaceId; scheduleId: ScheduleId; nextRunAt: TimestampMs }
-): Promise<ScheduleRow> {
-	const updatedRow = await repo.update(
-		params.namespaceId,
-		{ id: params.scheduleId },
-		{
-			status: "active",
-			nextRunAt: params.nextRunAt,
-		}
-	);
-	if (!updatedRow) {
-		throw new NotFoundError(`Schedule not found: ${params.scheduleId}`);
+	params: {
+		namespaceId: NamespaceId;
+		existing: ScheduleRow;
+		workflowRunInputHash: string;
+		definitionHash: string;
+		nextRunAt: TimestampMs;
 	}
+): Promise<ScheduleRow> {
+	const needsActivation = params.existing.status !== "active";
+	const hashesChanged =
+		params.existing.workflowRunInputHash !== params.workflowRunInputHash ||
+		params.existing.definitionHash !== params.definitionHash;
+
+	if (!needsActivation && !hashesChanged) {
+		return params.existing;
+	}
+
+	const updates: {
+		status?: "active";
+		nextRunAt?: TimestampMs;
+		workflowRunInputHash?: string;
+		definitionHash?: string;
+	} = {};
+
+	if (needsActivation) {
+		updates.status = "active";
+		updates.nextRunAt = params.nextRunAt;
+	}
+
+	if (hashesChanged) {
+		updates.workflowRunInputHash = params.workflowRunInputHash;
+		updates.definitionHash = params.definitionHash;
+	}
+
+	const updatedRow = await repo.update(params.namespaceId, { id: params.existing.id }, updates);
+
+	if (!updatedRow) {
+		throw new NotFoundError(`Schedule not found: ${params.existing.id}`);
+	}
+
 	return updatedRow;
 }
 

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -237,10 +237,9 @@ async function activateScheduleInTx(
 	definition: { currentHash: string; candidateHashes: string[] },
 	txRepos: TxRepositories
 ) {
-	const { workflowName, workflowVersionId, workflowRunInput, workflowRunInputHash, workflowRunOptions, spec, options } =
-		request;
+	const { workflowName, workflowVersionId, workflowRunInput, workflowRunOptions, spec, options } = request;
 	const definitionHash = definition.currentHash;
-	const workflowRunInputHashValue = workflowRunInputHash.value;
+	const workflowRunInputHash = request.workflowRunInputHash.value;
 
 	const referenceId = options?.reference?.id;
 	const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
@@ -265,7 +264,7 @@ async function activateScheduleInTx(
 			? await reuseSchedule(txRepos.schedule, {
 					namespaceId,
 					existing: existingScheduleByDefinition,
-					workflowRunInputHash: workflowRunInputHashValue,
+					workflowRunInputHash: workflowRunInputHash,
 					definitionHash,
 					nextRunAt,
 				})
@@ -274,7 +273,7 @@ async function activateScheduleInTx(
 					workflowId: workflowRow.id,
 					spec,
 					workflowRunInput,
-					workflowRunInputHash: workflowRunInputHashValue,
+					workflowRunInputHash: workflowRunInputHash,
 					definitionHash,
 					referenceId: undefined,
 					workflowRunOptions,
@@ -297,7 +296,7 @@ async function activateScheduleInTx(
 		const schedule = await reuseSchedule(txRepos.schedule, {
 			namespaceId,
 			existing: existingScheduleByReference,
-			workflowRunInputHash: workflowRunInputHashValue,
+			workflowRunInputHash: workflowRunInputHash,
 			definitionHash,
 			nextRunAt,
 		});
@@ -319,7 +318,7 @@ async function activateScheduleInTx(
 				referenceId,
 				status: "active",
 				nextRunAt,
-				workflowRunInputHash: workflowRunInputHashValue,
+				workflowRunInputHash: workflowRunInputHash,
 				definitionHash,
 			}
 		);
@@ -334,7 +333,7 @@ async function activateScheduleInTx(
 		workflowId: workflowRow.id,
 		spec,
 		workflowRunInput,
-		workflowRunInputHash: workflowRunInputHashValue,
+		workflowRunInputHash: workflowRunInputHash,
 		definitionHash,
 		referenceId,
 		workflowRunOptions,

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -214,6 +214,7 @@ async function hashScheduleDefinitions(request: ScheduleActivateRequestV1): Prom
 }> {
 	const { workflowName, workflowVersionId, workflowRunInputHash, workflowRunOptions, spec } = request;
 	const hashDefinition = (inputHash: string) =>
+		// insecure hashing is safe here as workflowRunInputHash already has keyed hashing
 		hashInput({
 			workflowName,
 			workflowVersionId,

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -70,6 +70,37 @@ describe("TaskService getTaskById", () => {
 });
 
 describe("TaskService setTaskState", () => {
+	test("creates a new task with the request's input hash and terminal state", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const input = { sku: "SKU-42", quantity: 3 };
+			const inputHash = "request-input-hash";
+			const output = { reservationId: "rsv-1" };
+
+			const taskService = createTaskService({ repos });
+			await taskService.setTaskState(context, {
+				type: "new",
+				workflowRunId: runId,
+				taskName: "reserve-inventory",
+				input,
+				inputHash,
+				state: { status: "completed", output },
+			});
+
+			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([
+				expect.objectContaining({
+					name: "reserve-inventory",
+					inputHash,
+					state: { status: "completed", attempts: 1, output },
+				}),
+			]);
+		}));
+
 	test("does not set the state of a task belonging to another run", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const otherNamespaceContext = namespaceRequestContextFactory.build({ namespaceId: "other-ns" as NamespaceId });

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -1,4 +1,3 @@
-import { hashInput } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
 import type {
 	TaskSetStateRequestExisting,
@@ -39,8 +38,7 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 
 	async setTaskState(context: NamespaceRequestContext, request: TaskSetStateRequestV1): Promise<void> {
 		if (request.type === "new") {
-			const inputHash = await hashInput(request.input);
-			return repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, inputHash, txRepos));
+			return repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, txRepos));
 		}
 		return repos.transaction(async (txRepos) => setExistingTaskStateInTx(context, request, txRepos));
 	},
@@ -51,7 +49,6 @@ export type TaskService = ReturnType<typeof createTaskService>;
 async function setNewTaskStateInTx(
 	context: NamespaceRequestContext,
 	request: TaskSetStateRequestNew,
-	inputHash: string,
 	txRepos: TxRepositories
 ): Promise<void> {
 	const { namespaceId, logger } = context;
@@ -88,7 +85,7 @@ async function setNewTaskStateInTx(
 		status: targetState.status,
 		attempts: 1,
 		input: request.input,
-		inputHash: inputHash,
+		inputHash: request.inputHash,
 		options: null,
 		latestStateTransitionId: targetStateTransitionId,
 	});

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -10,7 +10,7 @@ import type { TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
 import { createTaskStateMachine } from "./state-machine/task";
 import { createWorkflowRunStateMachine, type WorkflowRunStateMachine } from "./state-machine/workflow-run";
 import { describe, expect, test } from "bun:test";
-import { WorkflowRunRevisionConflictError } from "../errors";
+import { WorkflowRunReferenceConflictError, WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories } from "../infra/db/types";
 import { createImminentRunTimerQueue, type ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 import { computeRank } from "../lib/rank";
@@ -69,7 +69,7 @@ describe("WorkflowRunService getWorkflowRunById", () => {
 				name: "checkout",
 				versionId: "v1",
 				input,
-				inputHash,
+				inputHash: { value: inputHash },
 				options: { pool: "eu-west" },
 			});
 
@@ -363,7 +363,7 @@ describe("WorkflowRunService cancelByIds", () => {
 					name: parent.workflowName,
 					versionId: parent.workflowVersionId,
 					input: childInput,
-					inputHash: await hashInput(childInput),
+					inputHash: { value: await hashInput(childInput) },
 					parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
 				})
 			).rejects.toThrow(WorkflowRunRevisionConflictError);
@@ -381,7 +381,7 @@ describe("WorkflowRunService cancelByIds", () => {
 				name: parent.workflowName,
 				versionId: parent.workflowVersionId,
 				input: childInput,
-				inputHash: await hashInput(childInput),
+				inputHash: { value: await hashInput(childInput) },
 				parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
 			});
 
@@ -452,6 +452,78 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 		}));
 });
 
+describe("WorkflowRunService createWorkflowRun reference matching", () => {
+	test("returns the existing run when the stored hash is the current value", () =>
+		withHarness(async ({ context, repos }) => {
+			const { service } = createService(repos);
+			const input = { orderId: "order-1" };
+			const inputHash = await hashInput(input);
+			const request = {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash: { value: inputHash },
+				options: { reference: { id: "order-ref-1" } },
+			};
+
+			const runId = await service.createWorkflowRun(context, request);
+
+			expect(await service.createWorkflowRun(context, request)).toBe(runId);
+		}));
+
+	test("returns the existing run when the stored hash is a deprecated value", () =>
+		withHarness(async ({ context, repos }) => {
+			const { service } = createService(repos);
+			const input = { orderId: "order-1" };
+			const previousHash = "previous-hash";
+			const currentHash = await hashInput(input);
+			const options = { reference: { id: "order-ref-1" } };
+
+			const runId = await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash: { value: previousHash },
+				options,
+			});
+
+			const matchedRunId = await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash: { value: currentHash, deprecatedValues: [previousHash] },
+				options,
+			});
+
+			expect(matchedRunId).toBe(runId);
+		}));
+
+	test("rejects when the stored hash is neither the current value nor a deprecated value", () =>
+		withHarness(async ({ context, repos }) => {
+			const { service } = createService(repos);
+			const input = { orderId: "order-1" };
+			const options = { reference: { id: "order-ref-1" } };
+
+			await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input,
+				inputHash: { value: "previous-hash" },
+				options,
+			});
+
+			expect(
+				service.createWorkflowRun(context, {
+					name: "checkout",
+					versionId: "v1",
+					input,
+					inputHash: { value: await hashInput(input) },
+					options,
+				})
+			).rejects.toThrow(WorkflowRunReferenceConflictError);
+		}));
+});
+
 describe("WorkflowRunService imminent run timers", () => {
 	test("creating a due run adds its timer to the priority queue", () =>
 		withHarness(async ({ context, repos }) => {
@@ -469,7 +541,7 @@ describe("WorkflowRunService imminent run timers", () => {
 					name: "checkout",
 					versionId: "v1",
 					input,
-					inputHash,
+					inputHash: { value: inputHash },
 				})
 			);
 
@@ -491,7 +563,7 @@ describe("WorkflowRunService imminent run timers", () => {
 				name: "checkout",
 				versionId: "v1",
 				input,
-				inputHash: await hashInput(input),
+				inputHash: { value: await hashInput(input) },
 				options: { trigger: { type: "delayed", delayMs: 60_000 } },
 			});
 
@@ -512,7 +584,7 @@ describe("WorkflowRunService imminent run timers", () => {
 				name: "checkout",
 				versionId: "v1",
 				input,
-				inputHash,
+				inputHash: { value: inputHash },
 				options: { reference: { id: "order-ref-1" } },
 			};
 			const createdAtMs = Date.now();
@@ -545,7 +617,7 @@ describe("WorkflowRunService imminent run timers", () => {
 					name: parent.workflowName,
 					versionId: parent.workflowVersionId,
 					input: childInput,
-					inputHash: childInputHash,
+					inputHash: { value: childInputHash },
 					parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
 				})
 			);

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -13,7 +13,6 @@ import type {
 	WorkflowRunListTransitionsRequestV1,
 	WorkflowRunReference,
 } from "@aikirun/types/api/workflow-run";
-import type { InputHash } from "@aikirun/types/infra/hash";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
@@ -351,7 +350,9 @@ async function createWorkflowRunInTx(
 			referenceId,
 		});
 		if (existingRun) {
-			if (!inputHashIdentifies(inputHash, existingRun.inputHash)) {
+			const hashCandidates = [inputHash.value, ...(inputHash.deprecatedValues ?? [])];
+
+			if (!hashCandidates.includes(existingRun.inputHash)) {
 				const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
 				if (conflictPolicy === "error") {
 					throw new WorkflowRunReferenceConflictError(name, versionId, referenceId);
@@ -754,12 +755,4 @@ function buildChildWorkflowRunsByAddress(
 	}
 
 	return childRunsByAddress;
-}
-
-function inputHashIdentifies(inputHash: InputHash, stored: string): boolean {
-	if (stored === inputHash.value) {
-		return true;
-	}
-
-	return inputHash.deprecatedValues?.includes(stored) ?? false;
 }

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -13,6 +13,7 @@ import type {
 	WorkflowRunListTransitionsRequestV1,
 	WorkflowRunReference,
 } from "@aikirun/types/api/workflow-run";
+import type { InputHash } from "@aikirun/types/infra/hash";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
@@ -350,7 +351,7 @@ async function createWorkflowRunInTx(
 			referenceId,
 		});
 		if (existingRun) {
-			if (existingRun.inputHash !== inputHash) {
+			if (!inputHashIdentifies(inputHash, existingRun.inputHash)) {
 				const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
 				if (conflictPolicy === "error") {
 					throw new WorkflowRunReferenceConflictError(name, versionId, referenceId);
@@ -384,7 +385,7 @@ async function createWorkflowRunInTx(
 		parentWorkflowRunId: parent?.workflowRunId,
 		status: "scheduled",
 		input,
-		inputHash,
+		inputHash: inputHash.value,
 		options: options && { retry: options.retry, pool: options.pool },
 		referenceId,
 		latestStateTransitionId: transitionId,
@@ -753,4 +754,12 @@ function buildChildWorkflowRunsByAddress(
 	}
 
 	return childRunsByAddress;
+}
+
+function inputHashIdentifies(inputHash: InputHash, stored: string): boolean {
+	if (stored === inputHash.value) {
+		return true;
+	}
+
+	return inputHash.deprecatedValues?.includes(stored) ?? false;
 }

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -61,7 +61,7 @@ export async function seedScheduledRun(
 		name: seededWorkflow.name,
 		versionId: seededWorkflow.versionId,
 		input,
-		inputHash: await hashInput(input),
+		inputHash: { value: await hashInput(input) },
 		options: overrides?.options,
 	});
 

--- a/sdk/server/src/testing/seed/schedule.ts
+++ b/sdk/server/src/testing/seed/schedule.ts
@@ -23,7 +23,7 @@ export async function seedActiveSchedule(
 	const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
 		...seededSchedule,
 		workflowName: overrides?.workflowName ?? seededSchedule.workflowName,
-		workflowRunInputHash: await hashInput(seededSchedule.workflowRunInput),
+		workflowRunInputHash: { value: await hashInput(seededSchedule.workflowRunInput) },
 	});
 
 	return { schedule };

--- a/sdk/workflow/src/run/execute.test.ts
+++ b/sdk/workflow/src/run/execute.test.ts
@@ -188,6 +188,29 @@ describe("executeWorkflowRun", () => {
 			expect(capturedInput).toEqual({ orderId: "o1" });
 		}));
 
+	test("returns false when no hasher is bound for the run's input hash", () =>
+		withFakeClient(async (client) => {
+			const workflowRun = runningWorkflowRunRecordFactory.build();
+			let handlerCalled = false;
+			const workflowVersion = fakeWorkflowVersion(async () => {
+				handlerCalled = true;
+			});
+			client[INTERNAL].hasher = Object.assign(async () => ({ value: "unused" }), {
+				for: async () => null,
+			});
+
+			const result = await executeWorkflowRun({
+				client,
+				workflowRun,
+				workflowVersion,
+				logger: client.logger,
+				configProvider,
+			});
+
+			expect(result).toBe(false);
+			expect(handlerCalled).toBe(false);
+		}));
+
 	describe("claim refresh", () => {
 		test("keeps the claim alive by refreshing it while the handler runs", () =>
 			withFakeClient(async (client) => {

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -94,6 +94,15 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 
 		const createContext = client[INTERNAL].context;
 		const context = createContext ? createContext(workflowRun) : null;
+		const hasher = await client[INTERNAL].hasher.for(workflowRun.inputHash);
+
+		if (!hasher) {
+			logger.error("Failed to determine the bound hasher for the workflow run. Check hasher configuration.", {
+				workflowRunId,
+			});
+
+			return false;
+		}
 
 		await workflowVersion[INTERNAL].handler(
 			{
@@ -109,6 +118,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 					handle,
 					replayManifest: createReplayManifest(workflowRun),
 					configProvider,
+					hasher,
 				},
 			},
 			workflowRun.input
@@ -127,6 +137,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		}
 
 		logger.error("Unexpected error during workflow execution", { err });
+
 		return false;
 	} finally {
 		for (const interval of intervals) {

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -1,6 +1,7 @@
 import type { ConfigProvider } from "@aikirun/lib/config";
 import type { Duration } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
+import type { BoundHasher } from "@aikirun/types/infra/hash";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { ReplayManifest, SleepResult, WorkflowRunId, WorkflowRunOptions } from "@aikirun/types/workflow/run";
@@ -22,5 +23,6 @@ export interface WorkflowRun<Input, Context, TEvents extends EventsDefinition = 
 		handle: WorkflowRunHandle<Input, unknown, Context, TEvents>;
 		replayManifest: ReplayManifest;
 		configProvider: ConfigProvider<WorkflowExecutionConfig>;
+		hasher: BoundHasher;
 	};
 }

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -1,7 +1,7 @@
 import type { ConfigProvider } from "@aikirun/lib/config";
 import type { Duration } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
-import type { BoundHasher } from "@aikirun/types/infra/hash";
+import type { BoundHasher } from "@aikirun/types/infra/hasher";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { ReplayManifest, SleepResult, WorkflowRunId, WorkflowRunOptions } from "@aikirun/types/workflow/run";

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -22,13 +22,13 @@ const intervalScheduleActivateRequest = intervalScheduleActivateRequestFactory.p
 	workflowName: syncInventoryWorkflow.name,
 	workflowVersionId: syncInventoryWorkflow.versionId,
 	workflowRunInput,
-	workflowRunInputHash,
+	workflowRunInputHash: { value: workflowRunInputHash },
 });
 const cronScheduleActivateRequest = cronScheduleActivateRequestFactory.params({
 	workflowName: syncInventoryWorkflow.name,
 	workflowVersionId: syncInventoryWorkflow.versionId,
 	workflowRunInput,
-	workflowRunInputHash,
+	workflowRunInputHash: { value: workflowRunInputHash },
 });
 
 describe("schedule", () => {

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -67,7 +67,7 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 		...args: Input extends void ? [] : [Input]
 	): Promise<ScheduleHandle> {
 		const workflowRunInput = args[0];
-		const workflowRunInputHash = await hashInput(workflowRunInput);
+		const workflowRunInputHash = { value: await hashInput(workflowRunInput) };
 		const { workflowRun: workflowRunOptions, ...scheduleOptions } = options;
 
 		let scheduleSpec: ScheduleSpec;

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -1,4 +1,3 @@
-import { hashInput } from "@aikirun/lib/crypto";
 import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
@@ -67,7 +66,8 @@ export function schedule(params: ScheduleParams): ScheduleDefinition {
 		...args: Input extends void ? [] : [Input]
 	): Promise<ScheduleHandle> {
 		const workflowRunInput = args[0];
-		const workflowRunInputHash = { value: await hashInput(workflowRunInput) };
+		const hasher = client[INTERNAL].hasher;
+		const workflowRunInputHash = await hasher(workflowRunInput);
 		const { workflowRun: workflowRunOptions, ...scheduleOptions } = options;
 
 		let scheduleSpec: ScheduleSpec;

--- a/sdk/workflow/src/system/cancel-child-runs.test.ts
+++ b/sdk/workflow/src/system/cancel-child-runs.test.ts
@@ -38,6 +38,7 @@ function createTestWorkflowRun(
 			handle,
 			replayManifest: createReplayManifest(record),
 			configProvider: asConfigProvider(() => ({ claimRefreshIntervalMs: 30_000, maxInlineWaitMs: 10 })),
+			hasher: hashInput,
 		},
 	};
 }

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -56,6 +56,7 @@ function createTestWorkflowRun(
 				claimRefreshIntervalMs: 30_000,
 				maxInlineWaitMs: options.maxInlineWaitMs ?? 10,
 			})),
+			hasher: hashInput,
 		},
 	};
 }

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -1,6 +1,5 @@
 import { delay } from "@aikirun/lib/async";
 import type { ConfigProvider } from "@aikirun/lib/config";
-import { hashInput } from "@aikirun/lib/crypto";
 import { getCompositeId } from "@aikirun/lib/id";
 import type { Logger } from "@aikirun/lib/logger";
 import {
@@ -123,6 +122,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		...args: Input extends void ? [] : [Input]
 	): Promise<Output> {
 		const handle = run[INTERNAL].handle;
+		const hasher = run[INTERNAL].hasher;
 		handle[INTERNAL].assertExecutionAllowed();
 
 		const inputRaw = args[0];
@@ -132,7 +132,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			: (inputRaw as Input);
 		const input =
 			inputSchemaValidationResult instanceof Promise ? await inputSchemaValidationResult : inputSchemaValidationResult;
-		const inputHash = await hashInput(input);
+		const inputHash = await hasher(input);
 		const address = getCompositeId<TaskAddress>({ name: this.name, referenceId: inputHash });
 
 		const replayManifest = run[INTERNAL].replayManifest;

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -52,6 +52,7 @@ function createTestWorkflowRun(
 			handle,
 			replayManifest: createReplayManifest(record),
 			configProvider: asConfigProvider(() => ({ claimRefreshIntervalMs: 30_000, maxInlineWaitMs: 10 })),
+			hasher: hashInput,
 		},
 	};
 }
@@ -744,6 +745,39 @@ describe("creating a workflow run", () => {
 						versionId: "1.0.0",
 						input: "payload",
 						inputHash: { value: inputHash },
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
+						options: {},
+					},
+					{ id: childRunRecord.id }
+				);
+				client.api.workflowRun.getByIdV1.once({ id: childRunRecord.id }, { run: childRunRecord });
+
+				const childHandle = await childWorkflow.startAsChild(parentRun, "payload");
+
+				expect(childHandle.run.id).toBe(childRunRecord.id);
+			}));
+
+		test("hashes the child input with the parent run's hasher, not the client's", () =>
+			withFakeClient(async (client) => {
+				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
+					async handler(_run, payload: string) {
+						return payload;
+					},
+				});
+				const parentRunRecord = runningWorkflowRunRecordFactory.build();
+				const parentRun = createTestWorkflowRun(client, parentRunRecord);
+				parentRun[INTERNAL].hasher = async () => "run-bound-hash";
+				client[INTERNAL].hasher = Object.assign(async () => ({ value: "client-hash" }), {
+					for: async () => async () => "client-bound-hash",
+				});
+				const childRunRecord = runningWorkflowRunRecordFactory.build();
+
+				client.api.workflowRun.createV1.once(
+					{
+						name: "child-workflow",
+						versionId: "1.0.0",
+						input: "payload",
+						inputHash: { value: "run-bound-hash" },
 						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -552,7 +552,7 @@ describe("creating a workflow run", () => {
 				const inputHash = await hashInput("world");
 
 				client.api.workflowRun.createV1.once(
-					{ name: "greet", versionId: "1.0.0", input: "world", inputHash, options: {} },
+					{ name: "greet", versionId: "1.0.0", input: "world", inputHash: { value: inputHash }, options: {} },
 					{ id: newRunRecord.id }
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
@@ -581,7 +581,7 @@ describe("creating a workflow run", () => {
 				const inputHash = await hashInput("WORLD");
 
 				client.api.workflowRun.createV1.once(
-					{ name: "greet", versionId: "1.0.0", input: "WORLD", inputHash, options: {} },
+					{ name: "greet", versionId: "1.0.0", input: "WORLD", inputHash: { value: inputHash }, options: {} },
 					{ id: newRunRecord.id }
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
@@ -626,7 +626,7 @@ describe("creating a workflow run", () => {
 						name: "greet",
 						versionId: "1.0.0",
 						input: "world",
-						inputHash,
+						inputHash: { value: inputHash },
 						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 } },
 					},
 					{ id: newRunRecord.id }
@@ -652,7 +652,13 @@ describe("creating a workflow run", () => {
 				const inputHash = await hashInput("world");
 
 				client.api.workflowRun.createV1.once(
-					{ name: "greet", versionId: "1.0.0", input: "world", inputHash, options: { retry: { type: "never" } } },
+					{
+						name: "greet",
+						versionId: "1.0.0",
+						input: "world",
+						inputHash: { value: inputHash },
+						options: { retry: { type: "never" } },
+					},
 					{ id: newRunRecord.id }
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
@@ -678,7 +684,7 @@ describe("creating a workflow run", () => {
 						name: "greet",
 						versionId: "1.0.0",
 						input: "world",
-						inputHash,
+						inputHash: { value: inputHash },
 						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 } },
 					},
 					{ id: newRunRecord.id }
@@ -706,7 +712,7 @@ describe("creating a workflow run", () => {
 						name: "greet",
 						versionId: "1.0.0",
 						input: "world",
-						inputHash,
+						inputHash: { value: inputHash },
 						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 }, pool: "eu-west" },
 					},
 					{ id: newRunRecord.id }
@@ -737,7 +743,7 @@ describe("creating a workflow run", () => {
 						name: "child-workflow",
 						versionId: "1.0.0",
 						input: "payload",
-						inputHash,
+						inputHash: { value: inputHash },
 						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},
@@ -766,7 +772,7 @@ describe("creating a workflow run", () => {
 						name: "child-workflow",
 						versionId: "1.0.0",
 						input: "payload",
-						inputHash,
+						inputHash: { value: inputHash },
 						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},
@@ -793,7 +799,7 @@ describe("creating a workflow run", () => {
 						name: "child-workflow",
 						versionId: "1.0.0",
 						input: "payload",
-						inputHash,
+						inputHash: { value: inputHash },
 						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: { pool: "eu-west" },
 					},
@@ -917,7 +923,7 @@ describe("creating a workflow run", () => {
 						name: "child-workflow",
 						versionId: "1.0.0",
 						input: "PAYLOAD",
-						inputHash,
+						inputHash: { value: inputHash },
 						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
 						options: {},
 					},

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -136,7 +136,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			input = schemaValidationResult.value;
 		}
 
-		const inputHash = await hashInput(input);
+		const inputHash = { value: await hashInput(input) };
 		const { id } = await client.api.workflowRun.createV1({
 			name: this.name,
 			versionId: this.versionId,
@@ -178,13 +178,13 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			: inputRaw;
 		const input =
 			inputSchemaValidationResult instanceof Promise ? await inputSchemaValidationResult : inputSchemaValidationResult;
-		const inputHash = await hashInput(input);
+		const inputHash = { value: await hashInput(input) };
 
 		const referenceId = startOptions.reference?.id;
 		const address = getCompositeId<WorkflowRunAddress>({
 			name: this.name,
 			versionId: this.versionId,
-			referenceId: referenceId ?? inputHash,
+			referenceId: referenceId ?? inputHash.value,
 		});
 		const replayManifest = parentRun[INTERNAL].replayManifest;
 
@@ -209,7 +209,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 				);
 			}
 
-			await this.throwNonDeterminismError(parentRun, parentRunHandle, inputHash, referenceId, replayManifest);
+			await this.throwNonDeterminismError(parentRun, parentRunHandle, inputHash.value, referenceId, replayManifest);
 		}
 
 		const pool = parentRun.options.pool;

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -1,4 +1,3 @@
-import { hashInput } from "@aikirun/lib/crypto";
 import { getCompositeId } from "@aikirun/lib/id";
 import {
 	type ObjectBuilder,
@@ -125,6 +124,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		...args: Input extends void ? [] : [Input]
 	): Promise<WorkflowRunHandle<Input, Output, Context, TEvents>> {
 		let input = args[0];
+		const hasher = client[INTERNAL].hasher;
 		const schema = this.params.schema?.input;
 		if (schema) {
 			const schemaValidation = schema["~standard"].validate(input);
@@ -136,7 +136,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			input = schemaValidationResult.value;
 		}
 
-		const inputHash = { value: await hashInput(input) };
+		const inputHash = await hasher(input);
 		const { id } = await client.api.workflowRun.createV1({
 			name: this.name,
 			versionId: this.versionId,
@@ -178,7 +178,9 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			: inputRaw;
 		const input =
 			inputSchemaValidationResult instanceof Promise ? await inputSchemaValidationResult : inputSchemaValidationResult;
-		const inputHash = { value: await hashInput(input) };
+		// we should use a parent hasher instead of the client to enforce consistency
+		const hasher = parentRun[INTERNAL].hasher;
+		const inputHash = { value: await hasher(input) };
 
 		const referenceId = startOptions.reference?.id;
 		const address = getCompositeId<WorkflowRunAddress>({

--- a/testing/src/client.ts
+++ b/testing/src/client.ts
@@ -1,3 +1,4 @@
+import { plainHasher } from "@aikirun/lib/crypto";
 import { noopLogger } from "@aikirun/lib/logger";
 import type { ApiClient, Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
@@ -202,7 +203,10 @@ function fakeClient<Context = null>(options: FakeClientOptions<Context> = {}): F
 	return {
 		api,
 		logger: noopLogger,
-		[INTERNAL]: options.context ? { context: options.context } : {},
+		[INTERNAL]: {
+			hasher: plainHasher,
+			...(options.context ? { context: options.context } : {}),
+		},
 		verify,
 	};
 }

--- a/testing/src/data-factory/api/schedule.ts
+++ b/testing/src/data-factory/api/schedule.ts
@@ -7,7 +7,7 @@ export const intervalScheduleActivateRequestFactory = Factory.define<
 >(() => ({
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
-	workflowRunInputHash: "hash",
+	workflowRunInputHash: { value: "hash" },
 	options: {},
 	workflowRunOptions: {},
 	spec: { type: "interval", everyMs: 1_000 },
@@ -18,7 +18,7 @@ export const cronScheduleActivateRequestFactory = Factory.define<
 >(() => ({
 	workflowName: "workflow",
 	workflowVersionId: "1.0.0",
-	workflowRunInputHash: "hash",
+	workflowRunInputHash: { value: "hash" },
 	options: {},
 	workflowRunOptions: {},
 	spec: { type: "cron", expression: "* * * * *" },

--- a/types/package.json
+++ b/types/package.json
@@ -36,6 +36,10 @@
 			"types": "./dist/infra/db.d.ts",
 			"import": "./dist/infra/db.js"
 		},
+		"./infra/hash": {
+			"types": "./dist/infra/hash.d.ts",
+			"import": "./dist/infra/hash.js"
+		},
 		"./infra/queue": {
 			"types": "./dist/infra/queue/index.d.ts",
 			"import": "./dist/infra/queue/index.js"

--- a/types/src/api/schedule.ts
+++ b/types/src/api/schedule.ts
@@ -1,4 +1,4 @@
-import type { InputHash } from "../infra/hash";
+import type { Hash } from "../infra/hasher";
 import type { Schedule, ScheduleActivateOptions, ScheduleSpec, ScheduleStatus } from "../schedule";
 import type { WorkflowSource } from "../workflow";
 import type { WorkflowRunOptions } from "../workflow/run";
@@ -17,7 +17,7 @@ export interface ScheduleActivateRequestV1 {
 	workflowName: string;
 	workflowVersionId: string;
 	workflowRunInput?: unknown;
-	workflowRunInputHash: InputHash;
+	workflowRunInputHash: Hash;
 	spec: ScheduleSpec;
 	options?: ScheduleActivateOptions;
 	workflowRunOptions?: WorkflowRunOptions;

--- a/types/src/api/schedule.ts
+++ b/types/src/api/schedule.ts
@@ -1,3 +1,4 @@
+import type { InputHash } from "../infra/hash";
 import type { Schedule, ScheduleActivateOptions, ScheduleSpec, ScheduleStatus } from "../schedule";
 import type { WorkflowSource } from "../workflow";
 import type { WorkflowRunOptions } from "../workflow/run";
@@ -16,7 +17,7 @@ export interface ScheduleActivateRequestV1 {
 	workflowName: string;
 	workflowVersionId: string;
 	workflowRunInput?: unknown;
-	workflowRunInputHash: string;
+	workflowRunInputHash: InputHash;
 	spec: ScheduleSpec;
 	options?: ScheduleActivateOptions;
 	workflowRunOptions?: WorkflowRunOptions;

--- a/types/src/api/task.ts
+++ b/types/src/api/task.ts
@@ -82,6 +82,7 @@ export interface TaskSetStateRequestNew {
 	workflowRunId: string;
 	taskName: string;
 	input?: unknown;
+	inputHash: string;
 	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
 }
 

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -1,6 +1,6 @@
 import type { DistributiveOmit, OptionalProp } from "@aikirun/lib/object";
 
-import type { InputHash } from "../infra/hash";
+import type { Hash } from "../infra/hasher";
 import type { WorkflowSource } from "../workflow";
 import type {
 	WorkflowRunRecord,
@@ -105,7 +105,7 @@ export interface WorkflowRunCreateRequestV1 {
 	name: string;
 	versionId: string;
 	input?: unknown;
-	inputHash: InputHash;
+	inputHash: Hash;
 	parent?: {
 		workflowRunId: string;
 		expectedRevision: number;

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -1,5 +1,6 @@
 import type { DistributiveOmit, OptionalProp } from "@aikirun/lib/object";
 
+import type { InputHash } from "../infra/hash";
 import type { WorkflowSource } from "../workflow";
 import type {
 	WorkflowRunRecord,
@@ -104,7 +105,7 @@ export interface WorkflowRunCreateRequestV1 {
 	name: string;
 	versionId: string;
 	input?: unknown;
-	inputHash: string;
+	inputHash: InputHash;
 	parent?: {
 		workflowRunId: string;
 		expectedRevision: number;

--- a/types/src/client.ts
+++ b/types/src/client.ts
@@ -3,7 +3,7 @@ import type { Logger } from "@aikirun/lib/logger";
 import type { ScheduleApi } from "./api/schedule";
 import type { TaskApi } from "./api/task";
 import type { WorkflowRunApi } from "./api/workflow-run";
-import type { CreateHasher, Hasher } from "./infra/hash";
+import type { CreateHasher, Hasher } from "./infra/hasher";
 import { INTERNAL } from "./symbols";
 import type { WorkflowRunRecord } from "./workflow/run";
 

--- a/types/src/client.ts
+++ b/types/src/client.ts
@@ -3,12 +3,14 @@ import type { Logger } from "@aikirun/lib/logger";
 import type { ScheduleApi } from "./api/schedule";
 import type { TaskApi } from "./api/task";
 import type { WorkflowRunApi } from "./api/workflow-run";
+import type { CreateHasher, Hasher } from "./infra/hash";
 import { INTERNAL } from "./symbols";
 import type { WorkflowRunRecord } from "./workflow/run";
 
 interface BaseClientParams<Context = null> {
 	logger?: Logger;
 	context?: (run: Readonly<WorkflowRunRecord>) => Context | Promise<Context>;
+	hasher?: CreateHasher;
 }
 
 export interface RemoteClientParams<Context = null> extends BaseClientParams<Context> {
@@ -27,6 +29,7 @@ export interface Client<Context = null> {
 	logger: Logger;
 	[INTERNAL]: {
 		context?: (run: WorkflowRunRecord) => Context | Promise<Context>;
+		hasher: Hasher;
 	};
 }
 

--- a/types/src/infra/hash.ts
+++ b/types/src/infra/hash.ts
@@ -1,0 +1,5 @@
+export interface InputHash {
+	value: string;
+	/** Prior hashes that still identify this definition. */
+	deprecatedValues?: string[];
+}

--- a/types/src/infra/hash.ts
+++ b/types/src/infra/hash.ts
@@ -1,5 +1,20 @@
+import type { Logger } from "@aikirun/lib/logger";
+
 export interface InputHash {
 	value: string;
 	/** Prior hashes that still identify this definition. */
 	deprecatedValues?: string[];
 }
+
+export interface HasherContext {
+	logger: Logger;
+}
+
+export interface Hasher {
+	(input: unknown): Promise<InputHash>;
+	for(hash: string): Promise<BoundHasher | null>;
+}
+
+export type BoundHasher = (input: unknown) => Promise<string>;
+
+export type CreateHasher = (context: HasherContext) => Hasher;

--- a/types/src/infra/hasher.ts
+++ b/types/src/infra/hasher.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "@aikirun/lib/logger";
 
-export interface InputHash {
+export interface Hash {
 	value: string;
 	/** Prior hashes that still identify this definition. */
 	deprecatedValues?: string[];
@@ -11,7 +11,7 @@ export interface HasherContext {
 }
 
 export interface Hasher {
-	(input: unknown): Promise<InputHash>;
+	(input: unknown): Promise<Hash>;
 	for(hash: string): Promise<BoundHasher | null>;
 }
 

--- a/types/tsup.config.ts
+++ b/types/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 		iam: "src/iam.ts",
 		"infra/cache": "src/infra/cache.ts",
 		"infra/db": "src/infra/db.ts",
-		"infra/hash": "src/infra/hash.ts",
+		"infra/hasher": "src/infra/hasher.ts",
 		"infra/queue/index": "src/infra/queue/index.ts",
 		"infra/timer": "src/infra/timer.ts",
 		namespace: "src/namespace.ts",

--- a/types/tsup.config.ts
+++ b/types/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		iam: "src/iam.ts",
 		"infra/cache": "src/infra/cache.ts",
 		"infra/db": "src/infra/db.ts",
+		"infra/hash": "src/infra/hash.ts",
 		"infra/queue/index": "src/infra/queue/index.ts",
 		"infra/timer": "src/infra/timer.ts",
 		namespace: "src/namespace.ts",


### PR DESCRIPTION
The PR introduces a possibility to provide a custom (keyed) hasher to enhance the security of the data kept in the DB (particularly when the payload is encrypted).

Hasher is a callable function with one method: call it to hash an input under the active key, or call for to get a hasher locked to whichever key wrote an existing hash.

```
interface Hasher {
  (input: unknown): Promise<{ hash: string; previousHashes: string[] }>;
  for(hash: string): Promise<BoundHasher | null>;
}

type BoundHasher = (input: unknown) => Promise<string>;

type CreateHasher = (context: HasherContext) => Hasher;
```

When the custom hasher is not provided, plainHasher is used (SHA256).

To support changes to the hasher (in the case of key rotation), now multiple hash values (active and deprecated) are sent to the server.

Places where deprecated hash values are supported:
- when activating a schedule
- starting a run under a reference id