### PR TITLE
Per-run outcomes for event multicast

### DIFF
--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -24,6 +24,7 @@ import type {
 	WorkflowRunListTransitionsResponseV1,
 	WorkflowRunMulticastEventByReferenceRequestV1,
 	WorkflowRunMulticastEventRequestV1,
+	WorkflowRunMulticastEventResponseV1,
 	WorkflowRunSendEventRequestV1,
 	WorkflowRunTransitionStateRequestV1,
 	WorkflowRunTransitionStateResponseV1,
@@ -40,6 +41,7 @@ import {
 	cancelByIdsResponseSchema,
 	listChildRunsRequestSchema,
 	listChildRunsResponseSchema,
+	multicastEventResponseSchema,
 	workflowRunRecordSchema,
 	workflowRunStateAwaitingChildWorkflowSchema,
 	workflowRunStateAwaitingEventSchema,
@@ -241,7 +243,7 @@ const sendEventV1: ContractProcedure<WorkflowRunSendEventRequestV1, void> = oc
 	)
 	.output(type("undefined"));
 
-const multicastEventV1: ContractProcedure<WorkflowRunMulticastEventRequestV1, void> = oc
+const multicastEventV1: ContractProcedure<WorkflowRunMulticastEventRequestV1, WorkflowRunMulticastEventResponseV1> = oc
 	.input(
 		type({
 			ids: type("string > 0").array().atLeastLength(1).atMostLength(10),
@@ -252,9 +254,12 @@ const multicastEventV1: ContractProcedure<WorkflowRunMulticastEventRequestV1, vo
 			},
 		})
 	)
-	.output(type("undefined"));
+	.output(multicastEventResponseSchema);
 
-const multicastEventByReferenceV1: ContractProcedure<WorkflowRunMulticastEventByReferenceRequestV1, void> = oc
+const multicastEventByReferenceV1: ContractProcedure<
+	WorkflowRunMulticastEventByReferenceRequestV1,
+	WorkflowRunMulticastEventResponseV1
+> = oc
 	.input(
 		type({
 			references: type({
@@ -272,7 +277,7 @@ const multicastEventByReferenceV1: ContractProcedure<WorkflowRunMulticastEventBy
 			},
 		})
 	)
-	.output(type("undefined"));
+	.output(multicastEventResponseSchema);
 
 const listChildRunsV1: ContractProcedure<WorkflowRunListChildRunsRequestV1, WorkflowRunListChildRunsResponseV1> = oc
 	.input(listChildRunsRequestSchema)

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -213,3 +213,8 @@ export const cancelByIdsRequestSchema = type({
 export const cancelByIdsResponseSchema = type({
 	cancelledIds: type("string > 0").array(),
 });
+
+export const multicastEventResponseSchema = type({
+	sentIds: type("string > 0").array(),
+	failedIds: type("string > 0").array(),
+});

--- a/sdk/server/src/lib/concurrency.test.ts
+++ b/sdk/server/src/lib/concurrency.test.ts
@@ -1,0 +1,120 @@
+import { createBinaryLatch } from "@aikirun/lib/async";
+import { noopLogger } from "@aikirun/lib/logger";
+
+import { runConcurrently } from "./concurrency";
+import { describe, expect, test } from "bun:test";
+import { createDaemonContext } from "../middleware/context";
+
+const context = (signal = new AbortController().signal) =>
+	createDaemonContext({ name: "test", logger: noopLogger, signal });
+
+const gatedItem = (name: string) => ({ name, started: createBinaryLatch(), release: createBinaryLatch() });
+
+describe("runConcurrently", () => {
+	test("holds an item back until a running one finishes", async () => {
+		const first = gatedItem("first");
+		const second = gatedItem("second");
+		const third = gatedItem("third");
+		const startedNames: string[] = [];
+
+		const run = runConcurrently(
+			context(),
+			[first, second, third],
+			async (item) => {
+				startedNames.push(item.name);
+				item.started.signal();
+				await item.release.wait();
+			},
+			{ concurrency: 2 }
+		);
+
+		await second.started.wait();
+		expect(startedNames).toEqual(["first", "second"]);
+
+		first.release.signal();
+		await third.started.wait();
+		expect(startedNames).toEqual(["first", "second", "third"]);
+
+		second.release.signal();
+		third.release.signal();
+		await run;
+	});
+
+	test("stops taking new items once the context is aborted", async () => {
+		const abortController = new AbortController();
+		const itemStarted = createBinaryLatch();
+		const releaseItem = createBinaryLatch();
+		const startedItems: number[] = [];
+
+		const run = runConcurrently(
+			context(abortController.signal),
+			[1, 2, 3],
+			async (item) => {
+				startedItems.push(item);
+				itemStarted.signal();
+				await releaseItem.wait();
+			},
+			{ concurrency: 1 }
+		);
+
+		await itemStarted.wait();
+		abortController.abort();
+		releaseItem.signal();
+		await run;
+
+		expect(startedItems).toEqual([1]);
+	});
+
+	test("consumes a lazy iterable", async () => {
+		function* countUpToThree() {
+			yield 1;
+			yield 2;
+			yield 3;
+		}
+		const startedItems: number[] = [];
+
+		await runConcurrently(context(), countUpToThree(), async (item) => {
+			startedItems.push(item);
+		});
+
+		expect(startedItems.sort((left, right) => left - right)).toEqual([1, 2, 3]);
+	});
+
+	test("runs every item even when one of them throws", async () => {
+		const startedItems: number[] = [];
+
+		expect(
+			runConcurrently(
+				context(),
+				[1, 2, 3],
+				async (item) => {
+					startedItems.push(item);
+					if (item === 2) {
+						throw new Error("boom");
+					}
+				},
+				{ concurrency: 1 }
+			)
+		).rejects.toThrow("boom");
+
+		expect(startedItems).toEqual([1, 2, 3]);
+	});
+
+	test("stops at the first failure when failFast is set", async () => {
+		const startedItems: number[] = [];
+
+		expect(
+			runConcurrently(
+				context(),
+				[1, 2, 3],
+				async (item) => {
+					startedItems.push(item);
+					throw new Error(`boom ${item}`);
+				},
+				{ concurrency: 1, failFast: true }
+			)
+		).rejects.toThrow("boom 1");
+
+		expect(startedItems).toEqual([1]);
+	});
+});

--- a/sdk/server/src/lib/concurrency.ts
+++ b/sdk/server/src/lib/concurrency.ts
@@ -31,15 +31,16 @@ export async function runConcurrently<Item, TContext extends Context>(
 				return;
 			}
 
+			const item = next.value;
 			const spanCtx = forkContext(context);
 			try {
-				await fn(next.value, spanCtx);
+				await fn(item, spanCtx);
 			} catch (err) {
 				if (!hasError) {
 					hasError = true;
 					firstError = err;
 				} else {
-					spanCtx.logger.error("Concurrent task failed", { err });
+					spanCtx.logger.error("Concurrent call failed", { item, err });
 				}
 				if (failFast) {
 					stopped = true;

--- a/sdk/server/src/router/workflow-run.ts
+++ b/sdk/server/src/router/workflow-run.ts
@@ -1,7 +1,6 @@
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import { namespaceAuthedImplementer } from "./implementer";
-import { runConcurrently } from "../lib/concurrency";
 import type { EventService } from "../service/event";
 import type { WorkflowRunStateMachine } from "../service/state-machine/workflow-run";
 import type { WorkflowRunService } from "../service/workflow-run";
@@ -66,20 +65,22 @@ export function createWorkflowRunRouter(deps: WorkflowRunRouterDeps) {
 		}),
 
 		multicastEventV1: os.multicastEventV1.handler(async ({ input: request, context }) => {
-			const runIds = request.ids as WorkflowRunId[];
-			const { eventName, data, options } = request;
-
-			await runConcurrently(context, runIds, async (runId, spanCtx) => {
-				await eventService.sendEventToWorkflowRun(spanCtx, { runId, eventName, data, reference: options?.reference });
+			return eventService.multicastEventToWorkflowRuns(context, {
+				runIds: request.ids as WorkflowRunId[],
+				eventName: request.eventName,
+				data: request.data,
+				reference: request.options?.reference,
 			});
 		}),
 
 		multicastEventByReferenceV1: os.multicastEventByReferenceV1.handler(async ({ input: request, context }) => {
 			const runIds = await workflowRunService.resolveRunIdsByReferences(context, request.references);
-			const { eventName, data, options } = request;
 
-			await runConcurrently(context, runIds, async (runId, spanCtx) => {
-				await eventService.sendEventToWorkflowRun(spanCtx, { runId, eventName, data, reference: options?.reference });
+			return eventService.multicastEventToWorkflowRuns(context, {
+				runIds,
+				eventName: request.eventName,
+				data: request.data,
+				reference: request.options?.reference,
 			});
 		}),
 

--- a/sdk/server/src/service/event.integration.test.ts
+++ b/sdk/server/src/service/event.integration.test.ts
@@ -1,0 +1,273 @@
+import { NotFoundError } from "@aikirun/lib/error";
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+
+import { createWorkflowRunStateMachine } from "./state-machine/workflow-run";
+import { describe, expect, test } from "bun:test";
+import type { Repositories } from "../infra/db/types";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createEventService } from "../service/event";
+import { withFakeClock } from "../testing/clock";
+import { createServiceHarness } from "../testing/harness";
+import { seedAwaitingEventRun, seedClaimedRun, seedSleepingRun } from "../testing/seed/run";
+
+const withHarness = createServiceHarness();
+
+function createService(repos: Repositories) {
+	const childRunCanceller = createChildRunCanceller();
+	const workflowRunStateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller });
+	return createEventService({ repos, workflowRunStateMachine });
+}
+
+describe("EventService sendEventToWorkflowRun", () => {
+	test("records a received wait carrying the event data", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId } = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+
+			await createService(repos).sendEventToWorkflowRun(context, {
+				runId: runId as WorkflowRunId,
+				eventName: "orderShipped",
+				data: { trackingId: "TRK-1" },
+				reference: undefined,
+			});
+
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({
+					workflowRunId: runId,
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-1" },
+					referenceId: null,
+				}),
+			]);
+		}));
+
+	test("a repeat send under the same reference records one wait", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId } = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+			const eventService = createService(repos);
+
+			const send = (trackingId: string) =>
+				eventService.sendEventToWorkflowRun(context, {
+					runId: runId as WorkflowRunId,
+					eventName: "orderShipped",
+					data: { trackingId },
+					reference: { id: "carrier-callback-1" },
+				});
+
+			await send("TRK-1");
+			await send("TRK-2");
+
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({
+					workflowRunId: runId,
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-1" },
+					referenceId: "carrier-callback-1",
+				}),
+			]);
+		}));
+
+	test("two sends without a reference record two waits", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId } = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+			const eventService = createService(repos);
+
+			const send = (trackingId: string) =>
+				eventService.sendEventToWorkflowRun(context, {
+					runId: runId as WorkflowRunId,
+					eventName: "orderShipped",
+					data: { trackingId },
+					reference: undefined,
+				});
+
+			await send("TRK-1");
+			await send("TRK-2");
+
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-1" } }),
+				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-2" } }),
+			]);
+		}));
+
+	test("rejects a send to a run that does not exist", () =>
+		withHarness(async ({ repos, context }) => {
+			expect(
+				createService(repos).sendEventToWorkflowRun(context, {
+					runId: "01JZZZZZZZZZZZZZZZZZZZZZZZ" as WorkflowRunId,
+					eventName: "orderShipped",
+					data: { trackingId: "TRK-1" },
+					reference: undefined,
+				})
+			).rejects.toThrow(NotFoundError);
+		}));
+});
+
+describe("EventService sendEventToWorkflowRun waking a parked run", () => {
+	test("schedules a run parked on that event name", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId } = await seedAwaitingEventRun(
+				{ repos, namespaceRequestContext: context, publisher },
+				{ eventName: "orderShipped" }
+			);
+			const sentAt = Date.now() as TimestampMs;
+
+			await withFakeClock(sentAt, () =>
+				createService(repos).sendEventToWorkflowRun(context, {
+					runId: runId as WorkflowRunId,
+					eventName: "orderShipped",
+					data: { trackingId: "TRK-1" },
+					reference: undefined,
+				})
+			);
+
+			expect(await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId })).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "scheduled" }),
+					state: { status: "scheduled", reason: "event", scheduledAt: sentAt },
+				})
+			);
+		}));
+
+	test("leaves a run parked on a different event name parked", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId, revisionWhenParked } = await seedAwaitingEventRun(
+				{ repos, namespaceRequestContext: context, publisher },
+				{ eventName: "orderShipped" }
+			);
+
+			await createService(repos).sendEventToWorkflowRun(context, {
+				runId: runId as WorkflowRunId,
+				eventName: "orderCancelled",
+				data: { reason: "customer changed their mind" },
+				reference: undefined,
+			});
+
+			expect(await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId })).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "awaiting_event", revision: revisionWhenParked }),
+					state: { status: "awaiting_event", eventName: "orderShipped" },
+				})
+			);
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({ name: "orderCancelled", status: "received" }),
+			]);
+		}));
+
+	test("leaves a running run running", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				repos,
+				namespaceRequestContext: context,
+				publisher,
+			});
+
+			await createService(repos).sendEventToWorkflowRun(context, {
+				runId: runId as WorkflowRunId,
+				eventName: "orderShipped",
+				data: { trackingId: "TRK-1" },
+				reference: undefined,
+			});
+
+			expect(await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId })).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "running", revision: revisionWhenClaimed }),
+					state: { status: "running" },
+				})
+			);
+		}));
+});
+
+describe("EventService multicastEventToWorkflowRuns", () => {
+	test("delivers the event to every run it is given", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const first = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+			const second = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+
+			const result = await createService(repos).multicastEventToWorkflowRuns(context, {
+				runIds: [first.runId, second.runId] as WorkflowRunId[],
+				eventName: "orderShipped",
+				data: { trackingId: "TRK-1" },
+				reference: undefined,
+			});
+
+			expect({ sentIds: Array.from(result.sentIds).sort(), failedIds: result.failedIds }).toEqual({
+				sentIds: [first.runId, second.runId].sort(),
+				failedIds: [],
+			});
+			expect(await repos.eventWait.listByWorkflowRunId(first.runId)).toEqual([
+				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-1" } }),
+			]);
+			expect(await repos.eventWait.listByWorkflowRunId(second.runId)).toEqual([
+				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-1" } }),
+			]);
+		}));
+
+	test("delivers to the runs it reached and reports the one it could not", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const reachable = await seedClaimedRun({ repos, namespaceRequestContext: context, publisher });
+			const missingRunId = "01JZZZZZZZZZZZZZZZZZZZZZZZ";
+
+			const result = await createService(repos).multicastEventToWorkflowRuns(context, {
+				runIds: [reachable.runId, missingRunId] as WorkflowRunId[],
+				eventName: "orderShipped",
+				data: { trackingId: "TRK-1" },
+				reference: undefined,
+			});
+
+			expect(result).toEqual({ sentIds: [reachable.runId], failedIds: [missingRunId] });
+			expect(await repos.eventWait.listByWorkflowRunId(reachable.runId)).toEqual([
+				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-1" } }),
+			]);
+		}));
+
+	test("wakes the run parked on the event and leaves a sleeping one asleep", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const parked = await seedAwaitingEventRun(
+				{ repos, namespaceRequestContext: context, publisher },
+				{ eventName: "orderShipped" }
+			);
+			const sleeping = await seedSleepingRun(
+				{ repos, namespaceRequestContext: context, publisher },
+				{ sleepName: "restockDelay", durationMs: 60_000 }
+			);
+
+			const result = await createService(repos).multicastEventToWorkflowRuns(context, {
+				runIds: [parked.runId, sleeping.runId] as WorkflowRunId[],
+				eventName: "orderShipped",
+				data: { trackingId: "TRK-1" },
+				reference: undefined,
+			});
+
+			expect({ sentIds: Array.from(result.sentIds).sort(), failedIds: result.failedIds }).toEqual({
+				sentIds: [parked.runId, sleeping.runId].sort(),
+				failedIds: [],
+			});
+
+			expect(await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: parked.runId })).toEqual(
+				expect.objectContaining({ run: expect.objectContaining({ id: parked.runId, status: "scheduled" }) })
+			);
+			expect(
+				await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: sleeping.runId })
+			).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: sleeping.runId,
+						status: "sleeping",
+						revision: sleeping.revisionWhenAsleep,
+					}),
+					state: { status: "sleeping", sleepName: "restockDelay", wakeupAt: sleeping.wakeupAt },
+				})
+			);
+			expect(await repos.sleep.listByWorkflowRunId(sleeping.runId)).toEqual([
+				expect.objectContaining({
+					name: "restockDelay",
+					status: "sleeping",
+					wakeupAt: sleeping.wakeupAt,
+					completedAt: null,
+					cancelledAt: null,
+				}),
+			]);
+		}));
+});

--- a/sdk/server/src/service/event.ts
+++ b/sdk/server/src/service/event.ts
@@ -1,11 +1,12 @@
 import { NotFoundError } from "@aikirun/lib/error";
 import { propsRequiredNonNull } from "@aikirun/lib/object";
-import type { EventReference, WorkflowRunId } from "@aikirun/types/workflow/run";
+import type { EventMulticastResult, EventReference, WorkflowRunId } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import type { WorkflowRunStateMachine } from "./state-machine/workflow-run";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { EventWaitRowInsert } from "../infra/db/types/event-wait";
+import { runConcurrently } from "../lib/concurrency";
 import type { NamespaceRequestContext } from "../middleware/context";
 
 export interface EventServiceDeps {
@@ -26,6 +27,35 @@ export const createEventService = ({ repos, workflowRunStateMachine }: EventServ
 		return repos.transaction(async (txRepos) =>
 			sendEventToWorkflowRunInTx(context, params, txRepos, workflowRunStateMachine)
 		);
+	},
+
+	async multicastEventToWorkflowRuns(
+		context: NamespaceRequestContext,
+		params: {
+			runIds: WorkflowRunId[];
+			eventName: string;
+			data: unknown;
+			reference: EventReference | undefined;
+		}
+	): Promise<EventMulticastResult> {
+		const { runIds, eventName, data, reference } = params;
+
+		const sentIds: string[] = [];
+		const failedIds: string[] = [];
+
+		await runConcurrently(context, runIds, async (runId, spanCtx) => {
+			try {
+				await repos.transaction(async (txRepos) =>
+					sendEventToWorkflowRunInTx(spanCtx, { runId, eventName, data, reference }, txRepos, workflowRunStateMachine)
+				);
+				sentIds.push(runId);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to send event to workflow run", { "aiki.runId": runId, err });
+				failedIds.push(runId);
+			}
+		});
+
+		return { sentIds, failedIds };
 	},
 });
 

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -182,6 +182,52 @@ export async function seedPublishedRun(deps: SeedRunDeps & { publisher: FakePubl
 	return seeded;
 }
 
+export async function seedAwaitingEventRun(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	params: { eventName: string }
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedClaimedRun({ ...deps, namespaceRequestContext });
+
+	const services = createServices(repos);
+	const parked = await services.workflowRunStateMachine.transitionState(namespaceRequestContext, {
+		type: "optimistic",
+		id: seeded.runId,
+		state: { status: "awaiting_event", eventName: params.eventName },
+		expectedRevision: seeded.revisionWhenClaimed,
+	});
+
+	return { ...seeded, eventName: params.eventName, revisionWhenParked: parked.revision };
+}
+
+export async function seedSleepingRun(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	params: { sleepName: string; durationMs: number }
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedClaimedRun({ ...deps, namespaceRequestContext });
+
+	const services = createServices(repos);
+	const sleepStartedAt = Date.now() as TimestampMs;
+	const asleep = await withFakeClock(sleepStartedAt, () =>
+		services.workflowRunStateMachine.transitionState(namespaceRequestContext, {
+			type: "optimistic",
+			id: seeded.runId,
+			state: { status: "sleeping", sleepName: params.sleepName, durationMs: params.durationMs },
+			expectedRevision: seeded.revisionWhenClaimed,
+		})
+	);
+
+	return {
+		...seeded,
+		sleepName: params.sleepName,
+		wakeupAt: (sleepStartedAt + params.durationMs) as TimestampMs,
+		revisionWhenAsleep: asleep.revision,
+	};
+}
+
 export async function seedStalledRun(deps: SeedRunDeps) {
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const seeded = await withFakeClock(1 as TimestampMs, () => seedQueuedRun(deps));

--- a/sdk/workflow/src/run/event.test.ts
+++ b/sdk/workflow/src/run/event.test.ts
@@ -238,14 +238,20 @@ describe("createEventMulticasters", () => {
 			const multicasters = createEventMulticasters(workflowName, versionId, {
 				orderShipped: event<{ trackingId: string }>(),
 			});
-			client.api.workflowRun.multicastEventV1.once({
-				ids: ["run-1", "run-2"],
-				eventName: "orderShipped",
-				data: { trackingId: "T1" },
-				options: {},
-			});
+			client.api.workflowRun.multicastEventV1.once(
+				{
+					ids: ["run-1", "run-2"],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: {},
+				},
+				{ sentIds: ["run-1", "run-2"], failedIds: [] }
+			);
 
-			await multicasters.orderShipped.send(client, ["run-1", "run-2"], { trackingId: "T1" });
+			expect(await multicasters.orderShipped.send(client, ["run-1", "run-2"], { trackingId: "T1" })).toEqual({
+				sentIds: ["run-1", "run-2"],
+				failedIds: [],
+			});
 		}));
 
 	test("wraps a single run id in an array", () =>
@@ -253,12 +259,15 @@ describe("createEventMulticasters", () => {
 			const multicasters = createEventMulticasters(workflowName, versionId, {
 				orderShipped: event<{ trackingId: string }>(),
 			});
-			client.api.workflowRun.multicastEventV1.once({
-				ids: ["run-1"],
-				eventName: "orderShipped",
-				data: { trackingId: "T1" },
-				options: {},
-			});
+			client.api.workflowRun.multicastEventV1.once(
+				{
+					ids: ["run-1"],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: {},
+				},
+				{ sentIds: ["run-1"], failedIds: [] }
+			);
 
 			await multicasters.orderShipped.send(client, "run-1", { trackingId: "T1" });
 		}));
@@ -269,7 +278,10 @@ describe("createEventMulticasters", () => {
 				orderShipped: event<{ trackingId: string }>(),
 			});
 
-			expect(await multicasters.orderShipped.send(client, [], { trackingId: "T1" })).toBeUndefined();
+			expect(await multicasters.orderShipped.send(client, [], { trackingId: "T1" })).toEqual({
+				sentIds: [],
+				failedIds: [],
+			});
 		}));
 
 	test("multicasts by reference id, tagging each with the workflow name and version", () =>
@@ -277,17 +289,22 @@ describe("createEventMulticasters", () => {
 			const multicasters = createEventMulticasters(workflowName, versionId, {
 				orderShipped: event<{ trackingId: string }>(),
 			});
-			client.api.workflowRun.multicastEventByReferenceV1.once({
-				references: [
-					{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-1" },
-					{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-2" },
-				],
-				eventName: "orderShipped",
-				data: { trackingId: "T1" },
-				options: {},
-			});
+			client.api.workflowRun.multicastEventByReferenceV1.once(
+				{
+					references: [
+						{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-1" },
+						{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-2" },
+					],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: {},
+				},
+				{ sentIds: ["run-1", "run-2"], failedIds: [] }
+			);
 
-			await multicasters.orderShipped.sendByReferenceId(client, ["ref-1", "ref-2"], { trackingId: "T1" });
+			expect(
+				await multicasters.orderShipped.sendByReferenceId(client, ["ref-1", "ref-2"], { trackingId: "T1" })
+			).toEqual({ sentIds: ["run-1", "run-2"], failedIds: [] });
 		}));
 
 	test("wraps a single reference id in an array", () =>
@@ -295,12 +312,15 @@ describe("createEventMulticasters", () => {
 			const multicasters = createEventMulticasters(workflowName, versionId, {
 				orderShipped: event<{ trackingId: string }>(),
 			});
-			client.api.workflowRun.multicastEventByReferenceV1.once({
-				references: [{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-1" }],
-				eventName: "orderShipped",
-				data: { trackingId: "T1" },
-				options: {},
-			});
+			client.api.workflowRun.multicastEventByReferenceV1.once(
+				{
+					references: [{ name: "order-workflow", versionId: "1.0.0", referenceId: "ref-1" }],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: {},
+				},
+				{ sentIds: ["run-1"], failedIds: [] }
+			);
 
 			await multicasters.orderShipped.sendByReferenceId(client, "ref-1", { trackingId: "T1" });
 		}));
@@ -311,7 +331,31 @@ describe("createEventMulticasters", () => {
 				orderShipped: event<{ trackingId: string }>(),
 			});
 
-			expect(await multicasters.orderShipped.sendByReferenceId(client, [], { trackingId: "T1" })).toBeUndefined();
+			expect(await multicasters.orderShipped.sendByReferenceId(client, [], { trackingId: "T1" })).toEqual({
+				sentIds: [],
+				failedIds: [],
+			});
+		}));
+
+	test("reports the runs the server could not reach alongside the ones it did", () =>
+		withFakeClient(async (client) => {
+			const multicasters = createEventMulticasters(workflowName, versionId, {
+				orderShipped: event<{ trackingId: string }>(),
+			});
+			client.api.workflowRun.multicastEventV1.once(
+				{
+					ids: ["run-1", "run-2", "run-3"],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: {},
+				},
+				{ sentIds: ["run-1", "run-3"], failedIds: ["run-2"] }
+			);
+
+			expect(await multicasters.orderShipped.send(client, ["run-1", "run-2", "run-3"], { trackingId: "T1" })).toEqual({
+				sentIds: ["run-1", "run-3"],
+				failedIds: ["run-2"],
+			});
 		}));
 
 	test("throws SchemaValidationError and sends nothing when the data fails the schema", () =>
@@ -328,12 +372,15 @@ describe("createEventMulticasters", () => {
 			const multicasters = createEventMulticasters(workflowName, versionId, {
 				orderShipped: event<{ trackingId: string }>(),
 			});
-			client.api.workflowRun.multicastEventV1.once({
-				ids: ["run-1"],
-				eventName: "orderShipped",
-				data: { trackingId: "T1" },
-				options: { reference: { id: "ref-1" } },
-			});
+			client.api.workflowRun.multicastEventV1.once(
+				{
+					ids: ["run-1"],
+					eventName: "orderShipped",
+					data: { trackingId: "T1" },
+					options: { reference: { id: "ref-1" } },
+				},
+				{ sentIds: ["run-1"], failedIds: [] }
+			);
 
 			await multicasters.orderShipped.with("reference.id", "ref-1").send(client, "run-1", { trackingId: "T1" });
 		}));

--- a/sdk/workflow/src/run/event.ts
+++ b/sdk/workflow/src/run/event.ts
@@ -8,6 +8,7 @@ import { INTERNAL } from "@aikirun/types/symbols";
 import { SchemaValidationError } from "@aikirun/types/validator";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
+	EventMulticastResult,
 	EventName,
 	EventSendOptions,
 	EventWait,
@@ -100,12 +101,12 @@ export interface EventMulticaster<Data> {
 		client: Client<Context>,
 		runId: string | string[],
 		...args: Data extends void ? [] : [Data]
-	) => Promise<void>;
+	) => Promise<EventMulticastResult>;
 	sendByReferenceId<Context>(
 		client: Client<Context>,
 		referenceId: string | string[],
 		...args: Data extends void ? [] : [Data]
-	): Promise<void>;
+	): Promise<EventMulticastResult>;
 }
 
 export function createEventWaiters<TEvents extends EventsDefinition>(
@@ -276,7 +277,7 @@ function createEventMulticaster<Data>(
 		client: Client<Context>,
 		runId: string | string[],
 		...args: Data extends void ? [] : [Data]
-	): Promise<void> {
+	): Promise<EventMulticastResult> {
 		let data = args[0];
 		if (schema) {
 			const schemaValidation = schema["~standard"].validate(data);
@@ -295,12 +296,12 @@ function createEventMulticaster<Data>(
 
 		const runIds = Array.isArray(runId) ? runId : [runId];
 		if (!isNonEmptyArray(runIds)) {
-			return;
+			return { sentIds: [], failedIds: [] };
 		}
 
 		const options = optionsBuilder.build();
 
-		await client.api.workflowRun.multicastEventV1({
+		const result = await client.api.workflowRun.multicastEventV1({
 			ids: runIds,
 			eventName,
 			data,
@@ -310,17 +311,20 @@ function createEventMulticaster<Data>(
 		client.logger.info("Multicasted event to workflows", {
 			"aiki.workflowName": workflowName,
 			"aiki.workflowVersionId": workflowVersionId,
-			"aiki.workflowRunIds": runIds,
+			"aiki.sentWorkflowRunIds": result.sentIds,
+			"aiki.failedWorkflowRunIds": result.failedIds,
 			"aiki.eventName": eventName,
 			...(options?.reference ? { "aiki.eventReferenceId": options.reference.id } : {}),
 		});
+
+		return result;
 	}
 
 	async function sendByReferenceId<Context>(
 		client: Client<Context>,
 		referenceId: string | string[],
 		...args: Data extends void ? [] : [Data]
-	): Promise<void> {
+	): Promise<EventMulticastResult> {
 		let data = args[0];
 		if (schema) {
 			const schemaValidation = schema["~standard"].validate(data);
@@ -339,12 +343,12 @@ function createEventMulticaster<Data>(
 
 		const referenceIds = Array.isArray(referenceId) ? referenceId : [referenceId];
 		if (!isNonEmptyArray(referenceIds)) {
-			return;
+			return { sentIds: [], failedIds: [] };
 		}
 
 		const options = optionsBuilder.build();
 
-		await client.api.workflowRun.multicastEventByReferenceV1({
+		const result = await client.api.workflowRun.multicastEventByReferenceV1({
 			references: referenceIds.map((referenceId) => ({
 				name: workflowName,
 				versionId: workflowVersionId,
@@ -359,9 +363,13 @@ function createEventMulticaster<Data>(
 			"aiki.workflowName": workflowName,
 			"aiki.workflowVersionId": workflowVersionId,
 			"aiki.referenceIds": referenceIds,
+			"aiki.sentWorkflowRunIds": result.sentIds,
+			"aiki.failedWorkflowRunIds": result.failedIds,
 			"aiki.eventName": eventName,
 			...(options?.reference ? { "aiki.eventReferenceId": options.reference.id } : {}),
 		});
+
+		return result;
 	}
 
 	return {

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -17,7 +17,7 @@ import type {
 	WorkflowRunStatus,
 	WorkflowStartOptions,
 } from "../workflow/run";
-import type { EventSendOptions } from "../workflow/run/event";
+import type { EventMulticastResult, EventSendOptions } from "../workflow/run/event";
 import type { StateTransition } from "../workflow/state-transition";
 import type { TaskStatus } from "../workflow/task";
 
@@ -30,8 +30,10 @@ export interface WorkflowRunApi {
 	transitionStateV1: (_: WorkflowRunTransitionStateRequestV1) => Promise<WorkflowRunTransitionStateResponseV1>;
 	listTransitionsV1: (_: WorkflowRunListTransitionsRequestV1) => Promise<WorkflowRunListTransitionsResponseV1>;
 	sendEventV1: (_: WorkflowRunSendEventRequestV1) => Promise<void>;
-	multicastEventV1: (_: WorkflowRunMulticastEventRequestV1) => Promise<void>;
-	multicastEventByReferenceV1: (_: WorkflowRunMulticastEventByReferenceRequestV1) => Promise<void>;
+	multicastEventV1: (_: WorkflowRunMulticastEventRequestV1) => Promise<WorkflowRunMulticastEventResponseV1>;
+	multicastEventByReferenceV1: (
+		_: WorkflowRunMulticastEventByReferenceRequestV1
+	) => Promise<WorkflowRunMulticastEventResponseV1>;
 	listChildRunsV1: (_: WorkflowRunListChildRunsRequestV1) => Promise<WorkflowRunListChildRunsResponseV1>;
 	cancelByIdsV1: (_: WorkflowRunCancelByIdsRequestV1) => Promise<WorkflowRunCancelByIdsResponseV1>;
 	claimReadyV1: (_: WorkflowRunClaimReadyRequestV1) => Promise<WorkflowRunClaimReadyResponseV1>;
@@ -231,6 +233,8 @@ export interface WorkflowRunMulticastEventByReferenceRequestV1 {
 	data?: unknown;
 	options?: EventSendOptions;
 }
+
+export type WorkflowRunMulticastEventResponseV1 = EventMulticastResult;
 
 export interface WorkflowRunListChildRunsRequestV1 {
 	id: string;

--- a/types/src/workflow/run/event.ts
+++ b/types/src/workflow/run/event.ts
@@ -35,6 +35,11 @@ export interface EventSendOptions {
 	reference?: EventReference;
 }
 
+export interface EventMulticastResult {
+	sentIds: string[];
+	failedIds: string[];
+}
+
 export interface EventReference {
 	id: string;
 }


### PR DESCRIPTION
## Problem

An event multicast sends one event to up to ten workflow runs. Each run is handled in its own transaction: the event is recorded as an event wait against that run, and if the run is parked waiting for that event name, it is scheduled to resume.

Multicast attempted every run, then raised the first error it collected. So a caller that reached nine runs out of ten saw a failed call. Nothing in the failure said which run was missed, or whether any run had been reached at all — a call that delivered nine looked the same as a call that delivered none.

The successful sends had already committed. Retrying the call to recover the missed run re-delivered to the nine that already had the event, and a send without a reference id records a fresh event wait every time.

## Solution

Multicast reports what happened to each run instead of raising.

```ts
// before
multicastEventV1: (_: Request) => Promise<void>;

// after
multicastEventV1: (_: Request) => Promise<{ sentIds: string[]; failedIds: string[] }>;
```

A send that fails is logged and its run id goes into `failedIds`. The other runs are unaffected, since each send already ran in its own transaction. The caller can retry exactly the runs that were missed.