### PR TITLE
Errors carry their own code and status

### DIFF
--- a/lib/src/error/index.test.ts
+++ b/lib/src/error/index.test.ts
@@ -1,0 +1,56 @@
+import { asAikiError, ConflictError, ForbiddenError, NotFoundError, UnauthorizedError, ValidationError } from "./index";
+import { describe, expect, test } from "bun:test";
+
+describe("asAikiError", () => {
+	// Bundlers inline lib into every package that depends on it, so an error thrown inside one
+	// package is built by a different constructor than the class another package imports.
+	// This stands in for that second copy.
+	class UnauthorizedErrorFromAnotherBundle extends Error {
+		readonly code = "UNAUTHORIZED";
+		readonly status = 401;
+
+		constructor(message: string) {
+			super(message);
+			this.name = "UnauthorizedError";
+		}
+	}
+
+	test("reports how every error lib defines should be returned", () => {
+		expect(
+			[
+				new NotFoundError("message"),
+				new ValidationError("message"),
+				new UnauthorizedError("message"),
+				new ForbiddenError("message"),
+				new ConflictError("message"),
+			].map((err) => [asAikiError(err)?.code, asAikiError(err)?.status])
+		).toEqual([
+			["NOT_FOUND", 404],
+			["BAD_REQUEST", 400],
+			["UNAUTHORIZED", 401],
+			["FORBIDDEN", 403],
+			["CONFLICT", 409],
+		]);
+	});
+
+	test("recognises an error built by another copy of the class", () => {
+		const err = new UnauthorizedErrorFromAnotherBundle("Invalid API key");
+
+		expect(err instanceof UnauthorizedError).toBe(false);
+		expect([asAikiError(err)?.code, asAikiError(err)?.status]).toEqual(["UNAUTHORIZED", 401]);
+	});
+
+	test("declines an error that carries a code but no status", () => {
+		const err = Object.assign(new Error("no such file"), { code: "ENOENT" });
+
+		expect(asAikiError(err)).toBeUndefined();
+	});
+
+	test("declines values that are not errors", () => {
+		expect([
+			asAikiError({ code: "UNAUTHORIZED", status: 401 }),
+			asAikiError("UNAUTHORIZED"),
+			asAikiError(undefined),
+		]).toEqual([undefined, undefined, undefined]);
+	});
+});

--- a/lib/src/error/index.ts
+++ b/lib/src/error/index.ts
@@ -1,32 +1,65 @@
-export class NotFoundError extends Error {
+export abstract class AikiError extends Error {
+	abstract readonly code: string;
+	abstract readonly status: number;
+}
+
+export function asAikiError(err: unknown): AikiError | undefined {
+	if (
+		err instanceof Error &&
+		"code" in err &&
+		typeof err.code === "string" &&
+		"status" in err &&
+		typeof err.status === "number"
+	) {
+		return err as AikiError;
+	}
+	return undefined;
+}
+
+export class NotFoundError extends AikiError {
+	readonly code = "NOT_FOUND";
+	readonly status = 404;
+
 	constructor(message: string) {
 		super(message);
 		this.name = "NotFoundError";
 	}
 }
 
-export class ValidationError extends Error {
+export class ValidationError extends AikiError {
+	readonly code = "BAD_REQUEST";
+	readonly status = 400;
+
 	constructor(message: string) {
 		super(message);
 		this.name = "ValidationError";
 	}
 }
 
-export class UnauthorizedError extends Error {
+export class UnauthorizedError extends AikiError {
+	readonly code = "UNAUTHORIZED";
+	readonly status = 401;
+
 	constructor(message: string) {
 		super(message);
 		this.name = "UnauthorizedError";
 	}
 }
 
-export class ForbiddenError extends Error {
+export class ForbiddenError extends AikiError {
+	readonly code = "FORBIDDEN";
+	readonly status = 403;
+
 	constructor(message: string) {
 		super(message);
 		this.name = "ForbiddenError";
 	}
 }
 
-export class ConflictError extends Error {
+export class ConflictError extends AikiError {
+	readonly code = "CONFLICT";
+	readonly status = 409;
+
 	constructor(message: string) {
 		super(message);
 		this.name = "ConflictError";

--- a/sdk/iam/src/dashboard-session.ts
+++ b/sdk/iam/src/dashboard-session.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedError } from "@aikirun/lib/error";
+import { asAikiError, UnauthorizedError } from "@aikirun/lib/error";
 import type {
 	CreateDashboardAuthenticator,
 	CreateDashboardIam,
@@ -136,8 +136,9 @@ function createOrganizationHandler(
 					try {
 						authorization = await authorizeOrganizationSession(authService, repos.organization, request);
 					} catch (err) {
-						if (err instanceof UnauthorizedError) {
-							return new Response(err.message, { status: 401 });
+						const aikiError = asAikiError(err);
+						if (aikiError) {
+							return new Response(aikiError.message, { status: aikiError.status });
 						}
 						logger.error("Unhandled error", { err });
 						return new Response("Internal Server Error", { status: 500 });

--- a/sdk/iam/src/router/error-handler.ts
+++ b/sdk/iam/src/router/error-handler.ts
@@ -1,26 +1,11 @@
 import type { ContextBase } from "@aikirun/lib/context";
-import { ConflictError, ForbiddenError, NotFoundError, UnauthorizedError, ValidationError } from "@aikirun/lib/error";
+import { asAikiError } from "@aikirun/lib/error";
 import { ORPCError } from "@orpc/server";
 
 export function handleError<T extends ContextBase>({ logger }: T, err: unknown) {
-	if (err instanceof NotFoundError) {
-		throw new ORPCError("NOT_FOUND", { message: err.message });
-	}
-
-	if (err instanceof ValidationError) {
-		throw new ORPCError("BAD_REQUEST", { message: err.message });
-	}
-
-	if (err instanceof UnauthorizedError) {
-		throw new ORPCError("UNAUTHORIZED", { message: err.message });
-	}
-
-	if (err instanceof ForbiddenError) {
-		throw new ORPCError("FORBIDDEN", { message: err.message, status: 403 });
-	}
-
-	if (err instanceof ConflictError) {
-		throw new ORPCError("CONFLICT", { message: err.message, status: 409 });
+	const aikiError = asAikiError(err);
+	if (aikiError) {
+		throw new ORPCError(aikiError.code, { message: aikiError.message, status: aikiError.status });
 	}
 
 	const cause = err instanceof Error && "cause" in err ? err.cause : undefined;

--- a/sdk/server/src/errors.ts
+++ b/sdk/server/src/errors.ts
@@ -1,8 +1,12 @@
+import { AikiError } from "@aikirun/lib/error";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRunId, WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import type { TaskId, TaskName, TaskStatus } from "@aikirun/types/workflow/task";
 
-export class WorkflowRunRevisionConflictError extends Error {
+export class WorkflowRunRevisionConflictError extends AikiError {
+	readonly code = "WORKFLOW_RUN_REVISION_CONFLICT";
+	readonly status = 409;
+
 	public readonly workflowRunId: WorkflowRunId;
 	public readonly expectedRevision: number;
 
@@ -14,7 +18,10 @@ export class WorkflowRunRevisionConflictError extends Error {
 	}
 }
 
-export class InvalidWorkflowRunStateTransitionError extends Error {
+export class InvalidWorkflowRunStateTransitionError extends AikiError {
+	readonly code = "BAD_REQUEST";
+	readonly status = 400;
+
 	public readonly workflowRunId: WorkflowRunId;
 	public readonly from: WorkflowRunStatus;
 	public readonly to: WorkflowRunStatus;
@@ -32,7 +39,10 @@ export class InvalidWorkflowRunStateTransitionError extends Error {
 	}
 }
 
-export class InvalidTaskStateTransitionError extends Error {
+export class InvalidTaskStateTransitionError extends AikiError {
+	readonly code = "BAD_REQUEST";
+	readonly status = 400;
+
 	public readonly workflowRunId: WorkflowRunId;
 	public readonly taskData:
 		| { taskId: TaskId; from: TaskStatus; to: TaskStatus }
@@ -53,7 +63,10 @@ export class InvalidTaskStateTransitionError extends Error {
 	}
 }
 
-export class TaskStateConflictError extends Error {
+export class TaskStateConflictError extends AikiError {
+	readonly code = "TASK_STATE_CONFLICT";
+	readonly status = 409;
+
 	public readonly workflowRunId: WorkflowRunId;
 	public readonly taskId: TaskId;
 	public readonly expectedStatus: TaskStatus;
@@ -71,7 +84,10 @@ export class TaskStateConflictError extends Error {
 	}
 }
 
-export class ScheduleConflictError extends Error {
+export class ScheduleConflictError extends AikiError {
+	readonly code = "SCHEDULE_CONFLICT";
+	readonly status = 409;
+
 	public readonly definitionHash: string;
 	public readonly referenceId?: string;
 
@@ -87,7 +103,10 @@ export class ScheduleConflictError extends Error {
 	}
 }
 
-export class WorkflowRunReferenceConflictError extends Error {
+export class WorkflowRunReferenceConflictError extends AikiError {
+	readonly code = "WORKFLOW_RUN_REFERENCE_CONFLICT";
+	readonly status = 409;
+
 	public readonly workflowName: WorkflowName;
 	public readonly workflowVersionId: WorkflowVersionId;
 	public readonly referenceId: string;

--- a/sdk/server/src/handler.test.ts
+++ b/sdk/server/src/handler.test.ts
@@ -1,0 +1,50 @@
+import { UnauthorizedError } from "@aikirun/lib/error";
+import { noopLogger } from "@aikirun/lib/logger";
+import type { Database } from "@aikirun/types/infra/db";
+
+import { createHandler } from "./handler";
+import { describe, expect, test } from "bun:test";
+
+// iam ships as its own bundle with its own copy of the lib error classes, so the error its
+// authorizer throws is never built by the constructor this package imports. This stands in
+// for that error: same shape and code, different constructor.
+class UnauthorizedErrorFromIamBundle extends Error {
+	readonly code = "UNAUTHORIZED";
+	readonly status = 401;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "UnauthorizedError";
+	}
+}
+
+describe("handler API authorization", () => {
+	function handlerWithFailingAuthorizer(err: unknown) {
+		return createHandler({
+			db: {} as Database,
+			logger: noopLogger,
+			iam: {
+				api: () => () => {
+					throw err;
+				},
+			},
+		});
+	}
+
+	test("an unauthorized error from iam bundle answers 401", async () => {
+		const err = new UnauthorizedErrorFromIamBundle("Invalid API key");
+		expect(err instanceof UnauthorizedError).toBe(false);
+
+		const handler = await handlerWithFailingAuthorizer(err);
+		const response = await handler(new Request("http://localhost/api/workflowRun/getById"));
+
+		expect([response.status, await response.text()]).toEqual([401, "Invalid API key"]);
+	});
+
+	test("an error carrying no reporting details answers 500", async () => {
+		const handler = await handlerWithFailingAuthorizer(new Error("boom"));
+		const response = await handler(new Request("http://localhost/api/workflowRun/getById"));
+
+		expect([response.status, await response.text()]).toEqual([500, "Internal Server Error"]);
+	});
+});

--- a/sdk/server/src/handler.ts
+++ b/sdk/server/src/handler.ts
@@ -1,5 +1,5 @@
 import { asConfigProvider, type ConfigProvider, type CreatePassiveConfigProvider } from "@aikirun/lib/config";
-import { UnauthorizedError } from "@aikirun/lib/error";
+import { asAikiError } from "@aikirun/lib/error";
 import { SENTINEL_ULID } from "@aikirun/lib/id";
 import type { Logger } from "@aikirun/lib/logger";
 import { merge } from "@aikirun/lib/object";
@@ -103,8 +103,9 @@ export async function createHandler(params: CreateHandlerParams) {
 			try {
 				context = await createNamespaceRequestContext({ request, logger, authorizer: apiAuthorizer });
 			} catch (err) {
-				if (err instanceof UnauthorizedError) {
-					return new Response(err.message, { status: 401 });
+				const aikiError = asAikiError(err);
+				if (aikiError) {
+					return new Response(aikiError.message, { status: aikiError.status });
 				}
 				logger.error("Unhandled error", { err });
 				return new Response("Internal Server Error", { status: 500 });

--- a/sdk/server/src/router/error-handler.ts
+++ b/sdk/server/src/router/error-handler.ts
@@ -1,59 +1,12 @@
-import { ConflictError, ForbiddenError, NotFoundError, UnauthorizedError, ValidationError } from "@aikirun/lib/error";
+import { asAikiError } from "@aikirun/lib/error";
 import { ORPCError } from "@orpc/server";
 
-import {
-	InvalidTaskStateTransitionError,
-	InvalidWorkflowRunStateTransitionError,
-	ScheduleConflictError,
-	TaskStateConflictError,
-	WorkflowRunReferenceConflictError,
-	WorkflowRunRevisionConflictError,
-} from "../errors";
 import type { RequestContext } from "../middleware/context";
 
 export function handleError<T extends RequestContext>({ logger }: T, err: unknown) {
-	if (err instanceof NotFoundError) {
-		throw new ORPCError("NOT_FOUND", { message: err.message });
-	}
-
-	if (err instanceof ValidationError) {
-		throw new ORPCError("BAD_REQUEST", { message: err.message });
-	}
-
-	if (err instanceof UnauthorizedError) {
-		throw new ORPCError("UNAUTHORIZED", { message: err.message });
-	}
-
-	if (err instanceof ForbiddenError) {
-		throw new ORPCError("FORBIDDEN", { message: err.message, status: 403 });
-	}
-
-	if (err instanceof ConflictError) {
-		throw new ORPCError("CONFLICT", { message: err.message, status: 409 });
-	}
-
-	if (err instanceof WorkflowRunRevisionConflictError) {
-		throw new ORPCError("WORKFLOW_RUN_REVISION_CONFLICT", { message: err.message, status: 409 });
-	}
-
-	if (err instanceof WorkflowRunReferenceConflictError) {
-		throw new ORPCError("WORKFLOW_RUN_REFERENCE_CONFLICT", { message: err.message, status: 409 });
-	}
-
-	if (err instanceof ScheduleConflictError) {
-		throw new ORPCError("SCHEDULE_CONFLICT", { message: err.message, status: 409 });
-	}
-
-	if (err instanceof TaskStateConflictError) {
-		throw new ORPCError("TASK_STATE_CONFLICT", { message: err.message, status: 409 });
-	}
-
-	if (err instanceof InvalidWorkflowRunStateTransitionError) {
-		throw new ORPCError("BAD_REQUEST", { message: err.message });
-	}
-
-	if (err instanceof InvalidTaskStateTransitionError) {
-		throw new ORPCError("BAD_REQUEST", { message: err.message });
+	const aikiError = asAikiError(err);
+	if (aikiError) {
+		throw new ORPCError(aikiError.code, { message: aikiError.message, status: aikiError.status });
 	}
 
 	const cause = err instanceof Error && "cause" in err ? err.cause : undefined;


### PR DESCRIPTION
## Problem

An API call with a bad key returned 500 instead of 401.

The error classes are written once in lib, but the build does not share lib between packages — it pastes a copy into each one. So the package supplying the authorizer has its own copy of `UnauthorizedError`, and the server has another. `instanceof` asks whether a value was made by one exact class, not whether it looks like one, so the server never recognised the error it was handed and treated it as an unknown crash.

Nothing warned about it. The error was the right kind of error, it just could not be identified across the boundary.

Both request error handlers had a second problem: a chain of `instanceof` branches, one per error type, that had to be edited whenever an error type was added.

## Solution

Errors now say what they are instead of relying on which class built them. `AikiError` is a base class in lib that requires two fields — `code` for the wire code and `status` for the HTTP status — and every error in lib and in the server extends it. Both fields are plain values on the instance, so they survive being copied into another bundle.

`asAikiError` recognises an error by those two fields rather than by its class, so it works whichever copy built it. It requires both, which keeps out node errors and database driver errors that carry a `code` of their own but no `status`.

Each error handler is now a single branch that builds the response from the error's own code and status. Anything without them is logged and rethrown, unchanged. Adding an error type no longer means editing a handler.

One behaviour change beyond the fix: the API handler and the dashboard session return the error's own status rather than only recognising 401, so a `ForbiddenError` from an authorizer now answers 403 instead of 500. Every other response is the same as before — the codes and statuses on each class are the ones the old chains produced.