### PR TITLE
docs: add the missing packages and setup steps for the SDK quick start

### DIFF
--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -14,8 +14,10 @@ You need Node.js 18+ or Bun 1.0+, and a PostgreSQL 14+ database (SQLite and MySQ
 ### Install the SDK packages
 
 ```package-install
-@aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server
+@aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server postgres
 ```
+
+`postgres` is the PostgreSQL driver. It is an optional peer dependency of `@aikirun/server`, so package managers do not install it for you, and the migration below fails without it.
 
 ### Apply the schema migration
 

--- a/app/website/content/docs/getting-started/quick-start.mdx
+++ b/app/website/content/docs/getting-started/quick-start.mdx
@@ -9,7 +9,7 @@ This example starts a 14-day free trial, then suspends the workflow waiting for 
 You need Node.js 18+ (or Bun 1.0+) and a PostgreSQL database. Install the SDK and apply the db migrations — the two commands below, covered in full in [Installation](./installation.md).
 
 ```package-install
-@aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server
+@aikirun/workflow @aikirun/client @aikirun/worker @aikirun/server postgres
 ```
 
 <Tabs groupId="runtime" persist items={["Node", "Bun"]}>
@@ -30,6 +30,13 @@ DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
 
 </Tab>
 </Tabs>
+
+The Node commands use [tsx](https://tsx.is) to run TypeScript directly, and `app.ts` uses ES modules with top-level `await`. Install tsx and set the module type before you start:
+
+```bash
+npm install -D tsx
+npm pkg set type=module
+```
 
 Build the app in three pieces. They live in one file, `app.ts` — the complete listing is at the end.
 


### PR DESCRIPTION
I followed [Installation](https://aiki.run/docs/getting-started/installation) and [Quick Start](https://aiki.run/docs/getting-started/quick-start) exactly as written, in an empty directory, and could not reach a working run. Three setup steps are missing. Each one stops you before the next.

Tested on macOS with Node v20.19.3, npm 10.8.2, PostgreSQL 16 and aiki 0.38.0.

### 1. `postgres` is missing from both install lists

This is the blocker — it stops the first command of both pages.

Installing exactly the four documented packages and then running the documented migrate command:

```
$ DATABASE_URL=postgresql://... npx aiki-server migrate apply
Cannot find package 'postgres' imported from
  .../node_modules/drizzle-orm/postgres-js/driver.js
```

`@aikirun/server` 0.38.0 declares it as an **optional** peer dependency:

```json
"peerDependencies":     { "postgres": "^3.4.8" },
"peerDependenciesMeta": { "postgres": { "optional": true } }
```

npm does not install optional peer dependencies. `postgres` is also in that package's own devDependencies, so it resolves inside this repo and is absent for everyone installing from the registry. It is not mentioned anywhere in `docs/` — I grepped the tree.

`npm install postgres` fixes it, and migrate then creates all nine tables.

I fixed this in the docs because that is the smaller change, but making the peer dependency non-optional would fix it for everyone without a docs change. Happy to switch to that if you prefer.

### 2. The sample cannot run as ES modules

`app.ts` uses ESM imports and top-level `await`. Nothing on either page tells you to set `"type": "module"`, and a default project does not have it, so tsx treats the file as CommonJS:

```
$ npx tsx app.ts
ERROR: Top-level await is currently not supported with the "cjs" output format
  (x5, at lines 45, 48, 49, 53, 54)
  code: 'ERR_REQUIRE_ASYNC_MODULE'
```

Captured on a file copied verbatim from the Quick Start listing. `npm pkg set type=module` fixes it.

### 3. tsx is never installed

`npx tsx app.ts` is the only mention of tsx on the page. With tsx not installed, npx stops and asks:

```
Need to install the following packages:
tsx@4.23.12
Ok to proceed? (y)
```

Fine when you are sitting there, a hang when nothing can answer. Minor, but it is the same three lines of setup as #2 so it is fixed in the same place.

### After these three steps

The Quick Start runs to completion and prints what the page says it will:

```
Activated 14-day trial for user-123
Run completed
```

The run is recorded in Postgres with status `completed`, and `downgradeToFree` never fires, exactly as the page describes.
