### PR TITLE
Collapse the option builders into `with`

### DIFF
--- a/app/website/content/docs/core-concepts/client.mdx
+++ b/app/website/content/docs/core-concepts/client.mdx
@@ -111,8 +111,7 @@ Prevent duplicate executions using a reference ID:
 
 ```typescript
 const handle = await workflowVersion
-	.with()
-	.opt("reference.id", "order-123")
+	.with("reference.id", "order-123")
 	.start(aikiClient, { orderId: "order-123" });
 ```
 

--- a/app/website/content/docs/core-concepts/events.md
+++ b/app/website/content/docs/core-concepts/events.md
@@ -95,8 +95,7 @@ Prevent duplicate event delivery using a reference ID:
 
 ```typescript
 await handle.events.paymentReceived
-	.with()
-	.opt("reference.id", "payment-txn_abc123")
+	.with("reference.id", "payment-txn_abc123")
 	.send({ transactionId: "txn_abc123", amount: 99.99 });
 ```
 
@@ -174,14 +173,12 @@ Events with the same reference ID are silently deduplicated - duplicates are ign
 ```typescript
 // First send - event delivered
 await handle.events.paymentReceived
-	.with()
-	.opt("reference.id", "payment-123")
+	.with("reference.id", "payment-123")
 	.send({ transactionId: "txn_abc" });
 
 // Second send with same reference ID - silently ignored
 await handle.events.paymentReceived
-	.with()
-	.opt("reference.id", "payment-123")
+	.with("reference.id", "payment-123")
 	.send({ transactionId: "txn_abc" });
 ```
 

--- a/app/website/content/docs/core-concepts/schedules.md
+++ b/app/website/content/docs/core-concepts/schedules.md
@@ -104,7 +104,7 @@ Overlap policies are evaluated per schedule instance, not globally. If you activ
 
 ## Run Options
 
-A workflow definition can declare default start options, such as its `retry` strategy. A schedule sets the start options for the runs it fires:
+A schedule fires runs of the workflow you hand to `activate()`, and those runs carry that workflow's options — whatever it declared at definition time, plus anything you set via `with()`. Configure the workflow, not the schedule:
 
 ```typescript
 const hourlySync = schedule({
@@ -112,14 +112,17 @@ const hourlySync = schedule({
 	every: { hours: 1 },
 });
 
-await hourlySync
-	.with()
-	.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
-	.opt("workflowRun.pool", "foo-bar")
-	.activate(client, inventorySyncV1);
+await hourlySync.activate(
+	client,
+	inventorySyncV1
+		.with("retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
+		.with("pool", "foo-bar")
+);
 ```
 
-Only `retry` and `pool` can be set: a scheduled run's reference ID and trigger are the schedule's to control, not the caller's. Run options are part of a schedule's identity, so changing them is a different schedule — or, with a [reference ID](#reference-ids), a conflict.
+Only `retry` and `pool` travel this way. `reference` or `trigger` answers something about one particular run — which run it is, when execution begins — and a schedule fires a fresh run every tick, so passing a workflow that carries either will not compile. See [Workflow Options](./workflows.md#workflow-options).
+
+Run options are part of a schedule's identity, so changing them is a different schedule — or, with a [reference ID](#reference-ids), a conflict.
 
 ## Idempotent Activation
 
@@ -133,8 +136,7 @@ By default, schedule identity is derived from a hash of the workflow name, versi
 
 ```typescript
 const handle = await dailyReport
-	.with()
-	.opt("reference.id", "tenant-acme-daily-report")
+	.with("reference.id", "tenant-acme-daily-report")
 	.activate(client, reportWorkflowV1, { tenantId: "acme" });
 ```
 
@@ -146,8 +148,7 @@ When activating a schedule with a reference ID that already identifies a schedul
 
 ```typescript
 const handle = await dailyReport
-	.with()
-	.opt("reference", {
+	.with("reference", {
 		id: "my-schedule",
 		conflictPolicy: "error",
 	})

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -136,14 +136,47 @@ Schemas work with any validation library that implements [Standard Schema](https
 
 **Why use output schemas?** For child workflows, cached outputs are validated against the schema. If the cached shape doesn't match, the parent workflow fails immediately. See [Refactoring Workflows](../guides/refactoring-workflows.md#changing-task-or-child-workflow-output-shapes).
 
+## Workflow Options
+
+`with()` sets one option and returns a copy, leaving the original untouched. Chain it to set several:
+
+```typescript
+const configured = orderWorkflowV1
+	.with("pool", "gpu")
+	.with("retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 });
+```
+
+The paths are strings, but they are type checked. `with()` takes only paths that exist on the options, and the value has to match the type at that path — your editor completes the paths, and anything else fails to compile:
+
+```typescript
+orderWorkflowV1.with("reference.id", "order-123");   // ✅︎
+orderWorkflowV1.with("reference.di", "order-123");   // ❌ no such option
+orderWorkflowV1.with("reference.id", 123);           // ❌ reference.id is a string
+```
+
+Look at what each option answers and they fall into two groups.
+
+`retry` answers "if this fails, try three more times". `pool` answers "run on this kind of workers". Answers like those fit any run — the one you start now, or one that goes next Tuesday. Set one and you get back something you can go on starting as often as you like.
+
+`reference` answers "this particular run is order-123" - a second run cannot be referenced as order-123. `trigger` answers "execute this particular run five minutes from now" - scheduled runs are triggered on a pre-configured cadence. Both are about one particular run — which one it is, when it goes. Set one and you get back a single start — you can `start()` it, and that is all.
+
+The difference is important because some things make or execute many runs out of one workflow: a schedule fires a run every tick, a worker executes whatever runs turn up. Hand either of them a single start and it will not compile:
+
+```typescript
+const oneOff = orderWorkflowV1.with("reference.id", "order-123");
+
+await oneOff.start(client, { orderId: "123" });        // ✅︎ fine
+await hourlySync.activate(client, oneOff);             // ❌ does not compile
+worker({ workflows: [oneOff] });                       // ❌ does not compile
+```
+
 ## Worker Pools
 
 Route workflows to a named worker pool when only part of your fleet should execute them — a fleet with special hardware, a fleet dedicated to one tenant, or a regional deployment:
 
 ```typescript
 const handle = await orderWorkflowV1
-	.with()
-	.opt("pool", "gpu")
+	.with("pool", "gpu")
 	.start(client, { orderId: "123" });
 ```
 
@@ -176,8 +209,7 @@ Use reference IDs for idempotent workflow starts:
 
 ```typescript
 const handle = await orderWorkflowV1
-	.with()
-	.opt("reference.id", "order-123")
+	.with("reference.id", "order-123")
 	.start(client, { orderId: "123" });
 ```
 
@@ -336,8 +368,7 @@ Use reference IDs to ensure idempotent child workflow creation:
 
 ```typescript
 const childHandle = await childWorkflowV1
-	.with()
-	.opt("reference.id", `process-user-${input.userId}`)
+	.with("reference.id", `process-user-${input.userId}`)
 	.startAsChild(run, { userId: input.userId });
 ```
 
@@ -350,14 +381,12 @@ When starting a child workflow multiple times with the same reference ID but dif
 ```typescript
 // Default: "error" - fails the parent workflow
 const childHandle = await childWorkflowV1
-	.with()
-	.opt("reference.id", "unique-id")
+	.with("reference.id", "unique-id")
 	.startAsChild(run, input);
 
 // Alternative: "return_existing" - returns the existing child run
 const childHandle = await childWorkflowV1
-	.with()
-	.opt("reference", { id: "unique-id", conflictPolicy: "return_existing" })
+	.with("reference", { id: "unique-id", conflictPolicy: "return_existing" })
 	.startAsChild(run, input);
 ```
 

--- a/app/website/content/docs/guides/reference-ids.md
+++ b/app/website/content/docs/guides/reference-ids.md
@@ -23,7 +23,7 @@ When starting workflows, you can provide a reference ID:
 ```typescript
 // Start a workflow with a reference ID
 const handle = await orderWorkflowV1
-  .with().opt("reference.id", "order-123")
+  .with("reference.id", "order-123")
   .start(client, { orderId: "order-123", items: [...] });
 
 // You can now look up this workflow using "order-123"
@@ -38,12 +38,12 @@ By default, Aiki throws an error when you try to start a workflow with a referen
 ```typescript
 // Default behavior: throw error on conflict
 const handle = await orderWorkflowV1
-  .with().opt("reference", { id: "order-123-process", conflictPolicy: "error" })
+  .with("reference", { id: "order-123-process", conflictPolicy: "error" })
   .start(client, { orderId: "order-123", items: [...] });
 
 // Alternative: return existing run on conflict
 const handle = await orderWorkflowV1
-  .with().opt("reference", { id: "order-123-process", conflictPolicy: "return_existing" })
+  .with("reference", { id: "order-123-process", conflictPolicy: "return_existing" })
   .start(client, { orderId: "order-123", items: [...] });
 
 // With "return_existing", duplicate calls return the same workflow run
@@ -57,15 +57,13 @@ When sending events to a workflow, you can provide a reference ID to prevent dup
 ```typescript
 // Send an event with a reference ID
 await handle.events.approved
-  .with()
-  .opt("reference.id", "approval-123")
+  .with("reference.id", "approval-123")
   .send({ by: "manager@example.com" });
 
 // If the same event is sent again with the same reference ID,
 // it will be silently ignored (no error, no duplicate)
 await handle.events.approved
-  .with()
-  .opt("reference.id", "approval-123")
+  .with("reference.id", "approval-123")
   .send({ by: "manager@example.com" }); // Ignored - duplicate
 
 // Without options, use send directly
@@ -80,8 +78,7 @@ When activating schedules, you can provide a reference ID for explicit identity:
 
 ```typescript
 const handle = await dailyReport
-	.with()
-	.opt("reference", {
+	.with("reference", {
 		id: "tenant-acme-daily-report",
 		conflictPolicy: "error",
 	})

--- a/examples/src/scenarios/delayed-start.ts
+++ b/examples/src/scenarios/delayed-start.ts
@@ -6,8 +6,7 @@ await runWithWorker([notify], async (client) => {
 	client.logger.info("Starting delayed workflow...");
 
 	const handle = await notify
-		.with()
-		.opt("trigger", { type: "delayed", delay: { seconds: 5 } })
+		.with("trigger", { type: "delayed", delay: { seconds: 5 } })
 		.start(client, "It's a good day");
 	const result = await handle.waitForStatus("completed");
 

--- a/examples/src/scenarios/scheduled-notify.ts
+++ b/examples/src/scenarios/scheduled-notify.ts
@@ -12,10 +12,12 @@ const everyTenSeconds = schedule({
 
 await runWithWorker([notify], async (client) => {
 	const scheduleHandle = await everyTenSeconds
-		.with()
-		.opt("reference.id", "my-correlation-rgwee")
-		.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-		.activate(client, notify, "This is a reminder");
+		.with("reference.id", "my-correlation-rgwee")
+		.activate(
+			client,
+			notify.with("retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 }),
+			"This is a reminder"
+		);
 	await delay(20_000);
 	await scheduleHandle.pause();
 });

--- a/presentations/durable-execution.md
+++ b/presentations/durable-execution.md
@@ -676,8 +676,8 @@ await run.sleep({ hours: 1 });
 
 ```typescript
 async function placeOrder(orderId, items) {
-  await processOrderV1.with()
-    .opt("reference", { id: orderId })
+  await processOrderV1
+    .with("reference", { id: orderId })
     .start(aikiClient, orderId);
   return { orderId, message: "Complete payment within 30 minutes" };
 }

--- a/sdk/worker/src/index.ts
+++ b/sdk/worker/src/index.ts
@@ -3,5 +3,5 @@ export { asConfigProvider } from "@aikirun/lib/config";
 
 export type { WorkerConfig, WorkerConfigOverrides } from "./config";
 export { defaultWorkerConfig, dynamicWorkerConfigProvider, staticWorkerConfigProvider } from "./config";
-export type { Worker, WorkerBuilder, WorkerHandle, WorkerParams, WorkerStartOptions } from "./worker";
+export type { Worker, WorkerHandle, WorkerParams, WorkerStartOptions } from "./worker";
 export { worker } from "./worker";

--- a/sdk/worker/src/worker.test.ts
+++ b/sdk/worker/src/worker.test.ts
@@ -1,0 +1,14 @@
+import { workflow } from "@aikirun/workflow";
+
+import { worker } from "./worker";
+
+const ordersV1 = workflow({ name: "orders" }).v("v1", { handler: async () => {} });
+
+// Compile-time guarantees, never executed. Each `@ts-expect-error` fails the build if its error stops
+// being reported, so they hold `WorkerParams.workflows` to workflows a worker can actually run.
+function _startConfiguredWorkflowIsNotRegistrable() {
+	// @ts-expect-error a worker executes runs it did not start, so a workflow bound to one start is not one it can run
+	worker({ workflows: [ordersV1.with("trigger", { type: "delayed", delay: { seconds: 5 } })] });
+
+	worker({ workflows: [ordersV1.with("pool", "gpu")] });
+}

--- a/sdk/worker/src/worker.ts
+++ b/sdk/worker/src/worker.ts
@@ -80,7 +80,11 @@ export interface WorkerStartOptions {
 }
 
 export interface Worker {
-	with(): WorkerBuilder;
+	/** Sets one start option and returns a copy of {@link Worker}. The original is unchanged. */
+	with<Path extends PathFromObject<WorkerStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<WorkerStartOptions, Path>
+	): Worker;
 	start: <Context>(client: Client<Context>) => WorkerHandle;
 }
 
@@ -90,19 +94,24 @@ export interface WorkerHandle {
 }
 
 class WorkerImpl implements Worker {
-	constructor(private readonly params: WorkerParams) {}
+	private readonly startOptionsBuilder: ObjectBuilder<WorkerStartOptions>;
 
-	public with(): WorkerBuilder {
-		const startOptionsOverrider = objectOverrider<WorkerStartOptions>({});
-		return createWorkerBuilder(this, startOptionsOverrider());
+	constructor(
+		private readonly params: WorkerParams,
+		startOptionsBuilder?: ObjectBuilder<WorkerStartOptions>
+	) {
+		this.startOptionsBuilder = startOptionsBuilder ?? objectOverrider<WorkerStartOptions>({})();
+	}
+
+	public with<Path extends PathFromObject<WorkerStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<WorkerStartOptions, Path>
+	): Worker {
+		return new WorkerImpl(this.params, this.startOptionsBuilder.with(path, value));
 	}
 
 	public start<Context>(client: Client<Context>): WorkerHandle {
-		return this.startWithOptions(client, {});
-	}
-
-	public startWithOptions<Context>(client: Client<Context>, startOptions: WorkerStartOptions): WorkerHandle {
-		return new WorkerHandleImpl(client, this.params, startOptions);
+		return new WorkerHandleImpl(client, this.params, this.startOptionsBuilder.build());
 	}
 }
 
@@ -461,27 +470,4 @@ class WorkerHandleImpl<Context> implements WorkerHandle {
 			this.availableCapacityLatch.signal();
 		}
 	}
-}
-
-export interface WorkerBuilder {
-	opt<Path extends PathFromObject<WorkerStartOptions>>(
-		path: Path,
-		value: TypeOfValueAtPath<WorkerStartOptions, Path>
-	): WorkerBuilder;
-	start: Worker["start"];
-}
-
-function createWorkerBuilder(
-	worker: WorkerImpl,
-	startOptionsBuilder: ObjectBuilder<WorkerStartOptions>
-): WorkerBuilder {
-	return {
-		opt(path, value) {
-			return createWorkerBuilder(worker, startOptionsBuilder.with(path, value));
-		},
-
-		start(client) {
-			return worker.startWithOptions(client, startOptionsBuilder.build());
-		},
-	};
 }

--- a/sdk/workflow/src/index.ts
+++ b/sdk/workflow/src/index.ts
@@ -57,4 +57,9 @@ export type { Task, TaskParams } from "./task";
 export { task } from "./task";
 export type { Workflow, WorkflowParams } from "./workflow";
 export { workflow } from "./workflow";
-export type { AnyWorkflowVersion, WorkflowVersion, WorkflowVersionParams } from "./workflow-version";
+export type {
+	AnyWorkflowVersion,
+	WorkflowVersion,
+	WorkflowVersionParams,
+	WorkflowVersionStart,
+} from "./workflow-version";

--- a/sdk/workflow/src/registry.test.ts
+++ b/sdk/workflow/src/registry.test.ts
@@ -147,3 +147,12 @@ describe("workflowRegistry", () => {
 		expect(result).toBe(registry);
 	});
 });
+
+// Compile-time guarantees, never executed. Each `@ts-expect-error` fails the build if its error stops
+// being reported, so they hold the run/start option split in place.
+function _startConfiguredWorkflowIsNotRegistrable() {
+	// @ts-expect-error a worker executes many runs, so a workflow bound to one start cannot be registered
+	workflowRegistry().add("user", ordersV1.with("trigger", { type: "delayed", delay: { seconds: 5 } }));
+
+	workflowRegistry().add("user", ordersV1.with("pool", "gpu"));
+}

--- a/sdk/workflow/src/run/event.test.ts
+++ b/sdk/workflow/src/run/event.test.ts
@@ -175,7 +175,12 @@ describe("createEventSenders", () => {
 				{ orderShipped: event<{ trackingId: string }>() },
 				client.logger
 			);
-			client.api.workflowRun.sendEventV1.once({ id: "run-1", eventName: "orderShipped", data: { trackingId: "T1" } });
+			client.api.workflowRun.sendEventV1.once({
+				id: "run-1",
+				eventName: "orderShipped",
+				data: { trackingId: "T1" },
+				options: {},
+			});
 
 			await senders.orderShipped.send({ trackingId: "T1" });
 		}));
@@ -188,7 +193,7 @@ describe("createEventSenders", () => {
 				{ note: event({ schema: appendBangSchema }) },
 				client.logger
 			);
-			client.api.workflowRun.sendEventV1.once({ id: "run-1", eventName: "note", data: "raw!" });
+			client.api.workflowRun.sendEventV1.once({ id: "run-1", eventName: "note", data: "raw!", options: {} });
 
 			await senders.note.send("raw");
 		}));
@@ -220,7 +225,7 @@ describe("createEventSenders", () => {
 				options: { reference: { id: "ref-1" } },
 			});
 
-			await senders.orderShipped.with().opt("reference.id", "ref-1").send({ trackingId: "T1" });
+			await senders.orderShipped.with("reference.id", "ref-1").send({ trackingId: "T1" });
 		}));
 });
 
@@ -237,6 +242,7 @@ describe("createEventMulticasters", () => {
 				ids: ["run-1", "run-2"],
 				eventName: "orderShipped",
 				data: { trackingId: "T1" },
+				options: {},
 			});
 
 			await multicasters.orderShipped.send(client, ["run-1", "run-2"], { trackingId: "T1" });
@@ -251,6 +257,7 @@ describe("createEventMulticasters", () => {
 				ids: ["run-1"],
 				eventName: "orderShipped",
 				data: { trackingId: "T1" },
+				options: {},
 			});
 
 			await multicasters.orderShipped.send(client, "run-1", { trackingId: "T1" });
@@ -277,6 +284,7 @@ describe("createEventMulticasters", () => {
 				],
 				eventName: "orderShipped",
 				data: { trackingId: "T1" },
+				options: {},
 			});
 
 			await multicasters.orderShipped.sendByReferenceId(client, ["ref-1", "ref-2"], { trackingId: "T1" });
@@ -291,6 +299,7 @@ describe("createEventMulticasters", () => {
 				references: [{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-1" }],
 				eventName: "orderShipped",
 				data: { trackingId: "T1" },
+				options: {},
 			});
 
 			await multicasters.orderShipped.sendByReferenceId(client, "ref-1", { trackingId: "T1" });
@@ -326,6 +335,6 @@ describe("createEventMulticasters", () => {
 				options: { reference: { id: "ref-1" } },
 			});
 
-			await multicasters.orderShipped.with().opt("reference.id", "ref-1").send(client, "run-1", { trackingId: "T1" });
+			await multicasters.orderShipped.with("reference.id", "ref-1").send(client, "run-1", { trackingId: "T1" });
 		}));
 });

--- a/sdk/workflow/src/run/event.ts
+++ b/sdk/workflow/src/run/event.ts
@@ -1,7 +1,7 @@
 import { isNonEmptyArray } from "@aikirun/lib/collection/array";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
-import { objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
+import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfValueAtPath } from "@aikirun/lib/object";
 import type { Serializable } from "@aikirun/lib/serializable";
 import type { ApiClient, Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
@@ -78,15 +78,11 @@ export type EventSenders<TEvents extends EventsDefinition> = {
 };
 
 export interface EventSender<Data> {
-	with(): EventSenderBuilder<Data>;
-	send: (...args: Data extends void ? [] : [Data]) => Promise<void>;
-}
-
-export interface EventSenderBuilder<Data> {
-	opt<Path extends PathFromObject<EventSendOptions>>(
+	/** Sets one send option and returns of {@link EventSender}. The original is unchanged. */
+	with<Path extends PathFromObject<EventSendOptions>>(
 		path: Path,
 		value: TypeOfValueAtPath<EventSendOptions, Path>
-	): EventSenderBuilder<Data>;
+	): EventSender<Data>;
 	send: (...args: Data extends void ? [] : [Data]) => Promise<void>;
 }
 
@@ -95,29 +91,16 @@ export type EventMulticasters<TEvents extends EventsDefinition> = {
 };
 
 export interface EventMulticaster<Data> {
-	with(): EventMulticasterBuilder<Data>;
+	/** Sets one send option and returns a copy of {@link EventMulticaster}. The original is unchanged. */
+	with<Path extends PathFromObject<EventSendOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<EventSendOptions, Path>
+	): EventMulticaster<Data>;
 	send: <Context>(
 		client: Client<Context>,
 		runId: string | string[],
 		...args: Data extends void ? [] : [Data]
 	) => Promise<void>;
-	sendByReferenceId<Context>(
-		client: Client<Context>,
-		referenceId: string | string[],
-		...args: Data extends void ? [] : [Data]
-	): Promise<void>;
-}
-
-export interface EventMulticasterBuilder<Data> {
-	opt<Path extends PathFromObject<EventSendOptions>>(
-		path: Path,
-		value: TypeOfValueAtPath<EventSendOptions, Path>
-	): EventMulticasterBuilder<Data>;
-	send<Context>(
-		client: Client<Context>,
-		runId: string | string[],
-		...args: Data extends void ? [] : [Data]
-	): Promise<void>;
 	sendByReferenceId<Context>(
 		client: Client<Context>,
 		referenceId: string | string[],
@@ -204,11 +187,13 @@ export function createEventSenders<TEvents extends EventsDefinition>(
 	const senders = {} as EventSenders<TEvents>;
 
 	for (const [eventName, eventDefinition] of Object.entries(eventsDefinition)) {
+		const optionsBuilder = objectOverrider<EventSendOptions>({})();
 		const sender = createEventSender(
 			api,
 			workflowRunId,
 			eventName as EventName,
 			eventDefinition.schema,
+			optionsBuilder,
 			logger.child({ "aiki.eventName": eventName })
 		) as EventSender<EventData<TEvents[keyof TEvents]>>;
 		senders[eventName as keyof TEvents] = sender;
@@ -222,17 +207,9 @@ function createEventSender<Data>(
 	workflowRunId: string,
 	eventName: EventName,
 	schema: StandardSchemaV1<Data> | undefined,
-	logger: Logger,
-	options?: EventSendOptions
+	optionsBuilder: ObjectBuilder<EventSendOptions>,
+	logger: Logger
 ): EventSender<Data> {
-	const optionsOverrider = objectOverrider(options ?? {});
-
-	const createBuilder = (optionsBuilder: ReturnType<typeof optionsOverrider>): EventSenderBuilder<Data> => ({
-		opt: (path, value) => createBuilder(optionsBuilder.with(path, value)),
-		send: (...args: Data extends void ? [] : [Data]) =>
-			createEventSender(api, workflowRunId, eventName, schema, logger, optionsBuilder.build()).send(...args),
-	});
-
 	async function send(...args: Data extends void ? [] : [Data]): Promise<void> {
 		let data = args[0];
 		if (schema) {
@@ -244,6 +221,8 @@ function createEventSender<Data>(
 			}
 			data = schemaValidationResult.value;
 		}
+
+		const options = optionsBuilder.build();
 
 		await api.workflowRun.sendEventV1({
 			id: workflowRunId,
@@ -258,7 +237,8 @@ function createEventSender<Data>(
 	}
 
 	return {
-		with: () => createBuilder(optionsOverrider()),
+		with: (path, value) =>
+			createEventSender(api, workflowRunId, eventName, schema, optionsBuilder.with(path, value), logger),
 		send,
 	};
 }
@@ -271,11 +251,13 @@ export function createEventMulticasters<TEvents extends EventsDefinition>(
 	const senders = {} as EventMulticasters<TEvents>;
 
 	for (const [eventName, eventDefinition] of Object.entries(eventsDefinition)) {
+		const optionsBuilder = objectOverrider<EventSendOptions>({})();
 		const sender = createEventMulticaster(
 			workflowName,
 			workflowVersionId,
 			eventName as EventName,
-			eventDefinition.schema
+			eventDefinition.schema,
+			optionsBuilder
 		) as EventMulticaster<EventData<TEvents[keyof TEvents]>>;
 		senders[eventName as keyof TEvents] = sender;
 	}
@@ -288,32 +270,8 @@ function createEventMulticaster<Data>(
 	workflowVersionId: WorkflowVersionId,
 	eventName: EventName,
 	schema: StandardSchemaV1<Data> | undefined,
-	options?: EventSendOptions
+	optionsBuilder: ObjectBuilder<EventSendOptions>
 ): EventMulticaster<Data> {
-	const optionsOverrider = objectOverrider(options ?? {});
-
-	const createBuilder = (optionsBuilder: ReturnType<typeof optionsOverrider>): EventMulticasterBuilder<Data> => ({
-		opt: (path, value) => createBuilder(optionsBuilder.with(path, value)),
-		send: <Context>(client: Client<Context>, runId: string | string[], ...args: Data extends void ? [] : [Data]) =>
-			createEventMulticaster(workflowName, workflowVersionId, eventName, schema, optionsBuilder.build()).send(
-				client,
-				runId,
-				...args
-			),
-		sendByReferenceId: <Context>(
-			client: Client<Context>,
-			referenceId: string | string[],
-			...args: Data extends void ? [] : [Data]
-		) =>
-			createEventMulticaster(
-				workflowName,
-				workflowVersionId,
-				eventName,
-				schema,
-				optionsBuilder.build()
-			).sendByReferenceId(client, referenceId, ...args),
-	});
-
 	async function send<Context>(
 		client: Client<Context>,
 		runId: string | string[],
@@ -339,6 +297,8 @@ function createEventMulticaster<Data>(
 		if (!isNonEmptyArray(runIds)) {
 			return;
 		}
+
+		const options = optionsBuilder.build();
 
 		await client.api.workflowRun.multicastEventV1({
 			ids: runIds,
@@ -382,6 +342,8 @@ function createEventMulticaster<Data>(
 			return;
 		}
 
+		const options = optionsBuilder.build();
+
 		await client.api.workflowRun.multicastEventByReferenceV1({
 			references: referenceIds.map((referenceId) => ({
 				name: workflowName,
@@ -403,7 +365,8 @@ function createEventMulticaster<Data>(
 	}
 
 	return {
-		with: () => createBuilder(optionsOverrider()),
+		with: (path, value) =>
+			createEventMulticaster(workflowName, workflowVersionId, eventName, schema, optionsBuilder.with(path, value)),
 		send,
 		sendByReferenceId,
 	};

--- a/sdk/workflow/src/schedule.test.ts
+++ b/sdk/workflow/src/schedule.test.ts
@@ -5,6 +5,7 @@ import {
 	intervalScheduleActivateRequestFactory,
 } from "@aikirun/testing/data-factory/api/schedule";
 import { cronScheduleFactory, intervalScheduleFactory } from "@aikirun/testing/data-factory/schedule";
+import type { Client } from "@aikirun/types/client";
 import type { ScheduleId } from "@aikirun/types/schedule";
 
 import { schedule } from "./schedule";
@@ -81,8 +82,8 @@ describe("schedule", () => {
 			}));
 	});
 
-	describe("with builder", () => {
-		test("opt sets the options sent to activate", () =>
+	describe("with", () => {
+		test("sets the options sent to activate", () =>
 			withFakeClient(async (client) => {
 				client.api.schedule.activateV1.once(
 					intervalScheduleActivateRequest.build({
@@ -92,8 +93,7 @@ describe("schedule", () => {
 				);
 
 				await schedule({ type: "interval", every: { seconds: 1 } })
-					.with()
-					.opt("reference.id", "ref-1")
+					.with("reference.id", "ref-1")
 					.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
 			}));
 	});
@@ -104,26 +104,7 @@ describe("schedule", () => {
 			retry: { type: "fixed", maxAttempts: 5, delayMs: 300 },
 		});
 
-		test("opt carries retry and pool to every fired run", () =>
-			withFakeClient(async (client) => {
-				client.api.schedule.activateV1.once(
-					intervalScheduleActivateRequest.build({
-						workflowRunOptions: {
-							retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 },
-							pool: "eu",
-						},
-					}),
-					{ schedule: intervalScheduleFactory.build() }
-				);
-
-				await schedule({ type: "interval", every: { seconds: 1 } })
-					.with()
-					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-					.opt("workflowRun.pool", "eu")
-					.activate(client, syncInventoryWorkflow, { warehouseId: "wh-1" });
-			}));
-
-		test("carries the workflow's declared retry default when the schedule sets no overrides", () =>
+		test("carries the workflow's declared retry default", () =>
 			withFakeClient(async (client) => {
 				client.api.schedule.activateV1.once(
 					intervalScheduleActivateRequest.build({
@@ -137,7 +118,7 @@ describe("schedule", () => {
 				});
 			}));
 
-		test("a schedule retry override replaces the workflow's declared default", () =>
+		test("carries the workflow's own overrides to every fired run", () =>
 			withFakeClient(async (client) => {
 				client.api.schedule.activateV1.once(
 					intervalScheduleActivateRequest.build({
@@ -149,11 +130,33 @@ describe("schedule", () => {
 					{ schedule: intervalScheduleFactory.build() }
 				);
 
-				await schedule({ type: "interval", every: { seconds: 1 } })
-					.with()
-					.opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
-					.opt("workflowRun.pool", "eu")
-					.activate(client, retryingSyncInventoryWorkflow, { warehouseId: "wh-1" });
+				await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					syncInventoryWorkflow
+						.with("retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 })
+						.with("pool", "eu"),
+					{ warehouseId: "wh-1" }
+				);
+			}));
+
+		test("a workflow override replaces its declared default", () =>
+			withFakeClient(async (client) => {
+				client.api.schedule.activateV1.once(
+					intervalScheduleActivateRequest.build({
+						workflowRunOptions: { retry: { type: "exponential", maxAttempts: 3, baseDelayMs: 1_000 } },
+					}),
+					{ schedule: intervalScheduleFactory.build() }
+				);
+
+				await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+					client,
+					retryingSyncInventoryWorkflow.with("retry", {
+						type: "exponential",
+						maxAttempts: 3,
+						baseDelayMs: 1_000,
+					}),
+					{ warehouseId: "wh-1" }
+				);
 			}));
 	});
 
@@ -204,3 +207,20 @@ describe("schedule", () => {
 			}));
 	});
 });
+
+// Compile-time guarantees, never executed. Each `@ts-expect-error` fails the build if its error stops
+// being reported, so they hold the run/start option split in place.
+async function _startConfiguredWorkflowIsNotSchedulable(client: Client<null>) {
+	await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+		client,
+		// @ts-expect-error a schedule mints many runs, so a workflow bound to one start cannot back one
+		syncInventoryWorkflow.with("reference.id", "one-off"),
+		{ warehouseId: "wh-1" }
+	);
+
+	await schedule({ type: "interval", every: { seconds: 1 } }).activate(
+		client,
+		syncInventoryWorkflow.with("pool", "gpu"),
+		{ warehouseId: "wh-1" }
+	);
+}

--- a/sdk/workflow/src/schedule.ts
+++ b/sdk/workflow/src/schedule.ts
@@ -4,7 +4,6 @@ import { type ObjectBuilder, objectOverrider, type PathFromObject, type TypeOfVa
 import type { Client } from "@aikirun/types/client";
 import type { ScheduleActivateOptions, ScheduleId, ScheduleOverlapPolicy, ScheduleSpec } from "@aikirun/types/schedule";
 import { INTERNAL } from "@aikirun/types/symbols";
-import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 
 import type { EventsDefinition } from "./run/event";
 import type { WorkflowVersion } from "./workflow-version";
@@ -31,15 +30,17 @@ export interface ScheduleHandle {
 	deactivate(): Promise<void>;
 }
 
-type ScheduleBuilderActivateOptions = ScheduleActivateOptions & {
-	workflowRun?: WorkflowRunOptions;
-};
-
-export interface ScheduleBuilder {
-	opt<Path extends PathFromObject<ScheduleBuilderActivateOptions>>(
+export interface ScheduleDefinition {
+	/**
+	 * Sets one option and returns a copy of {@link ScheduleDefinition}. The original is unchanged.
+	 *
+	 * These describe the schedule itself. What the runs it fires carry comes from the workflow you
+	 * hand to {@link ScheduleDefinition.activate} — configure that with its own `with`.
+	 */
+	with<Path extends PathFromObject<ScheduleActivateOptions>>(
 		path: Path,
-		value: TypeOfValueAtPath<ScheduleBuilderActivateOptions, Path>
-	): ScheduleBuilder;
+		value: TypeOfValueAtPath<ScheduleActivateOptions, Path>
+	): ScheduleDefinition;
 
 	activate<Input, Output, Context, TEvents extends EventsDefinition>(
 		client: Client<Context>,
@@ -48,99 +49,75 @@ export interface ScheduleBuilder {
 	): Promise<ScheduleHandle>;
 }
 
-export type ScheduleDefinition = ScheduleParams & {
-	with(): ScheduleBuilder;
-
-	activate<Input, Output, Context, TEvents extends EventsDefinition>(
-		client: Client<Context>,
-		workflow: WorkflowVersion<Input, Output, Context, TEvents>,
-		...args: Input extends void ? [] : [Input]
-	): Promise<ScheduleHandle>;
-};
-
 export function schedule(params: ScheduleParams): ScheduleDefinition {
-	async function activateWithOptions<Input, Output, Context, TEvents extends EventsDefinition>(
-		client: Client<Context>,
-		workflow: WorkflowVersion<Input, Output, Context, TEvents>,
-		options: ScheduleBuilderActivateOptions,
-		...args: Input extends void ? [] : [Input]
-	): Promise<ScheduleHandle> {
-		const workflowRunInput = args[0];
-		const hasher = client[INTERNAL].hasher;
-		const workflowRunInputHash = await hasher(workflowRunInput);
-		const { workflowRun: workflowRunOptions, ...scheduleOptions } = options;
+	return createSchedule(params, objectOverrider<ScheduleActivateOptions>({})());
+}
 
-		let scheduleSpec: ScheduleSpec;
-		if (params.type === "interval") {
-			const { every, ...rest } = params;
-			scheduleSpec = {
-				...rest,
-				everyMs: toMilliseconds(every),
-			};
-		} else {
-			scheduleSpec = params;
-		}
+function createSchedule(
+	params: ScheduleParams,
+	optionsBuilder: ObjectBuilder<ScheduleActivateOptions>
+): ScheduleDefinition {
+	return {
+		with: (path, value) => createSchedule(params, optionsBuilder.with(path, value)),
 
-		const { schedule } = await client.api.schedule.activateV1({
-			workflowName: workflow.name,
-			workflowVersionId: workflow.versionId,
-			spec: scheduleSpec,
-			workflowRunInput,
-			workflowRunInputHash,
-			options: scheduleOptions,
-			workflowRunOptions,
-		});
-		client.logger.info("Schedule activated", {
-			"aiki.scheduleSpec": scheduleSpec,
-			"aiki.workflowName": workflow.name,
-			"aiki.workflowVersionId": workflow.versionId,
-			"aiki.scheduleReferenceId": scheduleOptions.reference?.id,
-		});
+		activate: (client, workflow, ...args) =>
+			activateWithOptions(client, workflow, params, optionsBuilder.build(), ...args),
+	};
+}
 
-		const scheduleId = schedule.id as ScheduleId;
+async function activateWithOptions<Input, Output, Context, TEvents extends EventsDefinition>(
+	client: Client<Context>,
+	workflow: WorkflowVersion<Input, Output, Context, TEvents>,
+	params: ScheduleParams,
+	options: ScheduleActivateOptions,
+	...args: Input extends void ? [] : [Input]
+): Promise<ScheduleHandle> {
+	const workflowRunInput = args[0];
+	const hasher = client[INTERNAL].hasher;
+	const workflowRunInputHash = await hasher(workflowRunInput);
 
-		return {
-			id: scheduleId,
-
-			pause: async () => {
-				await client.api.schedule.pauseV1({ id: scheduleId });
-			},
-
-			resume: async () => {
-				await client.api.schedule.resumeV1({ id: scheduleId });
-			},
-
-			deactivate: async () => {
-				await client.api.schedule.deactivateV1({ id: scheduleId });
-			},
+	let scheduleSpec: ScheduleSpec;
+	if (params.type === "interval") {
+		const { every, ...rest } = params;
+		scheduleSpec = {
+			...rest,
+			everyMs: toMilliseconds(every),
 		};
+	} else {
+		scheduleSpec = params;
 	}
 
-	// The builder threads its .opt() calls as a function so they can be applied at activate, once the
-	// workflow (and thus its default run options) is known.
-	function createBuilder(
-		apply: (builder: ObjectBuilder<ScheduleBuilderActivateOptions>) => ObjectBuilder<ScheduleBuilderActivateOptions>
-	): ScheduleBuilder {
-		return {
-			opt: (path, value) => createBuilder((builder) => apply(builder).with(path, value)),
+	const { schedule: activatedSchedule } = await client.api.schedule.activateV1({
+		workflowName: workflow.name,
+		workflowVersionId: workflow.versionId,
+		spec: scheduleSpec,
+		workflowRunInput,
+		workflowRunInputHash,
+		options,
+		workflowRunOptions: workflow[INTERNAL].runOptions(),
+	});
+	client.logger.info("Schedule activated", {
+		"aiki.scheduleSpec": scheduleSpec,
+		"aiki.workflowName": workflow.name,
+		"aiki.workflowVersionId": workflow.versionId,
+		"aiki.scheduleReferenceId": options.reference?.id,
+	});
 
-			async activate(client, workflow, ...args) {
-				const base: ScheduleBuilderActivateOptions = { workflowRun: workflow[INTERNAL].definitionStartOptions() };
-				const activateOptions = apply(objectOverrider(base)()).build();
-				return activateWithOptions(client, workflow, activateOptions, ...args);
-			},
-		};
-	}
+	const scheduleId = activatedSchedule.id as ScheduleId;
 
 	return {
-		...params,
+		id: scheduleId,
 
-		with(): ScheduleBuilder {
-			return createBuilder((builder) => builder);
+		pause: async () => {
+			await client.api.schedule.pauseV1({ id: scheduleId });
 		},
 
-		async activate(client, workflow, ...args) {
-			return createBuilder((builder) => builder).activate(client, workflow, ...args);
+		resume: async () => {
+			await client.api.schedule.resumeV1({ id: scheduleId });
+		},
+
+		deactivate: async () => {
+			await client.api.schedule.deactivateV1({ id: scheduleId });
 		},
 	};
 }

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -476,7 +476,7 @@ describe("task", () => {
 						{ taskInfo: completedTaskInfo }
 					);
 
-				expect(await sendEmail.with().opt("retry", retry).start(run, input)).toBe(output);
+				expect(await sendEmail.with("retry", retry).start(run, input)).toBe(output);
 			}));
 	});
 });

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -92,31 +92,38 @@ export interface TaskParams<Input, Output> {
 
 export interface Task<Input, Output> {
 	name: TaskName;
-	with(): TaskBuilder<Input, Output>;
+	/** Sets one start option and returns a copy of {@link Task}. The original is unchanged. */
+	with<Path extends PathFromObject<TaskStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<TaskStartOptions, Path>
+	): Task<Input, Output>;
 	start: (run: UnknownWorkflowRun, ...args: Input extends void ? [] : [Input]) => Promise<Output>;
 }
 
 class TaskImpl<Input, Output> implements Task<Input, Output> {
 	public readonly name: TaskName;
+	private readonly startOptionsBuilder: ObjectBuilder<TaskStartOptions>;
 
-	constructor(private readonly params: TaskParams<Input, Output>) {
+	constructor(
+		private readonly params: TaskParams<Input, Output>,
+		startOptionsBuilder?: ObjectBuilder<TaskStartOptions>
+	) {
 		this.name = params.name as TaskName;
+		this.startOptionsBuilder = startOptionsBuilder ?? objectOverrider<TaskStartOptions>({ retry: this.params.retry })();
 	}
 
-	private definitionStartOptions(): TaskStartOptions {
-		return this.params.retry === undefined ? {} : { retry: this.params.retry };
-	}
-
-	public with(): TaskBuilder<Input, Output> {
-		const startOptionsOverrider = objectOverrider(this.definitionStartOptions());
-		return createTaskBuilder(this, startOptionsOverrider());
+	public with<Path extends PathFromObject<TaskStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<TaskStartOptions, Path>
+	): Task<Input, Output> {
+		return new TaskImpl(this.params, this.startOptionsBuilder.with(path, value));
 	}
 
 	public async start(run: UnknownWorkflowRun, ...args: Input extends void ? [] : [Input]): Promise<Output> {
-		return this.startWithOptions(run, this.definitionStartOptions(), ...args);
+		return this.startWithOptions(run, this.startOptionsBuilder.build(), ...args);
 	}
 
-	public async startWithOptions(
+	private async startWithOptions(
 		run: UnknownWorkflowRun,
 		startOptions: TaskStartOptions,
 		...args: Input extends void ? [] : [Input]
@@ -373,27 +380,4 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			throw new TaskFailedError(taskId, attempts, "Task retry not allowed");
 		}
 	}
-}
-
-export interface TaskBuilder<Input, Output> {
-	opt<Path extends PathFromObject<TaskStartOptions>>(
-		path: Path,
-		value: TypeOfValueAtPath<TaskStartOptions, Path>
-	): TaskBuilder<Input, Output>;
-	start: Task<Input, Output>["start"];
-}
-
-function createTaskBuilder<Input, Output>(
-	task: TaskImpl<Input, Output>,
-	startOptionsBuilder: ObjectBuilder<TaskStartOptions>
-): TaskBuilder<Input, Output> {
-	return {
-		opt(path, value) {
-			return createTaskBuilder(task, startOptionsBuilder.with(path, value));
-		},
-
-		start(run, ...args) {
-			return task.startWithOptions(run, startOptionsBuilder.build(), ...args);
-		},
-	};
 }

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -641,7 +641,7 @@ describe("creating a workflow run", () => {
 	});
 
 	describe("with", () => {
-		test("overrides the definition start options via opt", () =>
+		test("overrides the definition start options", () =>
 			withFakeClient(async (client) => {
 				const workflowVersion = workflow({ name: "greet" }).v("1.0.0", {
 					async handler(_run, name: string) {
@@ -664,40 +664,12 @@ describe("creating a workflow run", () => {
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
 
-				const handle = await workflowVersion.with().opt("retry", { type: "never" }).start(client, "world");
+				const handle = await workflowVersion.with("retry", { type: "never" }).start(client, "world");
 
 				expect(handle.run.id).toBe(newRunRecord.id);
 			}));
 
-		test("starts from the definition start options when no overrides are given", () =>
-			withFakeClient(async (client) => {
-				const workflowVersion = workflow({ name: "greet" }).v("1.0.0", {
-					async handler(_run, name: string) {
-						return name;
-					},
-					retry: { type: "fixed", maxAttempts: 3, delayMs: 100 },
-				});
-				const newRunRecord = runningWorkflowRunRecordFactory.build();
-				const inputHash = await hashInput("world");
-
-				client.api.workflowRun.createV1.once(
-					{
-						name: "greet",
-						versionId: "1.0.0",
-						input: "world",
-						inputHash: { value: inputHash },
-						options: { retry: { type: "fixed", maxAttempts: 3, delayMs: 100 } },
-					},
-					{ id: newRunRecord.id }
-				);
-				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
-
-				const handle = await workflowVersion.with().start(client, "world");
-
-				expect(handle.run.id).toBe(newRunRecord.id);
-			}));
-
-		test("merges opt overrides with the definition start options", () =>
+		test("merges overrides with the definition start options", () =>
 			withFakeClient(async (client) => {
 				const workflowVersion = workflow({ name: "greet" }).v("1.0.0", {
 					async handler(_run, name: string) {
@@ -720,7 +692,7 @@ describe("creating a workflow run", () => {
 				);
 				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
 
-				const handle = await workflowVersion.with().opt("pool", "eu-west").start(client, "world");
+				const handle = await workflowVersion.with("pool", "eu-west").start(client, "world");
 
 				expect(handle.run.id).toBe(newRunRecord.id);
 			}));

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -16,9 +16,9 @@ import { SchemaValidationError } from "@aikirun/types/validator";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
 	ReplayManifest,
-	WorkflowDefinitionStartOptions,
 	WorkflowRunAddress,
 	WorkflowRunId,
+	WorkflowRunOptions,
 	WorkflowRunRecord,
 	WorkflowRunStateFailed,
 	WorkflowStartOptions,
@@ -53,7 +53,23 @@ export interface WorkflowVersion<Input, Output, Context, TEvents extends EventsD
 	versionId: WorkflowVersionId;
 	events: EventMulticasters<TEvents>;
 
-	with(): WorkflowBuilder<Input, Output, Context, TEvents>;
+	/**
+	 * Sets one option and returns a copy. The original is unchanged.
+	 *
+	 * Which type comes back depends on what the option answers. `retry` answers "if this fails, try
+	 * three more times"; `pool` answers "run on this kind of workers". Answers like those fit any
+	 * run, so setting one — see {@link WorkflowRunOptions} — returns a {@link WorkflowVersion}, which
+	 * you can go on starting as often as you like.
+	 *
+	 * `reference` answers "this particular run is order-123"; `trigger` answers "execute this particular run five minutes from now".
+	 * Both are about one particular run, so setting one returns a {@link WorkflowVersionStart}:
+	 * that single start, and nothing else. Anything that mints or executes many runs from one version
+	 * e.g. a schedule or a worker, will not accept {@link WorkflowVersionStart}.
+	 */
+	with<Path extends PathFromObject<WorkflowStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<WorkflowStartOptions, Path>
+	): WorkflowVersionWith<Path, Input, Output, Context, TEvents>;
 
 	start(
 		client: Client<Context>,
@@ -75,8 +91,31 @@ export interface WorkflowVersion<Input, Output, Context, TEvents extends EventsD
 	[INTERNAL]: {
 		eventsDefinition: TEvents;
 		handler: (run: WorkflowRun<Input, Context, TEvents>, input: Input) => Promise<void>;
-		definitionStartOptions: () => WorkflowDefinitionStartOptions;
+		runOptions: () => WorkflowRunOptions;
 	};
+}
+
+/** Which of the two types {@link WorkflowVersion.with} gives back, decided by the option you set. */
+export type WorkflowVersionWith<Path, Input, Output, Context, TEvents extends EventsDefinition> =
+	Path extends PathFromObject<WorkflowRunOptions>
+		? WorkflowVersion<Input, Output, Context, TEvents>
+		: WorkflowVersionStart<Input, Output, Context, TEvents>;
+
+/**
+ * A {@link WorkflowVersion} pinned to one start.
+ *
+ * You get one by setting an option about one particular run — `reference` names the run, `trigger`
+ * says when it goes. Everything a version can do is still here save one thing: a schedule
+ * or a worker will not take it. A schedule creates its own starts, one per tick, and has no use for
+ * yours; a worker never starts anything at all — it executes runs that already exist, carrying the
+ * options recorded on them when they were created.
+ */
+export interface WorkflowVersionStart<Input, Output, Context, TEvents extends EventsDefinition = EventsDefinition>
+	extends Omit<WorkflowVersion<Input, Output, Context, TEvents>, typeof INTERNAL | "with"> {
+	with<Path extends PathFromObject<WorkflowStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<WorkflowStartOptions, Path>
+	): WorkflowVersionStart<Input, Output, Context, TEvents>;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: I want any workflow
@@ -87,38 +126,50 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 {
 	public readonly events: EventMulticasters<TEvents>;
 	public readonly [INTERNAL]: WorkflowVersion<Input, Output, Context, TEvents>[typeof INTERNAL];
+	private readonly startOptionsBuilder: ObjectBuilder<WorkflowStartOptions>;
 
 	constructor(
 		public readonly name: WorkflowName,
 		public readonly versionId: WorkflowVersionId,
-		private readonly params: WorkflowVersionParams<Input, Output, Context, TEvents>
+		private readonly params: WorkflowVersionParams<Input, Output, Context, TEvents>,
+		startOptionsBuilder?: ObjectBuilder<WorkflowStartOptions>
 	) {
 		const eventsDefinition = this.params.events ?? ({} as TEvents);
 		this.events = createEventMulticasters(this.name, this.versionId, eventsDefinition);
+		this.startOptionsBuilder =
+			startOptionsBuilder ?? objectOverrider<WorkflowStartOptions>({ retry: this.params.retry })();
 		this[INTERNAL] = {
 			eventsDefinition,
 			handler: this.handler.bind(this),
-			definitionStartOptions: this.definitionStartOptions.bind(this),
+			runOptions: this.runOptions.bind(this),
 		};
 	}
 
-	private definitionStartOptions(): WorkflowDefinitionStartOptions {
-		return { retry: this.params.retry };
+	private runOptions(): WorkflowRunOptions {
+		const { retry, pool } = this.startOptionsBuilder.build();
+		return { retry, pool };
 	}
 
-	public with(): WorkflowBuilder<Input, Output, Context, TEvents> {
-		const startOptionsOverrider = objectOverrider<WorkflowStartOptions>(this.definitionStartOptions());
-		return createWorkflowBuilder(this, startOptionsOverrider());
+	public with<Path extends PathFromObject<WorkflowStartOptions>>(
+		path: Path,
+		value: TypeOfValueAtPath<WorkflowStartOptions, Path>
+	): WorkflowVersionWith<Path, Input, Output, Context, TEvents> {
+		return new WorkflowVersionImpl(
+			this.name,
+			this.versionId,
+			this.params,
+			this.startOptionsBuilder.with(path, value)
+		) as WorkflowVersionWith<Path, Input, Output, Context, TEvents>;
 	}
 
 	public async start(
 		client: Client<Context>,
 		...args: Input extends void ? [] : [Input]
 	): Promise<WorkflowRunHandle<Input, Output, Context, TEvents>> {
-		return this.startWithOptions(client, this.definitionStartOptions(), ...args);
+		return this.startWithOptions(client, this.startOptionsBuilder.build(), ...args);
 	}
 
-	public async startWithOptions(
+	private async startWithOptions(
 		client: Client<Context>,
 		startOptions: WorkflowStartOptions,
 		...args: Input extends void ? [] : [Input]
@@ -158,10 +209,10 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		parentRun: WorkflowRun<unknown, Context, EventsDefinition>,
 		...args: Input extends void ? [] : [Input]
 	): Promise<ChildWorkflowRunHandle<Input, Output, Context, TEvents>> {
-		return this.startAsChildWithOptions(parentRun, this.definitionStartOptions(), ...args);
+		return this.startAsChildWithOptions(parentRun, this.startOptionsBuilder.build(), ...args);
 	}
 
-	public async startAsChildWithOptions(
+	private async startAsChildWithOptions(
 		parentRun: WorkflowRun<unknown, Context, EventsDefinition>,
 		startOptions: WorkflowStartOptions,
 		...args: Input extends void ? [] : [Input]
@@ -420,40 +471,4 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			error: createSerializableError(err),
 		};
 	}
-}
-
-export interface WorkflowBuilder<Input, Output, Context, TEvents extends EventsDefinition> {
-	opt<Path extends PathFromObject<WorkflowStartOptions>>(
-		path: Path,
-		value: TypeOfValueAtPath<WorkflowStartOptions, Path>
-	): WorkflowBuilder<Input, Output, Context, TEvents>;
-
-	start(
-		client: Client<Context>,
-		...args: Input extends void ? [] : [Input]
-	): Promise<WorkflowRunHandle<Input, Output, Context, TEvents>>;
-
-	startAsChild<ParentInput, ParentEvents extends EventsDefinition>(
-		parentRun: WorkflowRun<ParentInput, Context, ParentEvents>,
-		...args: Input extends void ? [] : [Input]
-	): Promise<ChildWorkflowRunHandle<Input, Output, Context, TEvents>>;
-}
-
-function createWorkflowBuilder<Input, Output, Context, TEvents extends EventsDefinition>(
-	workflowVersion: WorkflowVersionImpl<Input, Output, Context, TEvents>,
-	startOptionsBuilder: ObjectBuilder<WorkflowStartOptions>
-): WorkflowBuilder<Input, Output, Context, TEvents> {
-	return {
-		opt(path, value) {
-			return createWorkflowBuilder(workflowVersion, startOptionsBuilder.with(path, value));
-		},
-
-		start(client, ...args) {
-			return workflowVersion.startWithOptions(client, startOptionsBuilder.build(), ...args);
-		},
-
-		startAsChild(parentRun, ...args) {
-			return workflowVersion.startAsChildWithOptions(parentRun, startOptionsBuilder.build(), ...args);
-		},
-	};
 }

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -62,8 +62,6 @@ export interface WorkflowStartOptions extends WorkflowRunOptions {
 	reference?: WorkflowReference;
 }
 
-export type WorkflowDefinitionStartOptions = Pick<WorkflowStartOptions, "retry">;
-
 interface WorkflowRunStateBase {
 	status: WorkflowRunStatus;
 }


### PR DESCRIPTION
## Problem

`with()` took no arguments, so it could set nothing — it existed only to give `.opt(path, value)` somewhere to live. Every call site in the SDK, the examples, and the docs was `.with().opt(...)`; none was `.with()` followed by a terminal call.

Six things carried this shape: a task, a workflow version, a schedule, a worker, an event sender, and an event multicaster. Each returned a separate builder type from `with()`.

## Solution

`with` takes the path and the value, and returns a configured copy. The six builder types are gone.

```typescript
// before
await orderWorkflowV1.with().opt("pool", "gpu").opt("reference.id", "order-123").start(client, input);

// after
await orderWorkflowV1.with("pool", "gpu").with("reference.id", "order-123").start(client, input);
```

**A workflow version's `with` returns one of two types.** `retry` and `pool` hold for any run of the workflow. `reference` names one run and `trigger` says when that run goes — a schedule picks its own timing and gives each run its own identity, and a worker never starts a run at all.

| Option set | Returns | `start`, `startAsChild` | `activate`, registry, worker | |---|---|---|---|
| `retry`, `pool` | `WorkflowVersion` | yes | yes | | `trigger`, `reference` | `WorkflowVersionStart` | yes | compile error |

**A schedule's runs take their options from the workflow.** `workflowRun.*` existed because `activate` could not accept a configured workflow. It is gone.

```typescript
// before
await hourlySync
  .with()
  .opt("workflowRun.retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
  .activate(client, inventorySyncV1);

// after
await hourlySync.activate(
  client,
  inventorySyncV1.with("retry", { type: "exponential", maxAttempts: 3, baseDelayMs: 1000 })
);
```

## Breaking changes

- `.opt()` is removed from all six builders. `WorkerBuilder` was the only one in a package's public exports.
- Passing a workflow configured with `trigger` or `reference` to `schedule.activate`, `workflowRegistry.add`, or `worker({ workflows })` is a type error.
- `workflowRun.*` is removed from a schedule's activate options.
- `ScheduleDefinition` no longer carries the fields of `ScheduleParams`.
- `WorkflowDefinitionStartOptions` is removed from `@aikirun/types`.