### PR TITLE
Signal sequence closes lost wake-ups on event waits

### DIFF
--- a/lib/src/object/types.ts
+++ b/lib/src/object/types.ts
@@ -53,6 +53,32 @@ declare const _requireAtLeastOnePropTypeTests: [
 	>,
 ];
 
+export type AtMostOneProp<T, Keys extends keyof T = keyof T> =
+	| {
+			[K in Keys]-?: { [P in K]: T[K] } & { [P in Exclude<Keys, K>]?: never };
+	  }[Keys]
+	| Partial<Record<Keys, never>>;
+declare const _requireAtMostOnePropTypeTests: [
+	ExpectTrue<
+		Equal<
+			AtMostOneProp<{ a: string; b: number; c: boolean }>,
+			| { a: string; b: undefined; c: undefined }
+			| { a: undefined; b: number; c: undefined }
+			| { a: undefined; b: undefined; c: boolean }
+			| { a: undefined; b: undefined; c: undefined }
+		>
+	>,
+	ExpectTrue<
+		Equal<
+			AtMostOneProp<{ a?: string; b: number | null; c: boolean }>,
+			| { a: string | undefined; b: undefined; c: undefined }
+			| { a: undefined; b: number | null; c: undefined }
+			| { a: undefined; b: undefined; c: boolean }
+			| { a: undefined; b: undefined; c: undefined }
+		>
+	>,
+];
+
 type IsSubtype<SubT, SuperT> = SubT extends SuperT ? true : false;
 
 type IsUnion<T, Copy = T> = T extends unknown ? ([Copy] extends [T] ? false : true) : never;

--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -177,31 +177,40 @@ const transitionStateV1: ContractProcedure<WorkflowRunTransitionStateRequestV1, 
 				type: "'optimistic'",
 				id: "string > 0",
 				expectedRevision: "number.integer >= 0",
-				state: workflowRunStateScheduledRequestOptimisticSchema
-					.or(workflowRunStateQueuedSchema)
-					.or(workflowRunStateRunningSchema)
-					.or(workflowRunStateSleepingSchema.omit("wakeupAt").and({ durationMs: "number > 0" }))
-					.or(
-						workflowRunStateAwaitingEventSchema
-							.omit("timeoutAt")
-							.and({ "timeoutInMs?": "number.integer > 0 | undefined" })
-					)
-					.or(workflowRunStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }))
-					.or(
-						workflowRunStateAwaitingChildWorkflowSchema
-							.omit("timeoutAt")
-							.and({ "timeoutInMs?": "number.integer > 0 | undefined" })
-					)
-					.or(workflowRunStateCompletedSchema.omit("output").and({ "output?": "unknown" }))
-					.or(workflowRunStateFailedSchema),
-			}).or({
-				type: "'pessimistic'",
-				id: "string > 0",
-				state: workflowRunStateScheduledRequestPessimisticSchema
-					.or(workflowRunStatePausedSchema)
-					.or(workflowRunStateStalledSchema)
-					.or(workflowRunStateCancelledSchema),
 			})
+				.and(
+					type({
+						state: workflowRunStateScheduledRequestOptimisticSchema
+							.or(workflowRunStateQueuedSchema)
+							.or(workflowRunStateRunningSchema)
+							.or(workflowRunStateSleepingSchema.omit("wakeupAt").and({ durationMs: "number > 0" }))
+							.or(
+								workflowRunStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" })
+							)
+							.or(workflowRunStateCompletedSchema.omit("output").and({ "output?": "unknown" }))
+							.or(workflowRunStateFailedSchema),
+					}).or({
+						expectedSignalSequence: "number.integer >= 0",
+						state: workflowRunStateAwaitingEventSchema
+							.omit("timeoutAt")
+							.and({ "timeoutInMs?": "number.integer > 0 | undefined" })
+							.or(
+								workflowRunStateAwaitingChildWorkflowSchema
+									.omit("timeoutAt")
+									.and({ "timeoutInMs?": "number.integer > 0 | undefined" })
+							),
+					})
+				)
+				.or(
+					type({
+						type: "'pessimistic'",
+						id: "string > 0",
+						state: workflowRunStateScheduledRequestPessimisticSchema
+							.or(workflowRunStatePausedSchema)
+							.or(workflowRunStateStalledSchema)
+							.or(workflowRunStateCancelledSchema),
+					})
+				)
 		)
 		.output(
 			type({

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -166,6 +166,7 @@ export const workflowRunRecordSchema = type({
 	source: workflowSourceSchema,
 	createdAt: "number > 0",
 	revision: "number >= 0",
+	signalSequence: "number.integer >= 0",
 	stateTransitionId: "string > 0",
 	"input?": "unknown",
 	inputHash: "string > 0",

--- a/sdk/server/src/infra/db/pg/migration/0023_dashing_phil_sheldon.sql
+++ b/sdk/server/src/infra/db/pg/migration/0023_dashing_phil_sheldon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow_run" ADD COLUMN "signal_sequence" integer DEFAULT 0 NOT NULL;

--- a/sdk/server/src/infra/db/pg/migration/meta/0023_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0023_snapshot.json
@@ -1,0 +1,1775 @@
+{
+	"id": "747c7395-3e7a-4639-93a8-26a006021410",
+	"prevId": "7ca4cf5d-da7e-4719-87d0-ec7cfb06c49e",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR \"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_id": {
+					"name": "idx_event_wait_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -162,6 +162,13 @@
 			"when": 1787074829782,
 			"tag": "0022_concerned_the_call",
 			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1787395980116,
+			"tag": "0023_dashing_phil_sheldon",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -1,8 +1,10 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
+import type { AtMostOneProp } from "@aikirun/lib/object";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowSource } from "@aikirun/types/workflow";
 import type {
+	WaitingForSignalWorkflowRunStatus,
 	WorkflowRunId,
 	WorkflowRunOptions,
 	WorkflowRunState,
@@ -20,12 +22,27 @@ import { stateTransition, workflow, workflowRun } from "../schema";
 
 export type WorkflowRunRow = typeof workflowRun.$inferSelect;
 export type WorkflowRunRowInsert = typeof workflowRun.$inferInsert;
-type WorkflowRunRowUpdate = Partial<
-	Pick<
-		WorkflowRunRowInsert,
-		"status" | "attempts" | "latestStateTransitionId" | "scheduledAt" | "wakeupAt" | "timeoutAt" | "nextAttemptAt"
-	>
->;
+
+export type UpdateWorkflowRunParams =
+	| {
+			waitForSignal: true;
+			filter: { namespaceId: NamespaceId; id: WorkflowRunId; revision: number; signalSequence: number };
+			updates: {
+				attempts: number;
+				latestStateTransitionId: string;
+				onSignalSequenceMatch: { status: WaitingForSignalWorkflowRunStatus; timeoutAt: TimestampMs | null };
+				onSignalSequenceMismatch: { status: "scheduled"; scheduledAt: TimestampMs };
+			};
+	  }
+	| {
+			waitForSignal: false;
+			filter: { namespaceId: NamespaceId; id: WorkflowRunId; revision?: number };
+			updates: {
+				status: Exclude<WorkflowRunStatus, WaitingForSignalWorkflowRunStatus>;
+				attempts: number;
+				latestStateTransitionId: string;
+			} & AtMostOneProp<{ scheduledAt: TimestampMs; wakeupAt: TimestampMs; nextAttemptAt: TimestampMs }>;
+	  };
 
 export type WorkflowRunWithState = {
 	run: Pick<
@@ -55,32 +72,87 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		await db.insert(workflowRun).values(values);
 	},
 
-	async update(
-		filter: { namespaceId: NamespaceId; id: WorkflowRunId; revision?: number },
-		updates: WorkflowRunRowUpdate
-	): Promise<{ revision: number } | undefined> {
+	async update(params: UpdateWorkflowRunParams): Promise<{ revision: number; signalSequence: number } | null> {
+		const { filter } = params;
 		const conditions = [eq(workflowRun.namespaceId, filter.namespaceId), eq(workflowRun.id, filter.id)];
 		if (filter.revision !== undefined) {
 			conditions.push(eq(workflowRun.revision, filter.revision));
 		}
 
-		const whereClause = and(...conditions);
+		if (params.waitForSignal) {
+			const { filter, updates } = params;
+			const { onSignalSequenceMatch, onSignalSequenceMismatch } = updates;
+			const signalSequenceMatches = sql`${workflowRun.signalSequence} = ${filter.signalSequence}`;
+			const timeoutAtIso =
+				onSignalSequenceMatch.timeoutAt === null ? null : new Date(onSignalSequenceMatch.timeoutAt).toISOString();
+			const scheduledAtIso = new Date(onSignalSequenceMismatch.scheduledAt).toISOString();
 
+			const result = await db
+				.update(workflowRun)
+				.set({
+					revision: sql`${workflowRun.revision} + 1`,
+					attempts: updates.attempts,
+					latestStateTransitionId: updates.latestStateTransitionId,
+					status: sql`CASE WHEN ${signalSequenceMatches} THEN ${onSignalSequenceMatch.status}::workflow_run_status ELSE ${onSignalSequenceMismatch.status}::workflow_run_status END`,
+					timeoutAt: sql`CASE WHEN ${signalSequenceMatches} THEN ${timeoutAtIso}::timestamptz ELSE NULL END`,
+					scheduledAt: sql`CASE WHEN ${signalSequenceMatches} THEN NULL ELSE ${scheduledAtIso}::timestamptz END`,
+					wakeupAt: null,
+					nextAttemptAt: null,
+				})
+				.where(and(...conditions))
+				.returning({ revision: workflowRun.revision, signalSequence: workflowRun.signalSequence });
+
+			return result[0] ?? null;
+		}
+
+		const { updates } = params;
 		const result = await db
 			.update(workflowRun)
 			.set({
-				...updates,
 				revision: sql`${workflowRun.revision} + 1`,
+				status: updates.status,
+				attempts: updates.attempts,
+				latestStateTransitionId: updates.latestStateTransitionId,
+				timeoutAt: null,
+				scheduledAt: "scheduledAt" in updates ? updates.scheduledAt : null,
+				wakeupAt: "wakeupAt" in updates ? updates.wakeupAt : null,
+				nextAttemptAt: "nextAttemptAt" in updates ? updates.nextAttemptAt : null,
 			})
-			.where(whereClause)
-			.returning({ revision: workflowRun.revision });
+			.where(and(...conditions))
+			.returning({ revision: workflowRun.revision, signalSequence: workflowRun.signalSequence });
 
-		const revision = result[0]?.revision;
-		if (revision === undefined) {
-			return undefined;
+		return result[0] ?? null;
+	},
+
+	async incrementSignalSequence(filter: {
+		namespaceId: NamespaceId;
+		id: WorkflowRunId;
+	}): Promise<{ run: Pick<WorkflowRunRow, "status" | "revision" | "signalSequence">; state: WorkflowRunState } | null> {
+		const result = await db
+			.update(workflowRun)
+			.set({ signalSequence: sql`${workflowRun.signalSequence} + 1` })
+			.from(stateTransition)
+			.where(
+				and(
+					eq(workflowRun.namespaceId, filter.namespaceId),
+					eq(workflowRun.id, filter.id),
+					eq(stateTransition.id, workflowRun.latestStateTransitionId)
+				)
+			)
+			.returning({
+				run: {
+					status: workflowRun.status,
+					revision: workflowRun.revision,
+					signalSequence: workflowRun.signalSequence,
+				},
+				state: stateTransition.state,
+			});
+
+		const row = result[0];
+		if (!row) {
+			return null;
 		}
-
-		return { revision };
+		return { run: row.run, state: toWorkflowRunState(row.state) };
 	},
 
 	async exists(namespaceId: NamespaceId, id: string): Promise<boolean> {
@@ -130,7 +202,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		if (!row) {
 			return null;
 		}
-		return { ...row, state: toWorkflowRunState(row.state) };
+		return { run: row.run, state: toWorkflowRunState(row.state) };
 	},
 
 	async getByIdWithWorkflowAndState(filter: { namespaceId: NamespaceId; id: string }) {
@@ -140,6 +212,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 					id: workflowRun.id,
 					createdAt: workflowRun.createdAt,
 					revision: workflowRun.revision,
+					signalSequence: workflowRun.signalSequence,
 					attempts: workflowRun.attempts,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
 					input: workflowRun.input,
@@ -162,7 +235,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		if (!row) {
 			return null;
 		}
-		return { ...row, state: toWorkflowRunState(row.state) };
+		return { run: row.run, workflow: row.workflow, state: toWorkflowRunState(row.state) };
 	},
 
 	async getByReferenceWithWorkflowAndState(filter: {
@@ -178,6 +251,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 					id: workflowRun.id,
 					createdAt: workflowRun.createdAt,
 					revision: workflowRun.revision,
+					signalSequence: workflowRun.signalSequence,
 					attempts: workflowRun.attempts,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
 					input: workflowRun.input,
@@ -208,7 +282,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		if (!row) {
 			return null;
 		}
-		return { ...row, state: toWorkflowRunState(row.state) };
+		return { run: row.run, workflow: row.workflow, state: toWorkflowRunState(row.state) };
 	},
 
 	async listByIdsAndStatus(_context: DaemonContext, ids: NonEmptyArray<string>, status: WorkflowRunStatus) {

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -128,6 +128,7 @@ export const workflowRun = pgTable(
 
 		status: workflowRunStatusEnum("status").notNull(),
 		revision: integer("revision").notNull().default(0),
+		signalSequence: integer("signal_sequence").notNull().default(0),
 		attempts: integer("attempts").notNull().default(1),
 
 		input: jsonb("input"),

--- a/sdk/server/src/infra/db/types/workflow-run.ts
+++ b/sdk/server/src/infra/db/types/workflow-run.ts
@@ -1,5 +1,6 @@
 export type {
 	DueWorkflowRun,
+	UpdateWorkflowRunParams,
 	WorkflowRunMeta,
 	WorkflowRunRepository,
 	WorkflowRunRow,

--- a/sdk/server/src/infra/db/workflow-run.integration.test.ts
+++ b/sdk/server/src/infra/db/workflow-run.integration.test.ts
@@ -1,6 +1,13 @@
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { WaitingForSignalWorkflowRunStatus, WorkflowRunId } from "@aikirun/types/workflow/run";
+import { ulid } from "ulidx";
+
+import type { Repositories } from "./types";
+import type { DueWorkflowRun } from "./types/workflow-run";
 import { describe, expect, test } from "bun:test";
+import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../../testing/harness";
-import { seedCompletedRun } from "../../testing/seed/run";
+import { seedAwaitingEventRun, seedClaimedRun, seedCompletedRun } from "../../testing/seed/run";
 
 const withHarness = createServiceHarness();
 
@@ -61,5 +68,389 @@ describe("workflow run repository state reads", () => {
 
 			expect(row?.state).toContainKey("output");
 			expect(row?.state).toEqual({ status: "completed", output: undefined });
+		}));
+});
+
+describe("update guarded on the signal sequence", () => {
+	// Each waiting status has its own timed-out scan; the cell is the read that would surface
+	// the stored timeout.
+	const waitingStatusCases = {
+		awaiting_event: {
+			status: "awaiting_event",
+			listTimedOutRuns: (repos: Repositories, before: TimestampMs) =>
+				repos.workflowRun.listEventWaitTimedOutRuns(daemonContextFactory.build(), before, 10),
+		},
+		awaiting_child_workflow: {
+			status: "awaiting_child_workflow",
+			listTimedOutRuns: (repos: Repositories, before: TimestampMs) =>
+				repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContextFactory.build(), before, 10),
+		},
+	} satisfies {
+		[S in WaitingForSignalWorkflowRunStatus]: {
+			status: S;
+			listTimedOutRuns: (repos: Repositories, before: TimestampMs) => Promise<DueWorkflowRun[]>;
+		};
+	};
+
+	for (const { status, listTimedOutRuns } of Object.values(waitingStatusCases)) {
+		test(`applies the matched ${status} update when the sequence is unchanged`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const { runId, revisionWhenClaimed } = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+
+				const result = await repos.workflowRun.update({
+					waitForSignal: true,
+					filter: {
+						namespaceId: context.namespaceId,
+						id: runId as WorkflowRunId,
+						revision: revisionWhenClaimed,
+						signalSequence: 0,
+					},
+					updates: {
+						attempts: 1,
+						latestStateTransitionId: ulid(),
+						onSignalSequenceMatch: { status, timeoutAt: null },
+						onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+					},
+				});
+
+				expect(result).toEqual({ revision: revisionWhenClaimed + 1, signalSequence: 0 });
+				expect(await repos.workflowRun.getById({ namespaceId: context.namespaceId, id: runId })).toEqual({
+					id: runId,
+					revision: revisionWhenClaimed + 1,
+					status,
+				});
+			}));
+
+		test(`the matched ${status} update writes the timeout it was given`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const { runId, revisionWhenClaimed } = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+				const timeoutAt = 1_000_000 as TimestampMs;
+
+				await repos.workflowRun.update({
+					waitForSignal: true,
+					filter: {
+						namespaceId: context.namespaceId,
+						id: runId as WorkflowRunId,
+						revision: revisionWhenClaimed,
+						signalSequence: 0,
+					},
+					updates: {
+						attempts: 1,
+						latestStateTransitionId: ulid(),
+						onSignalSequenceMatch: { status, timeoutAt },
+						onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+					},
+				});
+
+				expect(await listTimedOutRuns(repos, timeoutAt)).toEqual([
+					expect.objectContaining({ id: runId, dueAt: timeoutAt }),
+				]);
+				expect(await listTimedOutRuns(repos, (timeoutAt - 1) as TimestampMs)).toEqual([]);
+			}));
+
+		test(`the matched ${status} without a timeout stores no due time`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const { runId, revisionWhenClaimed } = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+
+				await repos.workflowRun.update({
+					waitForSignal: true,
+					filter: {
+						namespaceId: context.namespaceId,
+						id: runId as WorkflowRunId,
+						revision: revisionWhenClaimed,
+						signalSequence: 0,
+					},
+					updates: {
+						attempts: 1,
+						latestStateTransitionId: ulid(),
+						onSignalSequenceMatch: { status, timeoutAt: null },
+						onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+					},
+				});
+
+				expect(await repos.workflowRun.getById({ namespaceId: context.namespaceId, id: runId })).toEqual({
+					id: runId,
+					revision: revisionWhenClaimed + 1,
+					status,
+				});
+				const endOfTime = 253_402_214_400_000 as TimestampMs; // 9999-12-31
+				expect(await repos.workflowRun.listEventWaitTimedOutRuns(daemonContextFactory.build(), endOfTime, 10)).toEqual(
+					[]
+				);
+			}));
+	}
+
+	test("the mismatched update writes the schedule it was given", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+			await repos.workflowRun.incrementSignalSequence({
+				namespaceId: context.namespaceId,
+				id: runId as WorkflowRunId,
+			});
+
+			const scheduledAt = 2_000_000 as TimestampMs;
+
+			await repos.workflowRun.update({
+				waitForSignal: true,
+				filter: {
+					namespaceId: context.namespaceId,
+					id: runId as WorkflowRunId,
+					revision: revisionWhenClaimed,
+					signalSequence: 0,
+				},
+				updates: {
+					attempts: 1,
+					latestStateTransitionId: ulid(),
+					onSignalSequenceMatch: { status: "awaiting_event", timeoutAt: null },
+					onSignalSequenceMismatch: { status: "scheduled", scheduledAt },
+				},
+			});
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(await repos.workflowRun.listDueScheduleRuns(daemonContext, scheduledAt, 10)).toEqual([
+				expect.objectContaining({ id: runId, dueAt: scheduledAt }),
+			]);
+			expect(await repos.workflowRun.listDueScheduleRuns(daemonContext, (scheduledAt - 1) as TimestampMs, 10)).toEqual(
+				[]
+			);
+		}));
+
+	test("applies the mismatched update when the sequence has moved", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+			await repos.workflowRun.incrementSignalSequence({
+				namespaceId: context.namespaceId,
+				id: runId as WorkflowRunId,
+			});
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: true,
+				filter: {
+					namespaceId: context.namespaceId,
+					id: runId as WorkflowRunId,
+					revision: revisionWhenClaimed,
+					signalSequence: 0,
+				},
+				updates: {
+					attempts: 1,
+					latestStateTransitionId: ulid(),
+					onSignalSequenceMatch: { status: "awaiting_event", timeoutAt: null },
+					onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+				},
+			});
+
+			expect(result).toEqual({ revision: revisionWhenClaimed + 1, signalSequence: 1 });
+			expect(await repos.workflowRun.getById({ namespaceId: context.namespaceId, id: runId })).toEqual({
+				id: runId,
+				revision: revisionWhenClaimed + 1,
+				status: "scheduled",
+			});
+		}));
+
+	test("writes nothing when the revision has moved", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: true,
+				filter: {
+					namespaceId: context.namespaceId,
+					id: runId as WorkflowRunId,
+					revision: revisionWhenClaimed - 1,
+					signalSequence: 0,
+				},
+				updates: {
+					attempts: 1,
+					latestStateTransitionId: ulid(),
+					onSignalSequenceMatch: { status: "awaiting_event", timeoutAt: null },
+					onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+				},
+			});
+
+			expect(result).toBeNull();
+			expect(await repos.workflowRun.getById({ namespaceId: context.namespaceId, id: runId })).toEqual({
+				id: runId,
+				revision: revisionWhenClaimed,
+				status: "running",
+			});
+		}));
+});
+
+describe("update without a signal sequence guard", () => {
+	test("writes the schedule for a scheduled update", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const scheduledAt = 2_000_000 as TimestampMs;
+			const { runId, revisionWhenParked } = await seedAwaitingEventRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ eventName: "orderShipped" }
+			);
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: false,
+				filter: { namespaceId: context.namespaceId, id: runId as WorkflowRunId, revision: revisionWhenParked },
+				updates: { status: "scheduled", attempts: 1, latestStateTransitionId: ulid(), scheduledAt },
+			});
+
+			expect(result).toEqual({ revision: revisionWhenParked + 1, signalSequence: 0 });
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(await repos.workflowRun.listDueScheduleRuns(daemonContext, scheduledAt, 10)).toEqual([
+				expect.objectContaining({ id: runId, dueAt: scheduledAt }),
+			]);
+			expect(await repos.workflowRun.listDueScheduleRuns(daemonContext, (scheduledAt - 1) as TimestampMs, 10)).toEqual(
+				[]
+			);
+		}));
+
+	test("writes the wakeup for a sleeping update", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const wakeupAt = 3_000_000 as TimestampMs;
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: false,
+				filter: { namespaceId: context.namespaceId, id: runId as WorkflowRunId, revision: revisionWhenClaimed },
+				updates: { status: "sleeping", attempts: 1, latestStateTransitionId: ulid(), wakeupAt },
+			});
+
+			expect(result).toEqual({ revision: revisionWhenClaimed + 1, signalSequence: 0 });
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(await repos.workflowRun.listSleepElapsedRuns(daemonContext, wakeupAt, 10)).toEqual([
+				expect.objectContaining({ id: runId, dueAt: wakeupAt }),
+			]);
+			expect(await repos.workflowRun.listSleepElapsedRuns(daemonContext, (wakeupAt - 1) as TimestampMs, 10)).toEqual(
+				[]
+			);
+		}));
+
+	test("writes the next attempt for an awaiting_retry update", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const nextAttemptAt = 4_000_000 as TimestampMs;
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: false,
+				filter: { namespaceId: context.namespaceId, id: runId as WorkflowRunId, revision: revisionWhenClaimed },
+				updates: { status: "awaiting_retry", attempts: 1, latestStateTransitionId: ulid(), nextAttemptAt },
+			});
+
+			expect(result).toEqual({ revision: revisionWhenClaimed + 1, signalSequence: 0 });
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(await repos.workflowRun.listRetryableRuns(daemonContext, nextAttemptAt, 10)).toEqual([
+				expect.objectContaining({ id: runId, dueAt: nextAttemptAt }),
+			]);
+			expect(await repos.workflowRun.listRetryableRuns(daemonContext, (nextAttemptAt - 1) as TimestampMs, 10)).toEqual(
+				[]
+			);
+		}));
+
+	test("updates without a revision in the filter", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const result = await repos.workflowRun.update({
+				waitForSignal: false,
+				filter: { namespaceId: context.namespaceId, id: runId as WorkflowRunId },
+				updates: { status: "paused", attempts: 1, latestStateTransitionId: ulid() },
+			});
+
+			expect(result).toEqual({ revision: revisionWhenClaimed + 1, signalSequence: 0 });
+			expect(await repos.workflowRun.getById({ namespaceId: context.namespaceId, id: runId })).toEqual({
+				id: runId,
+				revision: revisionWhenClaimed + 1,
+				status: "paused",
+			});
+		}));
+});
+
+describe("incrementSignalSequence", () => {
+	test("increments the sequence on each call and returns the run with its current state", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const filter = { namespaceId: context.namespaceId, id: runId as WorkflowRunId };
+
+			expect(await repos.workflowRun.incrementSignalSequence(filter)).toEqual({
+				run: { status: "running", revision: revisionWhenClaimed, signalSequence: 1 },
+				state: { status: "running" },
+			});
+			expect(await repos.workflowRun.incrementSignalSequence(filter)).toEqual({
+				run: { status: "running", revision: revisionWhenClaimed, signalSequence: 2 },
+				state: { status: "running" },
+			});
+		}));
+
+	test("returns the state recorded by the run's latest transition", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenParked } = await seedAwaitingEventRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ eventName: "orderShipped" }
+			);
+
+			expect(
+				await repos.workflowRun.incrementSignalSequence({
+					namespaceId: context.namespaceId,
+					id: runId as WorkflowRunId,
+				})
+			).toEqual({
+				run: { status: "awaiting_event", revision: revisionWhenParked, signalSequence: 1 },
+				state: { status: "awaiting_event", eventName: "orderShipped" },
+			});
+		}));
+
+	test("returns null for an unknown run", () =>
+		withHarness(async ({ context, repos }) => {
+			expect(
+				await repos.workflowRun.incrementSignalSequence({
+					namespaceId: context.namespaceId,
+					id: "run-missing" as WorkflowRunId,
+				})
+			).toBeNull();
 		}));
 });

--- a/sdk/server/src/service/event.ts
+++ b/sdk/server/src/service/event.ts
@@ -1,9 +1,15 @@
 import { NotFoundError } from "@aikirun/lib/error";
 import { propsRequiredNonNull } from "@aikirun/lib/object";
-import type { EventMulticastResult, EventReference, WorkflowRunId } from "@aikirun/types/workflow/run";
+import {
+	type EventMulticastResult,
+	type EventReference,
+	isTerminalWorkflowRunStatus,
+	type WorkflowRunId,
+} from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import type { WorkflowRunStateMachine } from "./state-machine/workflow-run";
+import { WorkflowRunTerminatedError } from "../errors";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { EventWaitRowInsert } from "../infra/db/types/event-wait";
 import { runConcurrently } from "../lib/concurrency";
@@ -73,11 +79,18 @@ async function sendEventToWorkflowRunInTx(
 	workflowRunStateMachine: WorkflowRunStateMachine
 ) {
 	const { runId, eventName, data, reference } = params;
-	const runWithState = await txRepos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+	const { namespaceId } = context;
+
+	// acquire lock on run row so that the wakeup is never lost if the current status is running
+	// but there is a concurrent state transition moving it to awaiting_event
+	const runWithState = await txRepos.workflowRun.incrementSignalSequence({ namespaceId, id: runId });
 	if (!runWithState) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);
 	}
 	const { run, state } = runWithState;
+	if (isTerminalWorkflowRunStatus(run.status)) {
+		throw new WorkflowRunTerminatedError(runId, run.status);
+	}
 
 	const eventWaitEntry: EventWaitRowInsert = {
 		id: ulid(),

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -2,6 +2,7 @@ import { asConfigProvider } from "@aikirun/lib/config";
 import { NotFoundError } from "@aikirun/lib/error";
 import { noopLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import { createWorkflowRunStateMachine } from "./workflow-run";
 import { describe, expect, test } from "bun:test";
@@ -14,8 +15,9 @@ import { computeRank } from "../../lib/rank";
 import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../../testing/harness";
-import { claimRun, seedClaimedRun, seedScheduledRun, seedStalledRun } from "../../testing/seed/run";
+import { claimRun, seedClaimedRun, seedCompletedRun, seedScheduledRun, seedStalledRun } from "../../testing/seed/run";
 import { createChildRunCanceller } from "../cancel-child-runs";
+import { createEventService } from "../event";
 
 const withHarness = createServiceHarness();
 
@@ -597,6 +599,209 @@ describe("WorkflowRunStateMachine redelivery", () => {
 					state: { status: "scheduled", scheduledInMs: 0, reason: "resumption" },
 				})
 			).rejects.toThrow(InvalidWorkflowRunStateTransitionError);
+		}));
+});
+
+describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
+	test("a park with the run's current signal sequence parks it", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			const parkedAt = Date.now();
+			const result = await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "awaiting_event", eventName: "paymentReceived", timeoutInMs: 60_000 },
+					expectedRevision: revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(result).toEqual({
+				revision: revisionWhenClaimed + 1,
+				state: { status: "awaiting_event", eventName: "paymentReceived", timeoutAt: parkedAt + 60_000 },
+				attempts: attemptsWhenClaimed,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: runId,
+						status: "awaiting_event",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
+					state: { status: "awaiting_event", eventName: "paymentReceived", timeoutAt: parkedAt + 60_000 },
+				})
+			);
+		}));
+
+	test("an event landing between the worker's read and its park reschedules the run instead of parking it", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			await createEventService({ repos, workflowRunStateMachine: stateMachine }).sendEventToWorkflowRun(context, {
+				runId: runId as WorkflowRunId,
+				eventName: "paymentReceived",
+				data: { amount: 25 },
+				reference: undefined,
+			});
+
+			const parkedAt = Date.now();
+			const result = await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "awaiting_event", eventName: "paymentReceived" },
+					expectedRevision: revisionWhenClaimed,
+					// The sequence the worker read before the event landed.
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(result).toEqual({
+				revision: revisionWhenClaimed + 1,
+				state: { status: "scheduled", reason: "event", scheduledAt: parkedAt },
+				attempts: attemptsWhenClaimed,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: runId,
+						status: "scheduled",
+						revision: result.revision,
+						attempts: result.attempts,
+					}),
+					state: { status: "scheduled", reason: "event", scheduledAt: parkedAt },
+				})
+			);
+		}));
+
+	test("a signal landing before a child-workflow park reschedules the run with reason child_workflow", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			// Still scheduled, so the parent's wait is genuinely needed.
+			const child = await seedScheduledRun({ namespaceRequestContext: context, repos });
+
+			const stateMachine = createStateMachine(repos);
+			// One sequence counts every signal: an event moves it even for a child-workflow park.
+			await createEventService({ repos, workflowRunStateMachine: stateMachine }).sendEventToWorkflowRun(context, {
+				runId: parent.runId as WorkflowRunId,
+				eventName: "paymentReceived",
+				data: { amount: 25 },
+				reference: undefined,
+			});
+
+			const parkedAt = Date.now();
+			const result = await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: parent.runId,
+					state: {
+						status: "awaiting_child_workflow",
+						childWorkflowRunId: child.runId,
+						childWorkflowRunStatus: "completed",
+					},
+					expectedRevision: parent.revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(result).toEqual({
+				revision: parent.revisionWhenClaimed + 1,
+				state: { status: "scheduled", reason: "child_workflow", scheduledAt: parkedAt },
+				attempts: parent.attemptsWhenClaimed,
+			});
+
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: parent.runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: parent.runId, status: "scheduled", revision: result.revision }),
+					state: { status: "scheduled", reason: "child_workflow", scheduledAt: parkedAt },
+				})
+			);
+		}));
+
+	test("a mismatched park adds the run's timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+			await createEventService({ repos, workflowRunStateMachine: stateMachine }).sendEventToWorkflowRun(context, {
+				runId: runId as WorkflowRunId,
+				eventName: "paymentReceived",
+				data: { amount: 25 },
+				reference: undefined,
+			});
+
+			const parkedAt = Date.now();
+			await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "awaiting_event", eventName: "paymentReceived" },
+					expectedRevision: revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: parkedAt }) },
+			]);
+		}));
+
+	test("a park on a child already at the awaited status schedules the run immediately", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedCompletedRun({ namespaceRequestContext: context, repos, publisher });
+
+			const stateMachine = createStateMachine(repos);
+			const parkedAt = Date.now();
+			const result = await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: parent.runId,
+					state: {
+						status: "awaiting_child_workflow",
+						childWorkflowRunId: child.runId,
+						childWorkflowRunStatus: "completed",
+					},
+					expectedRevision: parent.revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(result).toEqual({
+				revision: parent.revisionWhenClaimed + 1,
+				state: { status: "scheduled", reason: "child_workflow", scheduledAt: parkedAt },
+				attempts: parent.attemptsWhenClaimed,
+			});
 		}));
 });
 

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -18,6 +18,7 @@ import { ulid } from "ulidx";
 
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../../errors";
 import type { Repositories, TxRepositories } from "../../infra/db/types";
+import type { UpdateWorkflowRunParams } from "../../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../../middleware/context";
 import type { ChildRunCanceller } from "../cancel-child-runs";
@@ -177,7 +178,7 @@ async function transitionStateInTx(
 		throw new WorkflowRunRevisionConflictError(runId, request.expectedRevision);
 	}
 
-	const now = Date.now();
+	const now = Date.now() as TimestampMs;
 	let toState = convertDurationToTimestamp(request.state, now);
 
 	if (fromState.status === "sleeping" && (toState.status === "scheduled" || toState.status === "cancelled")) {
@@ -229,6 +230,19 @@ async function transitionStateInTx(
 	}
 
 	const stateTransitionId = ulid();
+
+	const updatedRun = await updateWorkflowRun(
+		context,
+		runId,
+		request,
+		toState,
+		stateTransitionId,
+		attempts,
+		now,
+		txRepos
+	);
+	toState = updatedRun.state;
+
 	await txRepos.stateTransition.append({
 		id: stateTransitionId,
 		workflowRunId: runId,
@@ -237,8 +251,6 @@ async function transitionStateInTx(
 		attempt: attempts,
 		state: toState,
 	});
-
-	const newRevision = await updateWorkflowRun(context, runId, request, toState, stateTransitionId, attempts, txRepos);
 
 	if (imminentRunTimerQueue && toState.status === "scheduled") {
 		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt: toState.scheduledAt }]));
@@ -264,7 +276,7 @@ async function transitionStateInTx(
 		);
 	}
 
-	return { revision: newRevision, state: toState, attempts };
+	return { revision: updatedRun.revision, state: toState, attempts };
 }
 
 async function cancelSleep(runId: WorkflowRunId, sleepName: string, now: number, txRepos: TxRepositories) {
@@ -323,49 +335,108 @@ async function updateWorkflowRun(
 	toState: WorkflowRunState,
 	stateTransitionId: string,
 	attempts: number,
+	now: TimestampMs,
 	txRepos: TxRepositories
-): Promise<number> {
-	const updates: Record<string, unknown> = {
-		status: toState.status,
-		attempts,
-		latestStateTransitionId: stateTransitionId,
-		scheduledAt: null,
-		wakeupAt: null,
-		timeoutAt: null,
-		nextAttemptAt: null,
-	};
-	if (toState.status === "scheduled") {
-		updates.scheduledAt = toState.scheduledAt as TimestampMs;
-	} else if (toState.status === "sleeping") {
-		updates.wakeupAt = toState.wakeupAt as TimestampMs;
-	} else if (
-		(toState.status === "awaiting_event" || toState.status === "awaiting_child_workflow") &&
-		toState.timeoutAt !== undefined
-	) {
-		updates.timeoutAt = toState.timeoutAt as TimestampMs;
-	} else if (toState.status === "awaiting_retry") {
-		updates.nextAttemptAt = toState.nextAttemptAt as TimestampMs;
-	}
+): Promise<{ revision: number; state: WorkflowRunState }> {
+	const { namespaceId } = context;
 
-	if (request.type === "optimistic") {
-		const result = await txRepos.workflowRun.update(
-			{
-				namespaceId: context.namespaceId,
+	if (toState.status === "awaiting_event" || toState.status === "awaiting_child_workflow") {
+		if (request.type !== "optimistic" || !("expectedSignalSequence" in request)) {
+			// The request contract makes this impossible.
+			throw new Error(`Wait transition without expectedSignalSequence for run: ${runId}`);
+		}
+
+		const result = await txRepos.workflowRun.update({
+			waitForSignal: true,
+			filter: {
+				namespaceId,
 				id: runId,
 				revision: request.expectedRevision,
+				signalSequence: request.expectedSignalSequence,
 			},
-			updates
-		);
+			updates: {
+				attempts,
+				latestStateTransitionId: stateTransitionId,
+				onSignalSequenceMatch: {
+					status: toState.status,
+					timeoutAt: toState.timeoutAt !== undefined ? (toState.timeoutAt as TimestampMs) : null,
+				},
+				onSignalSequenceMismatch: { status: "scheduled", scheduledAt: now as TimestampMs },
+			},
+		});
 		if (!result) {
 			throw new WorkflowRunRevisionConflictError(runId, request.expectedRevision);
 		}
-		return result.revision;
+
+		if (result.signalSequence !== request.expectedSignalSequence) {
+			// TODO: gather metrics on false re-schedules.
+			// This can happen when sequence was moved by an unrelated signal like an
+			// event different from the one we attempted to wait on.
+			// My bet is that these are rare occurrences, but if they bite, we'll need
+			// find a solution, possibly querying the db to see if a re-schedule can be skipped.
+			if (toState.status === "awaiting_event") {
+				return {
+					revision: result.revision,
+					state: { status: "scheduled", reason: "event", scheduledAt: now },
+				};
+			} else {
+				toState.status satisfies "awaiting_child_workflow";
+				return {
+					revision: result.revision,
+					state: { status: "scheduled", reason: "child_workflow", scheduledAt: now },
+				};
+			}
+		}
+
+		return { revision: result.revision, state: toState };
+	}
+
+	let updates: Extract<UpdateWorkflowRunParams, { waitForSignal: false }>["updates"];
+	if (toState.status === "scheduled") {
+		updates = {
+			status: toState.status,
+			attempts,
+			latestStateTransitionId: stateTransitionId,
+			scheduledAt: toState.scheduledAt as TimestampMs,
+		};
+	} else if (toState.status === "sleeping") {
+		updates = {
+			status: toState.status,
+			attempts,
+			latestStateTransitionId: stateTransitionId,
+			wakeupAt: toState.wakeupAt as TimestampMs,
+		};
+	} else if (toState.status === "awaiting_retry") {
+		updates = {
+			status: toState.status,
+			attempts,
+			latestStateTransitionId: stateTransitionId,
+			nextAttemptAt: toState.nextAttemptAt as TimestampMs,
+		};
 	} else {
-		const result = await txRepos.workflowRun.update({ namespaceId: context.namespaceId, id: runId }, updates);
+		updates = { status: toState.status, attempts, latestStateTransitionId: stateTransitionId };
+	}
+
+	if (request.type === "optimistic") {
+		const result = await txRepos.workflowRun.update({
+			waitForSignal: false,
+			filter: { namespaceId, id: runId, revision: request.expectedRevision },
+			updates,
+		});
+		if (!result) {
+			throw new WorkflowRunRevisionConflictError(runId, request.expectedRevision);
+		}
+		return { revision: result.revision, state: toState };
+	} else {
+		const result = await txRepos.workflowRun.update({
+			waitForSignal: false,
+			filter: { namespaceId, id: runId },
+			updates,
+		});
 		if (!result) {
 			throw new NotFoundError(`Workflow run not found: ${runId}`);
 		}
-		return result.revision;
+		return { revision: result.revision, state: toState };
 	}
 }
 

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -483,6 +483,7 @@ async function getWorkflowRun(
 		source: workflow.source,
 		createdAt: run.createdAt,
 		revision: run.revision,
+		signalSequence: run.signalSequence,
 		stateTransitionId: run.latestStateTransitionId,
 		input: run.input,
 		inputHash: run.inputHash,

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -196,6 +196,7 @@ export async function seedAwaitingEventRun(
 		id: seeded.runId,
 		state: { status: "awaiting_event", eventName: params.eventName },
 		expectedRevision: seeded.revisionWhenClaimed,
+		expectedSignalSequence: 0,
 	});
 
 	return { ...seeded, eventName: params.eventName, revisionWhenParked: parked.revision };

--- a/sdk/workflow/src/run/event.test.ts
+++ b/sdk/workflow/src/run/event.test.ts
@@ -92,6 +92,7 @@ describe("createEventWaiters", () => {
 					id: record.id,
 					state: { status: "awaiting_event", eventName: "orderShipped" },
 					expectedRevision: 0,
+					expectedSignalSequence: 0,
 				},
 				{ revision: 1, state: workflowRunStateByStatus.awaiting_event, attempts: record.attempts }
 			);
@@ -113,6 +114,7 @@ describe("createEventWaiters", () => {
 					id: record.id,
 					state: { status: "awaiting_event", eventName: "orderShipped", timeoutInMs: 30_000 },
 					expectedRevision: 0,
+					expectedSignalSequence: 0,
 				},
 				{ revision: 1, state: workflowRunStateByStatus.awaiting_event, attempts: record.attempts }
 			);
@@ -134,6 +136,7 @@ describe("createEventWaiters", () => {
 					id: record.id,
 					state: { status: "awaiting_event", eventName: "orderShipped" },
 					expectedRevision: 0,
+					expectedSignalSequence: 0,
 				},
 				{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
 			);

--- a/sdk/workflow/src/run/handle-child.test.ts
+++ b/sdk/workflow/src/run/handle-child.test.ts
@@ -87,6 +87,7 @@ describe("childWorkflowRunHandle", () => {
 							childWorkflowRunStatus: "completed",
 						},
 						expectedRevision: 0,
+						expectedSignalSequence: 0,
 					},
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
 				);
@@ -112,6 +113,7 @@ describe("childWorkflowRunHandle", () => {
 							timeoutInMs: 300_000,
 						},
 						expectedRevision: 0,
+						expectedSignalSequence: 0,
 					},
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
 				);
@@ -138,6 +140,7 @@ describe("childWorkflowRunHandle", () => {
 							childWorkflowRunStatus: "completed",
 						},
 						expectedRevision: 0,
+						expectedSignalSequence: 0,
 					},
 					{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
 				);

--- a/sdk/workflow/src/run/handle-child.ts
+++ b/sdk/workflow/src/run/handle-child.ts
@@ -124,6 +124,8 @@ function createStatusWaiter<Input, Output, Context, TEvents extends EventsDefini
 		expectedStatus: Status,
 		options?: ChildWorkflowRunWaitOptions<boolean>
 	): Promise<WorkflowRunWaitResult<Status, Output, boolean, false>> {
+		// TODO: refresh first? like how event waits do it
+
 		const nextIndex = nextIndexByStatus[expectedStatus];
 
 		const { run } = handle;

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -354,6 +354,14 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 					id: this.run.id,
 					state: targetState,
 				});
+			} else if (targetState.status === "awaiting_event" || targetState.status === "awaiting_child_workflow") {
+				response = await this.api.workflowRun.transitionStateV1({
+					type: "optimistic",
+					id: this.run.id,
+					state: targetState,
+					expectedRevision: this.run.revision,
+					expectedSignalSequence: this.run.signalSequence,
+				});
 			} else {
 				response = await this.api.workflowRun.transitionStateV1({
 					type: "optimistic",

--- a/testing/src/data-factory/workflow/run.ts
+++ b/testing/src/data-factory/workflow/run.ts
@@ -53,6 +53,7 @@ const baseWorkflowRunRecord = (sequence: number): Omit<WorkflowRunRecord, "state
 	source: "user",
 	createdAt: 0,
 	revision: 0,
+	signalSequence: 0,
 	stateTransitionId: "transition",
 	inputHash: "hash",
 	attempts: 1,

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -3,6 +3,7 @@ import type { DistributiveOmit, OptionalProp } from "@aikirun/lib/object";
 import type { Hash } from "../infra/hasher";
 import type { WorkflowSource } from "../workflow";
 import type {
+	WaitingForSignalWorkflowRunStatus,
 	WorkflowRunRecord,
 	WorkflowRunState,
 	WorkflowRunStateAwaitingChildWorkflow,
@@ -164,12 +165,6 @@ export type WorkflowRunStateRequest =
 	| WorkflowRunStateAwaitingChildWorkflowRequest
 	| WorkflowRunStateCompletedRequest;
 
-interface WorkflowRunTransitionStateRequestBase {
-	type: "optimistic" | "pessimistic";
-	id: string;
-	state: WorkflowRunStateRequest;
-}
-
 type WorkflowRunStateRequestOptimistic = Exclude<WorkflowRunStateRequest, WorkflowRunStateRequestPessimistic>;
 
 type WorkflowRunStateRequestPessimistic =
@@ -178,14 +173,23 @@ type WorkflowRunStateRequestPessimistic =
 	| WorkflowRunStateStalled
 	| WorkflowRunStateCancelled;
 
-export interface WorkflowRunTransitionStateRequestOptimistic extends WorkflowRunTransitionStateRequestBase {
+export type WorkflowRunTransitionStateRequestOptimistic = {
 	type: "optimistic";
+	id: string;
 	expectedRevision: number;
-	state: WorkflowRunStateRequestOptimistic;
-}
+} & (
+	| {
+			state: Extract<WorkflowRunStateRequestOptimistic, { status: WaitingForSignalWorkflowRunStatus }>;
+			expectedSignalSequence: number;
+	  }
+	| {
+			state: Exclude<WorkflowRunStateRequestOptimistic, { status: WaitingForSignalWorkflowRunStatus }>;
+	  }
+);
 
-export interface WorkflowRunTransitionStateRequestPessimistic extends WorkflowRunTransitionStateRequestBase {
+export interface WorkflowRunTransitionStateRequestPessimistic {
 	type: "pessimistic";
+	id: string;
 	state: WorkflowRunStateRequestPessimistic;
 }
 

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -44,6 +44,12 @@ export function isTerminalWorkflowRunStatus(status: WorkflowRunStatus): status i
 	return false;
 }
 
+/**
+ * The statuses a run can rest at while waiting for something external it to arrive, so a write into
+ * one is guarded on the signal sequence.
+ */
+export type WaitingForSignalWorkflowRunStatus = "awaiting_event" | "awaiting_child_workflow";
+
 export const WORKFLOW_RUN_CONFLICT_POLICIES = ["error", "return_existing"] as const;
 export type WorkflowRunConflictPolicy = (typeof WORKFLOW_RUN_CONFLICT_POLICIES)[number];
 
@@ -263,6 +269,7 @@ export interface WorkflowRunRecord<Input = unknown, Output = unknown> {
 	source: WorkflowSource;
 	createdAt: number;
 	revision: number;
+	signalSequence: number;
 	stateTransitionId: string;
 	input?: Input;
 	inputHash: string;


### PR DESCRIPTION
## Problem

When a workflow calls `wait()` on an event, the worker checks the run record it fetched on its last refresh for an unconsumed `event_wait` row. If there is none, it parks the run: a second round trip transitions it to `awaiting_event`, and execution stops until something wakes it. The sender — anyone calling the send-event endpoint — writes an `event_wait` row and wakes the run only if it is already parked on that event name.

An event that lands between the worker's check and its park is seen by neither side. The sender reads a `running` run and does not wake it. The parker's transition is guarded on `revision`, the run's optimistic-concurrency token, but the sender writes only to `event_wait` — the two transactions share no written row, so every interleaving commits:

```
sender                              worker
------                              ------
                                    refresh → no `approved` row yet
send(approved)
  read run → status is `running`
  insert event_wait row
  not parked → no wake
  COMMIT
                                    park: UPDATE workflow_run
                                          SET status = 'awaiting_event'
                                          WHERE revision = R   → matches
                                    COMMIT
```

The run is now parked on an event that already arrived. Without a timeout it stays parked forever. With one, the timeout daemon writes an `event_wait` row with status `timeout` — and because replay hands rows out by position, that stray row is consumed by the *next* `wait()` on that name, which times out for no reason.

## Solution

`workflow_run` gains `signal_sequence`, an integer that increments every time a signal is delivered to the run. Its job is to give the sender and the parker a row they both write, so Postgres orders them.

**The sender bumps before it reads.** Its first statement is `UPDATE workflow_run SET signal_sequence = signal_sequence + 1 … RETURNING status`, which takes the row lock, increments, and returns values from the row version after the lock — never a stale snapshot. The event insert and the wake happen under that lock. A send to a `completed`, `cancelled`, or `failed` run is rejected with a conflict error; the rollback takes the bump with it.

**The park is one guarded write.** The park request carries `expectedSignalSequence` — the value from the worker's last refresh — next to `expectedRevision`. A single UPDATE picks the outcome with a CASE on the sequence:

| result | meaning | outcome |
|---|---|---|
| no row | revision moved — another worker owns the run | revision conflict | | row, sequence unchanged | nothing arrived in the window | parked | | row, sequence moved | a signal landed in the window | `scheduled`, reason `event` |

The transition row is appended after this write, because until the write returns the server does not know which state to record.

**A late signal reschedules the run instead of failing the request.** The rescheduled run is queued, redelivered, and its replay finds the event row waiting. Rejecting the park would be worse: the worker treats a rejected transition as a normal suspension and transitions nothing, so the run would sit in `running` holding its outbox claim until the recovery scan releases it.

Why the guard holds in both orders:

```
sender first                          parker first
------------                          ------------
sender: bump, seq S → S+1             parker: guarded UPDATE, parks
sender: COMMIT                        sender: bump blocks on the row lock
parker: guarded UPDATE                parker: COMMIT
parker: sees S+1, expected S          sender: unblocks, reads `awaiting_event`
parker: run is scheduled instead      sender: wakes the run
```

**One sequence, every signal kind.** `awaiting_child_workflow` parks carry the same guard and reschedule with reason `child_workflow`. The sequence does not distinguish which event arrived, so an unrelated signal can reschedule a park that did not need it — the replay finds nothing new and parks again with a current value. These cases need the signal to land inside one round trip on that one run; the implementation carries a TODO to count them before anyone builds an exact recheck. The producer side for child runs — a child reaching a terminal state bumping its parent's sequence — is planned as a separate PR.

## Breaking changes

- `workflow_run` gains a `signal_sequence` column (`NOT NULL DEFAULT 0`, migration 0023).
- `transitionStateV1` requires `expectedSignalSequence` on `awaiting_event` and `awaiting_child_workflow` transitions. Park requests from workers on older SDK versions are rejected by input validation.
- Sending an event to a run in a terminal state returns a conflict error instead of writing an `event_wait` row nothing would ever read.