### PR TITLE
docs: fix from-source install commands and unpin release tag

### DIFF
--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -122,21 +122,21 @@ Add `--package server,iam` to the migration when the server runs with auth. The 
 
 ### From source
 
-The same stack runs without Docker (this path needs Bun). Clone at a release tag so you run released code:
+The same stack runs without Docker (this path needs Bun). Clone at a release tag so you run released code — pick one from the [releases](https://github.com/aikirun/aiki/releases):
 
 ```bash
-git clone --branch v0.34.1 https://github.com/aikirun/aiki.git
+git clone --branch <version> https://github.com/aikirun/aiki.git
 cd aiki
 bun install
 cp app/server/.env.example app/server/.env
 # Edit app/server/.env with your DATABASE_URL
 
-bun run db:migrate:apply:server   # the migration step
-bun run server                    # Terminal 1
-bun run dashboard                 # Terminal 2
+bun run --cwd app/server db:migrate:apply:server   # the migration step
+bun run server                                     # Terminal 1
+bun run dashboard                                  # Terminal 2
 ```
 
-Run `bun run db:migrate:apply:iam` too when the server will run with auth. One piece differs from its container form: the dashboard here is a dev server, and the browser calls the Aiki server directly on `localhost:9850` — no proxy and no `AIKI_SERVER_UPSTREAM_URL` (the `.env.example` already allows the dashboard's origin through `CORS_ORIGINS`).
+Run `bun run --cwd app/server db:migrate:apply:iam` too when the server will run with auth. One piece differs from its container form: the dashboard here is a dev server, and the browser calls the Aiki server directly on `localhost:9850` — no proxy and no `AIKI_SERVER_UPSTREAM_URL` (the `.env.example` already allows the dashboard's origin through `CORS_ORIGINS`).
 
 ## Run the dashboard on its own
 
@@ -145,7 +145,7 @@ Serve the dashboard by itself when the server is embedded in your app (the [SDK 
 The server's URL is baked into the bundle at build time, so the dashboard is built per deployment (the build needs Bun) — from the release tag matching your installed `@aikirun/*` version:
 
 ```bash
-git clone --branch v0.34.1 https://github.com/aikirun/aiki.git
+git clone --branch <version> https://github.com/aikirun/aiki.git
 cd aiki
 bun install
 bun run build:types


### PR DESCRIPTION
The From source guide fails at the migration step.

It says to run:

    bun run db:migrate:apply:server

That script is not in the root package.json. It is in
app/server/package.json. So the command fails and a new user is
stuck at the first real step.

The scripts used to be at the root. Commit 25a46d06 (2026-07-15)
removed them, saying they are specific to app/server. That shipped
in v0.35.0. The docs were not updated to match.

CONTRIBUTING.md line 60 already uses the correct form:

    bun run --cwd app/server db:migrate:apply

This PR changes the guide to use that same form, for both the
server and the iam migration.

The second problem is in the same section. Both git clone commands
pin --branch v0.34.1, but the current release is v0.38.0.

The two problems are linked. At v0.34.1 the old commands work. From
v0.35.0 on they do not. So the page only makes sense against a tag
that is four releases old.

There is also a contradiction further down. The dashboard section
says to build from the release tag matching your installed
@aikirun/* version, then hardcodes v0.34.1 in the command below it.

This PR replaces both pins with <version> and links the releases
page. The page already uses <version> for the docker images, so it
matches what is there. Happy to change it if you prefer something
else.
