### PR TITLE
Guard manual task writes

### DIFF
--- a/sdk/server/src/errors.ts
+++ b/sdk/server/src/errors.ts
@@ -1,6 +1,6 @@
 import { AikiError } from "@aikirun/lib/error";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
-import type { WorkflowRunId, WorkflowRunStatus } from "@aikirun/types/workflow/run";
+import type { TerminalWorkflowRunStatus, WorkflowRunId, WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import type { TaskId, TaskName, TaskStatus } from "@aikirun/types/workflow/task";
 
 export class WorkflowRunRevisionConflictError extends AikiError {
@@ -36,6 +36,21 @@ export class InvalidWorkflowRunStateTransitionError extends AikiError {
 		this.from = from;
 		this.to = to;
 		this.reason = reason;
+	}
+}
+
+export class WorkflowRunTerminatedError extends AikiError {
+	readonly code = "WORKFLOW_RUN_TERMINATED";
+	readonly status = 409;
+
+	public readonly workflowRunId: WorkflowRunId;
+	public readonly runStatus: TerminalWorkflowRunStatus;
+
+	constructor(workflowRunId: WorkflowRunId, runStatus: TerminalWorkflowRunStatus) {
+		super(`Workflow ${workflowRunId} is ${runStatus}; it accepts no further writes`);
+		this.name = "WorkflowRunTerminatedError";
+		this.workflowRunId = workflowRunId;
+		this.runStatus = runStatus;
 	}
 }
 

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -94,7 +94,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 
 	async getById(filter: { namespaceId: NamespaceId; id: string }, options?: { lock?: "share" }) {
 		const query = db
-			.select({ id: workflowRun.id, revision: workflowRun.revision })
+			.select({ id: workflowRun.id, revision: workflowRun.revision, status: workflowRun.status })
 			.from(workflowRun)
 			.where(and(eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)))
 			.limit(1);

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -3,11 +3,12 @@ import type { NamespaceId } from "@aikirun/types/namespace";
 
 import { createTaskStateMachine } from "./state-machine/task";
 import { describe, expect, test } from "bun:test";
+import { InvalidTaskStateTransitionError, WorkflowRunTerminatedError } from "../errors";
 import { createTaskService } from "../service/task";
 import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
-import { seedClaimedRun } from "../testing/seed/run";
-import { seedRunningTask } from "../testing/seed/task";
+import { completeRun, seedClaimedRun, seedCompletedRun } from "../testing/seed/run";
+import { seedCompletedTask, seedRunningTask } from "../testing/seed/task";
 
 const withHarness = createServiceHarness();
 
@@ -134,5 +135,111 @@ describe("TaskService setTaskState", () => {
 			expect(await repos.task.getById({ id: victimTaskSeed.taskInfo.id, workflowRunId: victimTaskSeed.runId })).toEqual(
 				victimRowBefore
 			);
+		}));
+
+	test("does not create a task on a run that has already finished", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedCompletedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const taskService = createTaskService({ repos });
+			expect(
+				taskService.setTaskState(context, {
+					type: "new",
+					workflowRunId: runId,
+					taskName: "reserve-inventory",
+					input: { sku: "SKU-42", quantity: 3 },
+					inputHash: "request-input-hash",
+					state: { status: "completed", output: { reservationId: "rsv-1" } },
+				})
+			).rejects.toBeInstanceOf(WorkflowRunTerminatedError);
+
+			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([]);
+		}));
+
+	test("does not set an existing task's state on a run that has already finished", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+			await completeRun({ context, repos, runId, expectedRevision: revisionWhenClaimed });
+			const taskRowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+			expect(taskRowBefore).toEqual(expect.objectContaining({ id: taskInfo.id, status: "running" }));
+
+			const taskService = createTaskService({ repos });
+			expect(
+				taskService.setTaskState(context, {
+					type: "existing",
+					id: taskInfo.id,
+					workflowRunId: runId,
+					state: { status: "completed", output: { reservationId: "rsv-1" } },
+				})
+			).rejects.toBeInstanceOf(WorkflowRunTerminatedError);
+
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(taskRowBefore);
+		}));
+
+	test("does not reopen a task that already reached a terminal state", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, taskInfo } = await seedCompletedTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+			const taskRowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+			expect(taskRowBefore).toEqual(expect.objectContaining({ id: taskInfo.id, status: "completed" }));
+
+			const taskService = createTaskService({ repos });
+			expect(
+				taskService.setTaskState(context, {
+					type: "existing",
+					id: taskInfo.id,
+					workflowRunId: runId,
+					state: { status: "failed", error: { name: "Error", message: "boom" } },
+				})
+			).rejects.toBeInstanceOf(InvalidTaskStateTransitionError);
+
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(taskRowBefore);
+		}));
+
+	test("does not resolve a task that is waiting for its retry", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const taskStateMachine = createTaskStateMachine({ repos });
+			await taskStateMachine.transitionState(context, {
+				id: taskInfo.id,
+				workflowRunId: runId,
+				expectedWorkflowRunRevision: revisionWhenClaimed,
+				taskState: {
+					status: "awaiting_retry",
+					attempts: 1,
+					error: { name: "Error", message: "boom" },
+					nextAttemptInMs: 60_000,
+				},
+			});
+			const taskRowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
+			expect(taskRowBefore).toEqual(expect.objectContaining({ id: taskInfo.id, status: "awaiting_retry" }));
+
+			const taskService = createTaskService({ repos });
+			expect(
+				taskService.setTaskState(context, {
+					type: "existing",
+					id: taskInfo.id,
+					workflowRunId: runId,
+					state: { status: "failed", error: { name: "Error", message: "boom" } },
+				})
+			).rejects.toBeInstanceOf(InvalidTaskStateTransitionError);
+
+			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(taskRowBefore);
 		}));
 });

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -4,11 +4,12 @@ import type {
 	TaskSetStateRequestNew,
 	TaskSetStateRequestV1,
 } from "@aikirun/types/api/task";
-import type { WorkflowRunId } from "@aikirun/types/workflow/run";
-import type { TaskId, TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
+import { isTerminalWorkflowRunStatus, type WorkflowRunId } from "@aikirun/types/workflow/run";
+import type { TaskId, TaskName, TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
 import { monotonicFactory, ulid } from "ulidx";
 
-import { TaskStateConflictError } from "../errors";
+import { assertIsValidTaskStateTransition } from "./state-machine/task";
+import { TaskStateConflictError, WorkflowRunTerminatedError } from "../errors";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { NamespaceRequestContext } from "../middleware/context";
 
@@ -38,35 +39,40 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 
 	async setTaskState(context: NamespaceRequestContext, request: TaskSetStateRequestV1): Promise<void> {
 		if (request.type === "new") {
-			return repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, txRepos));
+			const taskId = await repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, txRepos));
+			context.logger.info("New task state set", {
+				"aiki.taskId": taskId,
+				"aiki.state": request.state,
+			});
+			return;
 		}
-		return repos.transaction(async (txRepos) => setExistingTaskStateInTx(context, request, txRepos));
+		await repos.transaction(async (txRepos) => setExistingTaskStateInTx(context, request, txRepos));
+		context.logger.info("Existing task state set", {
+			"aiki.taskId": request.id,
+			"aiki.state": request.state,
+		});
 	},
 });
 
 export type TaskService = ReturnType<typeof createTaskService>;
 
 async function setNewTaskStateInTx(
-	context: NamespaceRequestContext,
+	{ namespaceId }: NamespaceRequestContext,
 	request: TaskSetStateRequestNew,
 	txRepos: TxRepositories
-): Promise<void> {
-	const { namespaceId, logger } = context;
+): Promise<TaskId> {
 	const runId = request.workflowRunId as WorkflowRunId;
 	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}
+	if (isTerminalWorkflowRunStatus(run.status)) {
+		throw new WorkflowRunTerminatedError(runId, run.status);
+	}
 
-	const taskId = ulid();
+	const taskId = ulid() as TaskId;
 	const runningStateTransitionId = monotonicUlid();
 	const targetStateTransitionId = monotonicUlid();
-
-	logger.info("Setting task state (new task)", {
-		"aiki.runId": runId,
-		"aiki.taskId": taskId,
-		"aiki.state": request.state,
-	});
 
 	const runningState: TaskStateRunning = {
 		status: "running",
@@ -109,18 +115,22 @@ async function setNewTaskStateInTx(
 			state: targetState,
 		},
 	]);
+
+	return taskId;
 }
 
 async function setExistingTaskStateInTx(
-	context: NamespaceRequestContext,
+	{ namespaceId }: NamespaceRequestContext,
 	request: TaskSetStateRequestExisting,
 	txRepos: TxRepositories
 ): Promise<void> {
-	const { namespaceId, logger } = context;
 	const runId = request.workflowRunId as WorkflowRunId;
 	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
 	if (!run) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
+	}
+	if (isTerminalWorkflowRunStatus(run.status)) {
+		throw new WorkflowRunTerminatedError(runId, run.status);
 	}
 
 	const existingTaskRow = await txRepos.task.getById({ id: request.id, workflowRunId: runId });
@@ -128,11 +138,13 @@ async function setExistingTaskStateInTx(
 		throw new NotFoundError(`Task not found: ${request.id}`);
 	}
 
-	logger.info("Setting task state (existing task)", {
-		"aiki.runId": runId,
-		"aiki.taskId": request.id,
-		"aiki.state": request.state,
-	});
+	assertIsValidTaskStateTransition(
+		runId,
+		existingTaskRow.name as TaskName,
+		existingTaskRow.id as TaskId,
+		existingTaskRow.status,
+		request.state.status
+	);
 
 	const attempts = existingTaskRow.attempts;
 

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -120,6 +120,25 @@ export async function claimRun(deps: { context: NamespaceRequestContext; repos: 
 	return { revisionWhenClaimed: claim.revision, attemptsWhenClaimed: claim.attempts };
 }
 
+export async function completeRun(deps: {
+	context: NamespaceRequestContext;
+	repos: Repositories;
+	runId: string;
+	expectedRevision: number;
+}) {
+	const { context, repos, runId, expectedRevision } = deps;
+	const services = createServices(repos);
+
+	const completion = await services.workflowRunStateMachine.transitionState(context, {
+		type: "optimistic",
+		id: runId,
+		state: { status: "completed", output: seededRunOutput },
+		expectedRevision,
+	});
+
+	return { revisionWhenCompleted: completion.revision };
+}
+
 export async function seedClaimedRun(deps: SeedRunDeps & { publisher: FakePublisher }, overrides?: SeedRunOverrides) {
 	const { repos, publisher } = deps;
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();


### PR DESCRIPTION
## Problem

A task's state is written down two paths. Worker sessions drive the task state machine. The set-state endpoint is the other path — an out-of-band write with no worker session behind it, and so no run revision (the worker's proof that it still owns the run) to present.

| Guard | Worker path | Set-state endpoint |
|---|---|---|
| Run revision checked | yes | no — the request carries none | | Run still live | implied — a terminal transition bumps the revision, so a stale worker loses | no | | Task status change legal | validated against the task transition table | no | | Task row compare-and-set on `(status, attempts)` | yes | `existing` branch only; `new` inserts unguarded |

So a task can be created on or written to a run that already reached `cancelled`, `completed`, or `failed`. And a settled task can be moved again — the compare-and-set only asks whether the row still looks the way it was read, and a settled task does.

## Solution

**The run must still be live.** The run read now carries its status, and both branches reject a terminal run with a new conflict error. The share lock both paths already hold on the run row keeps that answer steady through commit.

**A task's status change must be legal.** The `existing` branch now validates against the same transition table the worker path uses. Since the request carries only `completed` or `failed`:

| Task status when the write lands | Outcome |
|---|---|
| `running` | accepted |
| `awaiting_retry` | rejected — the table allows only `running` next | | `completed`, `failed`, `discarded` | rejected — terminal |

Rejecting `awaiting_retry` is the point, not a side effect: moving that task straight to `completed` would charge an attempt that never ran. Rejecting `discarded` shapes stalled-run recovery, since stalling discards the run's leftover tasks — recording an outcome there means creating a task, not editing a dead one.

The `new` branch gets no transition check: it writes a `running` transition then the terminal one, both legal by construction.

## Breaking changes

The set-state endpoint rejects writes it previously accepted: a terminal run returns 409, a task that is not `running` returns 400.