### PR TITLE
docs: fix bullet list split by an unindented code block

### DIFF
--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -41,13 +41,13 @@ Want the web dashboard against your embedded server? Serve it separately — see
 Hosting Aiki as infrastructure means running two components:
 
 - **Server** — the Aiki server. Needs `DATABASE_URL`.
+- **Dashboard** — the web UI, a single-page app that talks to the server.
 
 However you run the server, applications connect the same way:
+
 ```typescript
 const aikiClient = client({ url: "http://localhost:9850" });
 ```
-
-- **Dashboard** — the web UI, a single-page app that talks to the server.
 
 Before the server starts, apply the schema. This one-off **migration step** applies the server package's migrations, plus the iam package's when the server runs with auth (`AIKI_SERVER_AUTH_SECRET`). It needs `DATABASE_URL`, and is safe to repeat: run it on a fresh database or when an aiki upgrade ships new migrations. Already-applied migrations are skipped.
 


### PR DESCRIPTION
The two-item list under "Run the standalone server and dashboard"
renders as two separate lists with text stuck in the middle.

The source has the Server bullet, then a paragraph and a code block
at column 0, then the Dashboard bullet. An unindented code block
ends a markdown list. So the Dashboard bullet starts a new list
instead of joining the first one.

On https://aiki.run/docs/getting-started/installation it currently
reads:

    Hosting Aiki as infrastructure means running two components:
      - Server - the Aiki server. Needs DATABASE_URL.
    However you run the server, applications connect the same way:
      [code block]
      - Dashboard - the web UI, a single-page app that talks to
        the server.

The sentence about connecting sits between the two components, and
the Dashboard bullet looks like it belongs to the code block.

This PR moves the Dashboard bullet up next to the Server bullet, and
moves the sentence and code block below both. It also adds the
missing blank line before the code fence.
