### PR TITLE
docs: add missing binary setup steps and use Compose v2 syntax

### DIFF
--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -59,7 +59,16 @@ There are three ways to run this stack:
 
 ### With the aiki binary
 
-Download the `aiki` binary for your platform from the [latest release](https://github.com/aikirun/aiki/releases/latest) and put it on your `PATH`. It carries the migrate and server commands plus its own runtime.
+Download the binary for your platform from the [latest release](https://github.com/aikirun/aiki/releases/latest). It carries the migrate and server commands plus its own runtime. Assets are published for macOS on Apple Silicon (`aiki-darwin-arm64`) and Linux (`aiki-linux-arm64`, `aiki-linux-x64`); on any other platform use [Docker](#with-docker) or [From source](#from-source) instead.
+
+The asset is named for its platform and downloads without the executable bit, so rename it and make it executable before putting it on your `PATH`:
+
+```bash
+mv aiki-darwin-arm64 aiki
+chmod +x aiki
+```
+
+If you downloaded the asset with a browser rather than `curl`, macOS also flags it as quarantined; clear that with `xattr -c aiki`.
 
 ```bash
 export DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
@@ -91,14 +100,16 @@ Create a `.env` next to it with your database URL:
 DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
 ```
 
+If Postgres runs on the same machine as the stack rather than on a remote host, use `host.docker.internal` as the host instead of `localhost` — inside a container, `localhost` is the container itself, not the machine running it.
+
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 - Server: http://localhost:9850
 - Dashboard: http://localhost:9851
 
-The migration step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker-compose up -d`.
+The migration step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker compose up -d`.
 
 #### Without Docker Compose
 


### PR DESCRIPTION
Three fixes to the Installation page, all found by following it literally on a clean machine (macOS, Apple Silicon, Docker Desktop, Postgres 16 in a container). Tested against v0.38.0.

### 1. The binary section skips two required steps

The page says to download "the `aiki` binary for your platform" and put it on your `PATH`. No release asset is named `aiki` — the assets are `aiki-darwin-arm64`, `aiki-linux-arm64` and `aiki-linux-x64` — and the asset arrives without the execute bit:

```
$ ls -l aiki-darwin-arm64
-rw-r--r--  1 user  staff  63781712 aiki-darwin-arm64

$ ./aiki-darwin-arm64 --version
zsh: permission denied: ./aiki-darwin-arm64
```

After renaming and `chmod +x`:

```
$ ./aiki --version
aiki/0.38.0 darwin-arm64 node-v24.3.0
```

"for your platform" also overpromises: there is no Intel macOS and no Windows asset, so the page now names the three that ship and points everyone else at Docker or source.

### 2. `localhost` in the Compose `.env` takes down the whole stack

Inside a container `localhost` is the container, not the host. `deploy/docker-compose.yml` already defaults to `host.docker.internal`, but the page never mentions it and hands you a `localhost` connection string to copy.

With `DATABASE_URL=postgresql://...@localhost:5432/aiki` in `.env`:

```
$ docker compose up -d
 ✔ Container aiki-server     Created
 ✔ Container aiki-dashboard  Created
service "migrate" didn't complete successfully: exit 1
```

`server` and `dashboard` reach `Created` and never start, because both are gated on `depends_on: migrate: condition: service_completed_successfully`. One wrong hostname stops everything.

The migrate logs are the whole problem — this is the complete output, confirmed twice, including a foreground `docker compose run --rm migrate`:

```
aiki-migrate  | Failed query: CREATE SCHEMA IF NOT EXISTS drizzle
aiki-migrate  | params:
```

No hostname, no port, no connection error. Nothing points at networking, so a new user cannot debug this from the logs. With `host.docker.internal` the same command succeeds.

I left a warning about that error message out of the diff to keep it small — happy to add one if you'd like it on the page.

### 3. `docker-compose` → `docker compose`

For consistency and portability, not because the old form is broken. `package.json` and the header of `deploy/docker-compose.yml` both use the space form. The hyphenated alias still works wherever Docker Desktop installs its shim (it reported v5.4.0 on my machine and forwarded fine), but that shim is a Docker Desktop convenience rather than part of the compose plugin, so the space form is the one that travels.
