### PR TITLE
Terminal child runs signal their parents

### DIFF
--- a/app/dashboard/src/components/run-detail/ExecutionTab.tsx
+++ b/app/dashboard/src/components/run-detail/ExecutionTab.tsx
@@ -1,6 +1,6 @@
 import type {
 	ChildWorkflowRunInfo,
-	ChildWorkflowRunWaitCompleted,
+	ChildWorkflowRunWaits,
 	EventWait,
 	Sleep,
 	TerminalWorkflowRunStatus,
@@ -312,13 +312,11 @@ function TaskText({ text, color }: { text: string; color: string }) {
 
 function resolveChildStatus(child: ChildWorkflowRunInfo): {
 	status: TerminalWorkflowRunStatus | "running";
-	resolvedWait: ChildWorkflowRunWaitCompleted | null;
+	resolvedWait: TerminalChildWait | null;
 } {
-	for (const terminalStatus of ["completed", "failed", "cancelled"] as const) {
-		const wait = child.waits[terminalStatus][0];
-		if (wait?.status === "completed") {
-			return { status: terminalStatus, resolvedWait: wait };
-		}
+	const terminal = child.waits.terminal;
+	if (terminal) {
+		return { status: terminal.state.status, resolvedWait: terminal };
 	}
 	return { status: "running", resolvedWait: null };
 }
@@ -475,8 +473,10 @@ function ChildWorkflowCard({ child, isAwaited }: { child: ChildWorkflowRunInfo; 
 	);
 }
 
-function ChildWorkflowResolvedPre({ wait }: { wait: ChildWorkflowRunWaitCompleted }) {
-	const childState = wait.childWorkflowRunState;
+type TerminalChildWait = NonNullable<ChildWorkflowRunWaits["terminal"]>;
+
+function ChildWorkflowResolvedPre({ wait }: { wait: TerminalChildWait }) {
+	const childState = wait.state;
 
 	if (childState.status === "completed" && childState.output !== undefined) {
 		return (

--- a/app/dashboard/src/components/run-detail/timeline-lookups.ts
+++ b/app/dashboard/src/components/run-detail/timeline-lookups.ts
@@ -121,34 +121,15 @@ export function buildTimelineLookups(
 					const prev = transitions[j];
 					if (prev.type === "workflow_run" && prev.state.status === "awaiting_child_workflow") {
 						const childId = prev.state.childWorkflowRunId;
-						const waitForStatus = prev.state.childWorkflowRunStatus;
 						context.scheduledByChildWorkflowRunId = childId;
 						if (reason === "child_workflow_wait_timeout") {
 							context.childWorkflowTimedOut = true;
 							break;
 						}
-						// The wait row carries the child's terminal status; it also classifies rows written
-						// before the reason split, whose timed-out waits are labelled "child_workflow".
-						const childInfo = childWorkflowById.get(childId);
-						const waits = childInfo?.waits[waitForStatus];
-						if (waits && waits.length > 0) {
-							let waitIndex = 0;
-							for (let k = 0; k < j; k++) {
-								const t2 = transitions[k];
-								if (
-									t2.type === "workflow_run" &&
-									t2.state.status === "awaiting_child_workflow" &&
-									t2.state.childWorkflowRunId === childId
-								) {
-									waitIndex++;
-								}
-							}
-							const result = waits[waitIndex];
-							if (result?.status === "completed") {
-								context.childWorkflowStatus = result.childWorkflowRunState.status;
-							} else if (result?.status === "timeout") {
-								context.childWorkflowTimedOut = true;
-							}
+						// A wake means the child reached a terminal state; the terminal wait carries it.
+						const terminal = childWorkflowById.get(childId)?.waits.terminal;
+						if (terminal) {
+							context.childWorkflowStatus = terminal.state.status;
 						}
 						break;
 					}

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -300,20 +300,22 @@ const parentWorkflowV1 = parentWorkflow.v("1.0.0", {
 
 ### Waiting for Child Completion
 
-To wait for a child workflow to complete, call `waitForStatus()` on the child handle:
+To wait for a child workflow to finish, call `wait()` on the child handle. The wait
+resolves when the child reaches any terminal status (`completed`, `failed`, or
+`cancelled`), and the result carries the state the child ended in:
 
 ```typescript
 const parentWorkflowV1 = parentWorkflow.v("1.0.0", {
 	async handler(run, input) {
 		const childHandle = await childWorkflowV1.startAsChild(run, { userId: input.userId });
 
-		// Parent suspends until child completes
-		const result = await childHandle.waitForStatus("completed");
+		// Parent suspends until the child finishes
+		const { state } = await childHandle.wait();
 
-		if (result.success) {
-			return { childOutput: result.state.output };
+		if (state.status === "completed") {
+			return { childOutput: state.output };
 		} else {
-			throw new Error(`Child failed: ${result.cause}`);
+			throw new Error(`Child ended ${state.status}`);
 		}
 	},
 });
@@ -322,12 +324,12 @@ const parentWorkflowV1 = parentWorkflow.v("1.0.0", {
 You can also wait with a timeout:
 
 ```typescript
-const result = await childHandle.waitForStatus("completed", {
+const result = await childHandle.wait({
 	timeout: { hours: 1 },
 });
 
-if (result.timeout) {
-	// Child didn't complete within 1 hour
+if (!result.success) {
+	// Child didn't finish within 1 hour
 }
 ```
 
@@ -347,11 +349,11 @@ const parentWorkflowV1 = parentWorkflow.v("1.0.0", {
 			sendNotificationV1.startAsChild(run, { userId: input.userId }),
 		]);
 
-		// Wait for all to complete
+		// Wait for all to finish
 		const [userResult, orderResult, notifyResult] = await Promise.all([
-			userHandle.waitForStatus("completed"),
-			orderHandle.waitForStatus("completed"),
-			notifyHandle.waitForStatus("completed"),
+			userHandle.wait(),
+			orderHandle.wait(),
+			notifyHandle.wait(),
 		]);
 
 		return {

--- a/app/website/content/docs/guides/reliable-hooks.md
+++ b/app/website/content/docs/guides/reliable-hooks.md
@@ -11,12 +11,12 @@ const orderWithHooks = workflow({ name: "order-with-hooks" });
 
 const orderWithHooksV1 = orderWithHooks.v("1.0.0", {
 	async handler(run, input: { orderId: string }) {
-		// Run main workflow and wait for completion
+		// Run main workflow and wait for it to finish
 		const handle = await orderWorkflowV1.startAsChild(run, input);
-		const result = await handle.waitForStatus("completed");
+		const { state } = await handle.wait();
 
-		if (!result.success) {
-			throw new Error(`Order workflow failed: ${result.cause}`);
+		if (state.status !== "completed") {
+			throw new Error(`Order workflow ended ${state.status}`);
 		}
 
 		// Run hook
@@ -24,7 +24,7 @@ const orderWithHooksV1 = orderWithHooks.v("1.0.0", {
 			orderId: input.orderId,
 		});
 
-		return result.state.output;
+		return state.output;
 	},
 });
 ```

--- a/examples/src/workflows/cancellation-cascade.ts
+++ b/examples/src/workflows/cancellation-cascade.ts
@@ -19,7 +19,7 @@ export const childWorkflowV1 = workflow({ name: "cascade-child" }).v("1.0.0", {
 export const parentWorkflowV1 = workflow({ name: "cascade-parent" }).v("1.0.0", {
 	async handler(run) {
 		const child = await childWorkflowV1.startAsChild(run);
-		await child.waitForStatus("completed");
+		await child.wait();
 		return { level: "parent" };
 	},
 });
@@ -27,7 +27,7 @@ export const parentWorkflowV1 = workflow({ name: "cascade-parent" }).v("1.0.0", 
 export const grandparentWorkflowV1 = workflow({ name: "cascade-grandparent" }).v("1.0.0", {
 	async handler(run) {
 		const parent = await parentWorkflowV1.startAsChild(run);
-		await parent.waitForStatus("completed");
+		await parent.wait();
 		return { level: "grandparent" };
 	},
 });

--- a/examples/src/workflows/fan-out-gather.ts
+++ b/examples/src/workflows/fan-out-gather.ts
@@ -23,8 +23,14 @@ export const childV1 = workflow({ name: "fan-out-child" }).v("1.0.0", {
 export const fanOutGatherV1 = workflow({ name: "fan-out-gather" }).v("1.0.0", {
 	async handler(run, input: { items: string[] }) {
 		const handles = await Promise.all(input.items.map((item) => childV1.startAsChild(run, { item })));
-		const results = await Promise.all(handles.map((h) => h.waitForStatus("completed")));
+		const results = await Promise.all(handles.map((h) => h.wait()));
 
-		return results.filter((r) => r.success).map((r) => r.state.output);
+		return results.flatMap(({ state }) => {
+			if (state.status !== "completed") {
+				run.logger.warn(`Child ended ${state.status}`);
+				return [];
+			}
+			return [state.output];
+		});
 	},
 });

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -91,7 +91,6 @@ export const workflowRunStateAwaitingRetrySchema = type({
 export const workflowRunStateAwaitingChildWorkflowSchema = type({
 	status: "'awaiting_child_workflow'",
 	childWorkflowRunId: "string > 0",
-	childWorkflowRunStatus: terminalWorkflowRunStatusSchema,
 	"timeoutAt?": "number > 0 | undefined",
 });
 
@@ -142,21 +141,20 @@ export const terminalWorkflowRunStateSchema = workflowRunStateCancelledSchema
 	.or(workflowRunStateCompletedSchema)
 	.or(workflowRunStateFailedSchema);
 
-const childWorkflowRunWaitSchema = type({
-	status: "'completed'",
-	completedAt: "number > 0",
-	childWorkflowRunState: terminalWorkflowRunStateSchema,
-}).or({
-	status: "'timeout'",
-	timedOutAt: "number > 0",
-});
-
 const childWorkflowRunInfoSchema = type({
 	id: "string > 0",
 	name: "string > 0",
 	versionId: "string > 0",
 	inputHash: "string > 0",
-	waits: type({ "['cancelled'|'completed'|'failed']": childWorkflowRunWaitSchema.array() }),
+	waits: type({
+		timeouts: type({
+			timedOutAt: "number > 0",
+		}).array(),
+		"terminal?": type({
+			state: terminalWorkflowRunStateSchema,
+			completedAt: "number > 0",
+		}).or("undefined"),
+	}),
 });
 
 export const workflowRunRecordSchema = type({

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -124,7 +124,6 @@ async function processChunk(
 			id: ulid(),
 			parentWorkflowRunId: run.id,
 			childWorkflowRunId: fromState.childWorkflowRunId,
-			childWorkflowRunStatus: fromState.childWorkflowRunStatus,
 			status: "timeout",
 			timedOutAt,
 		});

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -1,6 +1,6 @@
 import { streamChunks } from "@aikirun/lib/async";
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import { isNonEmptyArray, partitionArray } from "@aikirun/lib/collection/array";
+import { asNonEmptyArray, isNonEmptyArray, partitionArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
@@ -24,6 +24,7 @@ import { createKeysetStreamCursorAdvancer } from "../lib/keyset-stream";
 import { computeRank } from "../lib/rank";
 import type { DaemonContext } from "../middleware/context";
 import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
+import { deliverTerminatedSignalToParentRun, type TerminatedChildRun } from "../service/deliver-terminated-signals";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
 import { getDueOccurrences, getNextOccurrence, getReferenceId, scheduleRowToDomain } from "../service/schedule";
 
@@ -443,7 +444,7 @@ async function processOverlapCancelPreviousSchedules(
 		cancelPreviousAndInsertRunsInTx(
 			context,
 			deps.childRunCanceller,
-			now,
+			now as TimestampMs,
 			{
 				runIdsToCancel,
 				runsToCancel,
@@ -464,7 +465,7 @@ async function processOverlapCancelPreviousSchedules(
 async function cancelPreviousAndInsertRunsInTx(
 	context: DaemonContext,
 	childRunCanceller: ChildRunCanceller,
-	now: number,
+	now: TimestampMs,
 	entries: {
 		runIdsToCancel: string[];
 		runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string }>;
@@ -490,27 +491,30 @@ async function cancelPreviousAndInsertRunsInTx(
 	const cancelledRuns = isNonEmptyArray(runIdsToCancel)
 		? await txRepos.workflowRun.bulkTransitionToCancelled(context, runIdsToCancel)
 		: [];
-	const cancelledRunIds = cancelledRuns.map((run) => run.id);
+	const cancelledRunsById = new Map(cancelledRuns.map((run) => [run.id, run]));
 
 	// Step 2: Discard in-flight tasks and outbox entries for the cancelled runs, then insert
 	// cancel state transitions only for actually cancelled runs and set latestStateTransitionId
-	if (isNonEmptyArray(cancelledRunIds)) {
+	if (cancelledRunsById.size) {
+		const cancelledRunIds = asNonEmptyArray(Array.from(cancelledRunsById.keys()));
 		await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
-		await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now as TimestampMs);
+		await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now);
 		await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
-		const cancelledRunIdsSet = new Set(cancelledRunIds);
 		const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
 		const cancelledRunStateTransitionIdUpdates: {
 			filter: { namespaceId: NamespaceId; id: string };
 			update: { stateTransitionId: string };
 		}[] = [];
-		const cancelledRuns: CancelledRunMeta[] = [];
+		const cancelledRunsMeta: CancelledRunMeta[] = [];
+		const cancelledRunsHavingParent: TerminatedChildRun[] = [];
 
 		for (const run of runsToCancel) {
-			if (!cancelledRunIdsSet.has(run.id)) {
+			const cancelledRun = cancelledRunsById.get(run.id);
+			if (!cancelledRun) {
 				continue;
 			}
+
 			const stateTransitionId = ulid();
 			cancelStateTransitionEntries.push({
 				id: stateTransitionId,
@@ -524,15 +528,28 @@ async function cancelPreviousAndInsertRunsInTx(
 				filter: { namespaceId: run.namespaceId, id: run.id },
 				update: { stateTransitionId },
 			});
-			cancelledRuns.push({ namespaceId: run.namespaceId, id: run.id, pool: run.pool });
+			cancelledRunsMeta.push({ namespaceId: run.namespaceId, id: run.id, pool: run.pool });
+
+			if (cancelledRun.parentWorkflowRunId !== null) {
+				cancelledRunsHavingParent.push({
+					namespaceId: run.namespaceId,
+					id: run.id,
+					latestStateTransitionId: stateTransitionId,
+					parentWorkflowRunId: cancelledRun.parentWorkflowRunId,
+					status: "cancelled",
+				});
+			}
 		}
 
 		if (isNonEmptyArray(cancelStateTransitionEntries) && isNonEmptyArray(cancelledRunStateTransitionIdUpdates)) {
 			await txRepos.stateTransition.appendBatch(cancelStateTransitionEntries);
 			await txRepos.workflowRun.bulkSetLatestStateTransitionId(cancelledRunStateTransitionIdUpdates);
 		}
-		if (isNonEmptyArray(cancelledRuns)) {
-			await childRunCanceller.cancel(cancelledRuns, txRepos, context.logger);
+		if (isNonEmptyArray(cancelledRunsHavingParent)) {
+			await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, context.logger);
+		}
+		if (isNonEmptyArray(cancelledRunsMeta)) {
+			await childRunCanceller.cancel(cancelledRunsMeta, txRepos, context.logger);
 		}
 	}
 

--- a/sdk/server/src/infra/db/constants/child-workflow-run-wait.ts
+++ b/sdk/server/src/infra/db/constants/child-workflow-run-wait.ts
@@ -1,0 +1,2 @@
+export const CHILD_WORKFLOW_RUN_WAIT_STATUSES = ["completed", "timeout"] as const;
+export type ChildWorkflowRunWaitStatus = (typeof CHILD_WORKFLOW_RUN_WAIT_STATUSES)[number];

--- a/sdk/server/src/infra/db/pg/migration/0025_small_tiger_shark.sql
+++ b/sdk/server/src/infra/db/pg/migration/0025_small_tiger_shark.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "child_workflow_run_wait" ALTER COLUMN "child_workflow_run_status" DROP NOT NULL;--> statement-breakpoint
+DELETE FROM "child_workflow_run_wait" WHERE "status" = 'completed';--> statement-breakpoint
+INSERT INTO "child_workflow_run_wait" ("id", "parent_workflow_run_id", "child_workflow_run_id", "child_workflow_run_status", "status", "completed_at", "child_workflow_run_state_transition_id")
+SELECT
+	wr."id",
+	wr."parent_workflow_run_id",
+	wr."id",
+	wr."status"::text::"terminal_workflow_run_status",
+	'completed',
+	st."created_at",
+	wr."latest_state_transition_id"
+FROM "workflow_run" wr
+JOIN "state_transition" st ON st."id" = wr."latest_state_transition_id"
+WHERE wr."status" IN ('completed', 'cancelled', 'failed') AND wr."parent_workflow_run_id" IS NOT NULL;

--- a/sdk/server/src/infra/db/pg/migration/0026_blue_stone_men.sql
+++ b/sdk/server/src/infra/db/pg/migration/0026_blue_stone_men.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "child_workflow_run_wait" DROP CONSTRAINT "chk_child_workflow_run_wait_timeout_requires_timed_out_at";--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" DROP CONSTRAINT "chk_child_workflow_run_wait_completed_invariants";--> statement-breakpoint
+UPDATE "child_workflow_run_wait" SET "child_workflow_run_status" = NULL WHERE "status" = 'timeout';--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" ADD CONSTRAINT "chk_child_workflow_run_wait_timeout_invariants" CHECK ("child_workflow_run_wait"."status" != 'timeout' OR ("child_workflow_run_wait"."timed_out_at" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_status" IS NULL AND "child_workflow_run_wait"."child_workflow_run_state_transition_id" IS NULL));--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" ADD CONSTRAINT "chk_child_workflow_run_wait_completed_invariants" CHECK ("child_workflow_run_wait"."status" != 'completed' OR ("child_workflow_run_wait"."completed_at" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_state_transition_id" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_status" IS NOT NULL));

--- a/sdk/server/src/infra/db/pg/migration/meta/0025_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0025_snapshot.json
@@ -1,0 +1,1775 @@
+{
+	"id": "128d92cf-a5b4-4925-b621-f3e7c496ee02",
+	"prevId": "747c7395-3e7a-4639-93a8-26a006021410",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_requires_timed_out_at": {
+					"name": "chk_child_workflow_run_wait_timeout_requires_timed_out_at",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR \"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_id": {
+					"name": "idx_event_wait_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/0026_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0026_snapshot.json
@@ -1,0 +1,1775 @@
+{
+	"id": "78c8cdd0-7c1e-46c0-b761-76d40afffbf9",
+	"prevId": "128d92cf-a5b4-4925-b621-f3e7c496ee02",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_id": {
+					"name": "idx_event_wait_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -169,6 +169,20 @@
 			"when": 1787395980116,
 			"tag": "0023_dashing_phil_sheldon",
 			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1787565412838,
+			"tag": "0025_small_tiger_shark",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1787581975349,
+			"tag": "0026_blue_stone_men",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/child-workflow-run-wait.ts
+++ b/sdk/server/src/infra/db/pg/repository/child-workflow-run-wait.ts
@@ -1,3 +1,4 @@
+import type { WorkflowRunState } from "@aikirun/types/workflow";
 import { eq, getTableColumns } from "drizzle-orm";
 
 import { toWorkflowRunState } from "./state-transition";
@@ -7,13 +8,17 @@ import { childWorkflowRunWait, stateTransition } from "../schema";
 export type ChildWorkflowRunWaitRow = typeof childWorkflowRunWait.$inferSelect;
 export type ChildWorkflowRunWaitRowInsert = typeof childWorkflowRunWait.$inferInsert;
 
+export type ChildRunWaitWithState = ChildWorkflowRunWaitRow & {
+	childWorkflowRunState: WorkflowRunState | null;
+};
+
 export const createChildWorkflowRunWaitRepository = (db: PgDb) => ({
 	async insert(input: ChildWorkflowRunWaitRowInsert | ChildWorkflowRunWaitRowInsert[]): Promise<void> {
 		const values = Array.isArray(input) ? input : [input];
 		await db.insert(childWorkflowRunWait).values(values);
 	},
 
-	async listByParentRunIdWithChildState(parentRunId: string) {
+	async listByParentRunIdWithChildState(parentRunId: string): Promise<ChildRunWaitWithState[]> {
 		// TODO: explore loading in chunks
 		const rows = await db
 			.select({

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -15,6 +15,7 @@ import { and, count, eq, inArray, lte, or, sql } from "drizzle-orm";
 
 import { keysetStreamCursorFilter } from "./lib/keyset-stream";
 import { toWorkflowRunState } from "./state-transition";
+import type { WorkflowRow } from "./workflow";
 import type { KeysetStreamCursor } from "../../../../lib/keyset-stream";
 import type { DaemonContext } from "../../../../middleware/context";
 import type { PgDb } from "../provider";
@@ -47,9 +48,41 @@ export type UpdateWorkflowRunParams =
 export type WorkflowRunWithState = {
 	run: Pick<
 		WorkflowRunRow,
-		"id" | "status" | "revision" | "attempts" | "latestStateTransitionId" | "parentWorkflowRunId" | "options"
+		| "id"
+		| "status"
+		| "revision"
+		| "signalSequence"
+		| "attempts"
+		| "latestStateTransitionId"
+		| "options"
+		| "parentWorkflowRunId"
 	>;
 	state: WorkflowRunState;
+};
+
+export type WorkflowRunWithWorkflowAndState = {
+	run: Pick<
+		WorkflowRunRow,
+		| "id"
+		| "createdAt"
+		| "revision"
+		| "signalSequence"
+		| "attempts"
+		| "latestStateTransitionId"
+		| "input"
+		| "inputHash"
+		| "referenceId"
+		| "options"
+		| "parentWorkflowRunId"
+		| "scheduleId"
+	>;
+	workflow: Pick<WorkflowRow, "name" | "versionId" | "source">;
+	state: WorkflowRunState;
+};
+
+export type ChildRunWithWorkflow = {
+	run: Pick<WorkflowRunRow, "id" | "inputHash" | "referenceId">;
+	workflow: Pick<WorkflowRow, "name" | "versionId">;
 };
 
 export interface WorkflowRunMeta {
@@ -124,10 +157,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return result[0] ?? null;
 	},
 
-	async incrementSignalSequence(filter: {
-		namespaceId: NamespaceId;
-		id: WorkflowRunId;
-	}): Promise<{ run: Pick<WorkflowRunRow, "status" | "revision" | "signalSequence">; state: WorkflowRunState } | null> {
+	async incrementSignalSequence(filter: { namespaceId: NamespaceId; id: WorkflowRunId }) {
 		const result = await db
 			.update(workflowRun)
 			.set({ signalSequence: sql`${workflowRun.signalSequence} + 1` })
@@ -153,6 +183,32 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			return null;
 		}
 		return { run: row.run, state: toWorkflowRunState(row.state) };
+	},
+
+	async bulkIncrementSignalSequence(runs: NonEmptyArray<{ namespaceId: NamespaceId; id: WorkflowRunId }>) {
+		// Locked in id order so concurrent bulk deliveries acquire the same rows the same way.
+		const sortedRuns = [...runs].sort((a, b) => (a.id < b.id ? -1 : 1));
+		const valueRows = sortedRuns.map(({ namespaceId, id }, index) => {
+			if (index === 0) {
+				return sql`(${namespaceId}::text, ${id}::text)`;
+			}
+			return sql`(${namespaceId}, ${id})`;
+		});
+
+		return db
+			.update(workflowRun)
+			.set({ signalSequence: sql`${workflowRun.signalSequence} + 1` })
+			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(namespace_id, id)`)
+			.where(and(sql`${workflowRun.namespaceId} = v.namespace_id`, sql`${workflowRun.id} = v.id`))
+			.returning({
+				id: workflowRun.id,
+				namespaceId: workflowRun.namespaceId,
+				status: workflowRun.status,
+				revision: workflowRun.revision,
+				signalSequence: workflowRun.signalSequence,
+				attempts: workflowRun.attempts,
+				latestStateTransitionId: workflowRun.latestStateTransitionId,
+			});
 	},
 
 	async exists(namespaceId: NamespaceId, id: string): Promise<boolean> {
@@ -185,10 +241,11 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 					id: workflowRun.id,
 					status: workflowRun.status,
 					revision: workflowRun.revision,
+					signalSequence: workflowRun.signalSequence,
 					attempts: workflowRun.attempts,
 					latestStateTransitionId: workflowRun.latestStateTransitionId,
-					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
 					options: workflowRun.options,
+					parentWorkflowRunId: workflowRun.parentWorkflowRunId,
 				},
 				state: stateTransition.state,
 			})
@@ -205,7 +262,10 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		return { run: row.run, state: toWorkflowRunState(row.state) };
 	},
 
-	async getByIdWithWorkflowAndState(filter: { namespaceId: NamespaceId; id: string }) {
+	async getByIdWithWorkflowAndState(filter: {
+		namespaceId: NamespaceId;
+		id: string;
+	}): Promise<WorkflowRunWithWorkflowAndState | null> {
 		const result = await db
 			.select({
 				run: {
@@ -321,7 +381,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.limit(10_000);
 	},
 
-	async getChildRunsWithWorkflow(filter: { namespaceId: NamespaceId; id: string }) {
+	async getChildRunsWithWorkflow(filter: { namespaceId: NamespaceId; id: string }): Promise<ChildRunWithWorkflow[]> {
 		// TODO: explore loading in chunks
 		return db
 			.select({
@@ -630,6 +690,46 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 			.limit(limit);
 	},
 
+	async bulkTransitionToScheduled(
+		fromStatus: WaitingForSignalWorkflowRunStatus,
+		scheduledAt: TimestampMs,
+		runs: NonEmptyArray<{
+			filter: { namespaceId: NamespaceId; id: string; revision: number };
+			update: { stateTransitionId: string };
+		}>
+	): Promise<string[]> {
+		const valueRows = runs.map(({ filter, update }, index) => {
+			if (index === 0) {
+				return sql`(${filter.namespaceId}::text, ${filter.id}::text, ${filter.revision}::integer, ${update.stateTransitionId}::text)`;
+			}
+			return sql`(${filter.namespaceId}, ${filter.id}, ${filter.revision}, ${update.stateTransitionId})`;
+		});
+
+		const result = await db
+			.update(workflowRun)
+			.set({
+				status: "scheduled",
+				revision: sql`${workflowRun.revision} + 1`,
+				scheduledAt,
+				wakeupAt: null,
+				timeoutAt: null,
+				nextAttemptAt: null,
+				latestStateTransitionId: sql`v.state_transition_id`,
+			})
+			.from(sql`(VALUES ${sql.join(valueRows, sql`, `)}) AS v(namespace_id, id, revision, state_transition_id)`)
+			.where(
+				and(
+					eq(workflowRun.status, fromStatus),
+					sql`${workflowRun.namespaceId} = v.namespace_id`,
+					sql`${workflowRun.id} = v.id`,
+					sql`${workflowRun.revision} = v.revision`
+				)
+			)
+			.returning({ id: workflowRun.id });
+
+		return result.map((row) => row.id);
+	},
+
 	async bulkTransitionToQueued(
 		_context: DaemonContext,
 		fromStatus: "scheduled" | "sleeping" | "awaiting_retry" | "awaiting_event" | "awaiting_child_workflow" | "running",
@@ -686,7 +786,12 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 					inArray(workflowRun.status, NON_TERMINAL_WORKFLOW_RUN_STATUSES)
 				)
 			)
-			.returning({ id: workflowRun.id, attempts: workflowRun.attempts, options: workflowRun.options });
+			.returning({
+				id: workflowRun.id,
+				attempts: workflowRun.attempts,
+				options: workflowRun.options,
+				parentWorkflowRunId: workflowRun.parentWorkflowRunId,
+			});
 
 		return result;
 	},
@@ -708,6 +813,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				namespaceId: workflowRun.namespaceId,
 				attempts: workflowRun.attempts,
 				options: workflowRun.options,
+				parentWorkflowRunId: workflowRun.parentWorkflowRunId,
 			});
 
 		return result;

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -1,7 +1,6 @@
 import { SCHEDULE_OVERLAP_POLICIES, SCHEDULE_STATUSES, SCHEDULE_TYPES } from "@aikirun/types/schedule";
 import { WORKFLOW_SOURCES } from "@aikirun/types/workflow";
 import {
-	CHILD_WORKFLOW_RUN_WAIT_STATUSES,
 	EVENT_WAIT_STATUSES,
 	SLEEP_STATUSES,
 	TERMINAL_WORKFLOW_RUN_STATUSES,
@@ -25,6 +24,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { timestampMs } from "./timestamp";
+import { CHILD_WORKFLOW_RUN_WAIT_STATUSES } from "../constants/child-workflow-run-wait";
 import { WORKFLOW_RUN_OUTBOX_STATUSES } from "../constants/workflow-run-outbox";
 
 export const workflowSourceEnum = pgEnum("workflow_source", WORKFLOW_SOURCES);
@@ -321,7 +321,7 @@ export const childWorkflowRunWait = pgTable(
 		id: text("id").primaryKey(),
 		parentWorkflowRunId: text("parent_workflow_run_id").notNull(),
 		childWorkflowRunId: text("child_workflow_run_id").notNull(),
-		childWorkflowRunStatus: terminalWorkflowRunStatusEnum("child_workflow_run_status").notNull(),
+		childWorkflowRunStatus: terminalWorkflowRunStatusEnum("child_workflow_run_status"),
 
 		status: childWorkflowRunWaitStatusEnum("status").notNull(),
 		completedAt: timestampMs("completed_at"),
@@ -350,11 +350,11 @@ export const childWorkflowRunWait = pgTable(
 		index("idx_child_workflow_run_wait_parent_id").on(table.parentWorkflowRunId, table.id),
 		check(
 			"chk_child_workflow_run_wait_completed_invariants",
-			sql`${table.status} != 'completed' OR (${table.completedAt} IS NOT NULL AND ${table.childWorkflowRunStateTransitionId} IS NOT NULL)`
+			sql`${table.status} != 'completed' OR (${table.completedAt} IS NOT NULL AND ${table.childWorkflowRunStateTransitionId} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NOT NULL)`
 		),
 		check(
-			"chk_child_workflow_run_wait_timeout_requires_timed_out_at",
-			sql`${table.status} != 'timeout' OR ${table.timedOutAt} IS NOT NULL`
+			"chk_child_workflow_run_wait_timeout_invariants",
+			sql`${table.status} != 'timeout' OR (${table.timedOutAt} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NULL AND ${table.childWorkflowRunStateTransitionId} IS NULL)`
 		),
 	]
 );

--- a/sdk/server/src/infra/db/types/child-workflow-run-wait.ts
+++ b/sdk/server/src/infra/db/types/child-workflow-run-wait.ts
@@ -1,4 +1,5 @@
 export type {
+	ChildRunWaitWithState,
 	ChildWorkflowRunWaitRepository,
 	ChildWorkflowRunWaitRow,
 	ChildWorkflowRunWaitRowInsert,

--- a/sdk/server/src/infra/db/types/workflow-run.ts
+++ b/sdk/server/src/infra/db/types/workflow-run.ts
@@ -1,8 +1,11 @@
 export type {
+	ChildRunWithWorkflow,
 	DueWorkflowRun,
 	UpdateWorkflowRunParams,
 	WorkflowRunMeta,
 	WorkflowRunRepository,
 	WorkflowRunRow,
 	WorkflowRunRowInsert,
+	WorkflowRunWithState,
+	WorkflowRunWithWorkflowAndState,
 } from "../pg/repository/workflow-run";

--- a/sdk/server/src/infra/db/workflow-run.integration.test.ts
+++ b/sdk/server/src/infra/db/workflow-run.integration.test.ts
@@ -23,7 +23,7 @@ describe("workflow run repository state reads", () => {
 				{ output: undefined }
 			);
 
-			const row = await repos.workflowRun.getByIdWithWorkflowAndState({ namespaceId: context.namespaceId, id: runId });
+			const row = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
 
 			expect(row?.state).toContainKey("output");
 			expect(row?.state).toEqual({ status: "completed", output: undefined });

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -1,0 +1,134 @@
+import { asNonEmptyArray, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import type { Logger } from "@aikirun/lib/logger";
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type {
+	TerminalWorkflowRunStatus,
+	WorkflowRunId,
+	WorkflowRunState,
+	WorkflowRunStateScheduledByChildWorkflow,
+} from "@aikirun/types/workflow/run";
+import { ulid } from "ulidx";
+
+import type { TxRepositories } from "../infra/db/types";
+import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+
+export interface TerminatedChildRun {
+	namespaceId: NamespaceId;
+	id: string;
+	latestStateTransitionId: string;
+	parentWorkflowRunId: string;
+	status: TerminalWorkflowRunStatus;
+}
+
+/**
+ * Delivers the terminal signal of each child run to its parent, in one batch: writes the
+ * terminal wait rows, bumps each parent's signal sequence once, and wakes the parents that
+ * are parked on one of the children. Every path that takes a run with a parent to a
+ * terminal state must pass through here — a path that skips it opens a path to a lost-wakeup race.
+ */
+export async function deliverTerminatedSignalToParentRun(
+	runs: NonEmptyArray<TerminatedChildRun>,
+	now: TimestampMs,
+	txRepos: TxRepositories,
+	logger: Logger
+): Promise<void> {
+	await txRepos.childWorkflowRunWait.insert(
+		runs.map((run) => ({
+			id: ulid(),
+			parentWorkflowRunId: run.parentWorkflowRunId,
+			childWorkflowRunId: run.id,
+			childWorkflowRunStatus: run.status,
+			status: "completed",
+			completedAt: now,
+			childWorkflowRunStateTransitionId: run.latestStateTransitionId,
+		}))
+	);
+
+	const parentsRunsById = new Map<WorkflowRunId, { namespaceId: NamespaceId; id: WorkflowRunId }>();
+	for (const run of runs) {
+		const parentRunId = run.parentWorkflowRunId as WorkflowRunId;
+		parentsRunsById.set(parentRunId, { namespaceId: run.namespaceId, id: parentRunId });
+	}
+	// One sequence bump per unique parent, even if it has several children in the batch:
+	// 		the sequence records that a signal arrived, not how many.
+	// The bumps acquire locks on each parent run so that the wakeup is never lost if its current status
+	// is running but there is a concurrent state transition moving it to awaiting_child_workflow
+	const incrementedParentsRuns = await txRepos.workflowRun.bulkIncrementSignalSequence(
+		asNonEmptyArray(Array.from(parentsRunsById.values()))
+	);
+
+	const parkedParentsRuns = incrementedParentsRuns.filter((parent) => parent.status === "awaiting_child_workflow");
+	if (!isNonEmptyArray(parkedParentsRuns)) {
+		return;
+	}
+
+	const parentRunsLatestTransition = await txRepos.stateTransition.getByIds(
+		asNonEmptyArray(parkedParentsRuns.map((parent) => parent.latestStateTransitionId))
+	);
+	const parentRunStateByTransitionId = new Map(
+		parentRunsLatestTransition.map((transition) => [transition.id, transition.state as WorkflowRunState])
+	);
+
+	const childRunIds = new Set<string>(runs.map((childRun) => childRun.id));
+	const parentRunStateTransitionEntries: StateTransitionRowInsert[] = [];
+	const parentRunUpdates: {
+		filter: { namespaceId: NamespaceId; id: string; revision: number };
+		update: { stateTransitionId: string };
+	}[] = [];
+
+	for (const parentRun of parkedParentsRuns) {
+		const parentRunState = parentRunStateByTransitionId.get(parentRun.latestStateTransitionId);
+		if (
+			parentRunState?.status !== "awaiting_child_workflow" ||
+			// skip wake if parent is parked on a child not part of the batch generating the signal
+			!childRunIds.has(parentRunState.childWorkflowRunId)
+		) {
+			continue;
+		}
+
+		const stateTransitionId = ulid();
+		parentRunStateTransitionEntries.push({
+			id: stateTransitionId,
+			workflowRunId: parentRun.id,
+			type: "workflow_run",
+			status: "scheduled",
+			attempt: parentRun.attempts,
+			state: {
+				status: "scheduled",
+				reason: "child_workflow",
+				scheduledAt: now,
+			} satisfies WorkflowRunStateScheduledByChildWorkflow,
+		});
+		parentRunUpdates.push({
+			filter: { namespaceId: parentRun.namespaceId as NamespaceId, id: parentRun.id, revision: parentRun.revision },
+			update: { stateTransitionId },
+		});
+	}
+
+	if (!isNonEmptyArray(parentRunUpdates)) {
+		return;
+	}
+
+	const scheduledParentRunIds = await txRepos.workflowRun.bulkTransitionToScheduled(
+		"awaiting_child_workflow",
+		now,
+		parentRunUpdates
+	);
+	if (!isNonEmptyArray(scheduledParentRunIds)) {
+		return;
+	}
+
+	let parentRunStateTransitionEntriesToInsert = parentRunStateTransitionEntries;
+	if (scheduledParentRunIds.length !== parentRunStateTransitionEntries.length) {
+		const scheduledParentRunIdSet = new Set(scheduledParentRunIds);
+		parentRunStateTransitionEntriesToInsert = parentRunStateTransitionEntries.filter((entry) =>
+			scheduledParentRunIdSet.has(entry.workflowRunId)
+		);
+	}
+	if (isNonEmptyArray(parentRunStateTransitionEntriesToInsert)) {
+		await txRepos.stateTransition.appendBatch(parentRunStateTransitionEntriesToInsert);
+	}
+
+	logger.info("Woke parents parked on terminal children", { "aiki.parentRunIds": scheduledParentRunIds });
+}

--- a/sdk/server/src/service/event.ts
+++ b/sdk/server/src/service/event.ts
@@ -81,8 +81,8 @@ async function sendEventToWorkflowRunInTx(
 	const { runId, eventName, data, reference } = params;
 	const { namespaceId } = context;
 
-	// acquire lock on run row so that the wakeup is never lost if the current status is running
-	// but there is a concurrent state transition moving it to awaiting_event
+	// acquire lock on run row so that the wakeup is never lost if its current status
+	// is running but there is a concurrent state transition moving it to awaiting_event
 	const runWithState = await txRepos.workflowRun.incrementSignalSequence({ namespaceId, id: runId });
 	if (!runWithState) {
 		throw new NotFoundError(`Workflow run not found: ${runId}`);

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -2,7 +2,8 @@ import { asConfigProvider } from "@aikirun/lib/config";
 import { NotFoundError } from "@aikirun/lib/error";
 import { noopLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
-import type { WorkflowRunId } from "@aikirun/types/workflow/run";
+import type { WorkflowRunTransitionStateRequestV1 } from "@aikirun/types/api/workflow-run";
+import type { TerminalWorkflowRunStatus, WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import { createWorkflowRunStateMachine } from "./workflow-run";
 import { describe, expect, test } from "bun:test";
@@ -714,7 +715,6 @@ describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
 					state: {
 						status: "awaiting_child_workflow",
 						childWorkflowRunId: child.runId,
-						childWorkflowRunStatus: "completed",
 					},
 					expectedRevision: parent.revisionWhenClaimed,
 					expectedSignalSequence: 0,
@@ -776,10 +776,13 @@ describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
 			]);
 		}));
 
-	test("a park on a child already at the awaited status schedules the run immediately", () =>
+	test("a park on an already terminal child schedules the run immediately", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
-			const child = await seedCompletedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedCompletedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
 
 			const stateMachine = createStateMachine(repos);
 			const parkedAt = Date.now();
@@ -790,9 +793,9 @@ describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
 					state: {
 						status: "awaiting_child_workflow",
 						childWorkflowRunId: child.runId,
-						childWorkflowRunStatus: "completed",
 					},
 					expectedRevision: parent.revisionWhenClaimed,
+					// The sequence the parent's worker read before the child finished.
 					expectedSignalSequence: 0,
 				})
 			);
@@ -803,6 +806,129 @@ describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
 				attempts: parent.attemptsWhenClaimed,
 			});
 		}));
+});
+
+describe("WorkflowRunStateMachine child terminal signals", () => {
+	const terminalTransitionByStatus = {
+		completed: {
+			request: (id: string, expectedRevision: number) =>
+				({
+					type: "optimistic",
+					id,
+					state: { status: "completed", output: { receiptId: "child-receipt-9" } },
+					expectedRevision,
+				}) as const,
+			expectedChildState: { status: "completed", output: { receiptId: "child-receipt-9" } },
+		},
+		failed: {
+			request: (id: string, expectedRevision: number) =>
+				({
+					type: "optimistic",
+					id,
+					state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+					expectedRevision,
+				}) as const,
+			expectedChildState: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+		},
+		cancelled: {
+			request: (id: string) => ({ type: "pessimistic", id, state: { status: "cancelled" } }) as const,
+			expectedChildState: { status: "cancelled" },
+		},
+	} satisfies Record<
+		TerminalWorkflowRunStatus,
+		{
+			request: (id: string, expectedRevision: number) => WorkflowRunTransitionStateRequestV1;
+			expectedChildState: unknown;
+		}
+	>;
+
+	for (const [status, { request, expectedChildState }] of Object.entries(terminalTransitionByStatus)) {
+		test(`a child reaching ${status} writes the wait row`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+				const child = await seedClaimedRun(
+					{ namespaceRequestContext: context, repos, publisher },
+					{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+				);
+
+				const stateMachine = createStateMachine(repos);
+				await stateMachine.transitionState(context, request(child.runId, child.revisionWhenClaimed));
+
+				expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parent.runId)).toEqual([
+					expect.objectContaining({
+						parentWorkflowRunId: parent.runId,
+						childWorkflowRunId: child.runId,
+						childWorkflowRunStatus: status,
+						status: "completed",
+						childWorkflowRunState: expectedChildState,
+					}),
+				]);
+			}));
+
+		test(`a child reaching ${status} bumps its parent's signal sequence`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+				const child = await seedClaimedRun(
+					{ namespaceRequestContext: context, repos, publisher },
+					{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+				);
+
+				const stateMachine = createStateMachine(repos);
+				await stateMachine.transitionState(context, request(child.runId, child.revisionWhenClaimed));
+
+				const parentRecord = await repos.workflowRun.getByIdWithState({
+					namespaceId: context.namespaceId,
+					id: parent.runId,
+				});
+				expect(parentRecord).toEqual(
+					expect.objectContaining({
+						run: expect.objectContaining({
+							id: parent.runId,
+							revision: parent.revisionWhenClaimed,
+							signalSequence: 1,
+						}),
+						state: { status: "running" },
+					})
+				);
+			}));
+
+		test(`a child reaching ${status} wakes a parent parked on it`, () =>
+			withHarness(async ({ context, repos, publisher }) => {
+				const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+				const child = await seedClaimedRun(
+					{ namespaceRequestContext: context, repos, publisher },
+					{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+				);
+
+				const stateMachine = createStateMachine(repos);
+				const parked = await stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: parent.runId,
+					state: {
+						status: "awaiting_child_workflow",
+						childWorkflowRunId: child.runId,
+					},
+					expectedRevision: parent.revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				});
+
+				const childTerminatedAt = Date.now();
+				await withFakeClock(childTerminatedAt, () =>
+					stateMachine.transitionState(context, request(child.runId, child.revisionWhenClaimed))
+				);
+
+				const parentRun = await repos.workflowRun.getByIdWithState({
+					namespaceId: context.namespaceId,
+					id: parent.runId,
+				});
+				expect(parentRun).toEqual(
+					expect.objectContaining({
+						run: expect.objectContaining({ id: parent.runId, status: "scheduled", revision: parked.revision + 1 }),
+						state: { status: "scheduled", reason: "child_workflow", scheduledAt: childTerminatedAt },
+					})
+				);
+			}));
+	}
 });
 
 describe("WorkflowRunStateMachine imminent run timers", () => {

--- a/sdk/server/src/service/state-machine/workflow-run.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.test.ts
@@ -1,4 +1,5 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
+import type { TimestampMs } from "@aikirun/lib/timestamp";
 import { workflowRunStateByStatus } from "@aikirun/testing/data-factory/workflow/run";
 import type { WorkflowRunStateRequest } from "@aikirun/types/api/workflow-run";
 import {
@@ -109,7 +110,7 @@ describe("assertIsValidWorkflowRunStateTransition", () => {
 });
 
 describe("convertDurationToTimestamp", () => {
-	const now = 1_000;
+	const now = 1_000 as TimestampMs;
 
 	test("scheduled: scheduledInMs becomes an absolute scheduledAt", () => {
 		expect(convertDurationToTimestamp({ status: "scheduled", reason: "event", scheduledInMs: 500 }, now)).toEqual({
@@ -176,7 +177,6 @@ describe("convertDurationToTimestamp", () => {
 				{
 					status: "awaiting_child_workflow",
 					childWorkflowRunId: "child-1",
-					childWorkflowRunStatus: "completed",
 					timeoutInMs: 500,
 				},
 				now
@@ -184,21 +184,16 @@ describe("convertDurationToTimestamp", () => {
 		).toEqual({
 			status: "awaiting_child_workflow",
 			childWorkflowRunId: "child-1",
-			childWorkflowRunStatus: "completed",
 			timeoutAt: 1_500,
 		});
 	});
 
 	test("awaiting_child_workflow without a timeout: passes through with no timeoutAt", () => {
 		expect(
-			convertDurationToTimestamp(
-				{ status: "awaiting_child_workflow", childWorkflowRunId: "child-1", childWorkflowRunStatus: "completed" },
-				now
-			)
+			convertDurationToTimestamp({ status: "awaiting_child_workflow", childWorkflowRunId: "child-1" }, now)
 		).toEqual({
 			status: "awaiting_child_workflow",
 			childWorkflowRunId: "child-1",
-			childWorkflowRunStatus: "completed",
 		});
 	});
 

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -6,13 +6,7 @@ import type {
 	WorkflowRunTransitionStateRequestV1,
 	WorkflowRunTransitionStateResponseV1,
 } from "@aikirun/types/api/workflow-run";
-import type {
-	TerminalWorkflowRunStatus,
-	WorkflowRunId,
-	WorkflowRunState,
-	WorkflowRunStateAwaitingChildWorkflow,
-	WorkflowRunStatus,
-} from "@aikirun/types/workflow/run";
+import type { WorkflowRunId, WorkflowRunState, WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import { isTerminalWorkflowRunStatus, WORKFLOW_RUN_SCHEDULED_REASONS } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
@@ -22,6 +16,7 @@ import type { UpdateWorkflowRunParams } from "../../infra/db/types/workflow-run"
 import type { ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../../middleware/context";
 import type { ChildRunCanceller } from "../cancel-child-runs";
+import { deliverTerminatedSignalToParentRun } from "../deliver-terminated-signals";
 import { discardStaleTasks } from "../discard-stale-tasks";
 
 type StateTransitionValidation<Status extends WorkflowRunStatus> =
@@ -223,12 +218,6 @@ async function transitionStateInTx(
 		await txRepos.workflowRunOutbox.deleteByWorkflowRunId({ namespaceId, workflowRunId: runId });
 	}
 
-	if (toState.status === "awaiting_child_workflow") {
-		if (await childWorkflowRunWaitNotNeeded(context, runId, toState, now, txRepos)) {
-			toState = { status: "scheduled", scheduledAt: now, reason: "child_workflow" };
-		}
-	}
-
 	const stateTransitionId = ulid();
 
 	const updatedRun = await updateWorkflowRun(
@@ -262,24 +251,26 @@ async function transitionStateInTx(
 	}
 
 	if (isTerminalWorkflowRunStatus(toState.status) && propsRequiredNonNull(run, "parentWorkflowRunId")) {
-		await notifyParentOfStateChangeIfNecessary(
-			context,
-			{
-				id: run.id,
-				latestStateTransitionId: stateTransitionId,
-				parentWorkflowRunId: run.parentWorkflowRunId,
-				status: toState.status,
-			},
+		await deliverTerminatedSignalToParentRun(
+			[
+				{
+					namespaceId,
+					id: run.id,
+					latestStateTransitionId: stateTransitionId,
+					parentWorkflowRunId: run.parentWorkflowRunId,
+					status: toState.status,
+				},
+			],
 			now,
-			childRunCanceller,
-			txRepos
+			txRepos,
+			context.logger
 		);
 	}
 
 	return { revision: updatedRun.revision, state: toState, attempts };
 }
 
-async function cancelSleep(runId: WorkflowRunId, sleepName: string, now: number, txRepos: TxRepositories) {
+async function cancelSleep(runId: WorkflowRunId, sleepName: string, now: TimestampMs, txRepos: TxRepositories) {
 	const activeSleep = await txRepos.sleep.getActiveByWorkflowRunIdAndName(runId, sleepName);
 	if (!activeSleep) {
 		return;
@@ -287,45 +278,8 @@ async function cancelSleep(runId: WorkflowRunId, sleepName: string, now: number,
 
 	await txRepos.sleep.update(activeSleep.id, {
 		status: "cancelled",
-		cancelledAt: now as TimestampMs,
+		cancelledAt: now,
 	});
-}
-
-async function childWorkflowRunWaitNotNeeded(
-	{ namespaceId, logger }: NamespaceRequestContext,
-	runId: WorkflowRunId,
-	toState: WorkflowRunStateAwaitingChildWorkflow,
-	now: number,
-	txRepos: TxRepositories
-) {
-	const childRunId = toState.childWorkflowRunId as WorkflowRunId;
-	const childRunResult = await txRepos.workflowRun.getByIdWithState({ namespaceId, id: childRunId });
-	if (!childRunResult) {
-		throw new NotFoundError(`Workflow run not found: ${childRunId}`);
-	}
-	const childRun = childRunResult.run;
-
-	if (childRun.status === toState.childWorkflowRunStatus || isTerminalWorkflowRunStatus(childRun.status)) {
-		await txRepos.childWorkflowRunWait.insert({
-			id: ulid(),
-			parentWorkflowRunId: runId,
-			childWorkflowRunId: childRunId,
-			childWorkflowRunStatus: toState.childWorkflowRunStatus,
-			status: "completed",
-			completedAt: now as TimestampMs,
-			childWorkflowRunStateTransitionId: childRun.latestStateTransitionId,
-		});
-
-		logger.info("Child already at status, scheduling immediately", {
-			"aiki.runId": runId,
-			"aiki.childRunId": childRunId,
-			"aiki.childRunStatus": childRun.status,
-		});
-
-		return true;
-	}
-
-	return false;
 }
 
 async function updateWorkflowRun(
@@ -361,7 +315,7 @@ async function updateWorkflowRun(
 					status: toState.status,
 					timeoutAt: toState.timeoutAt !== undefined ? (toState.timeoutAt as TimestampMs) : null,
 				},
-				onSignalSequenceMismatch: { status: "scheduled", scheduledAt: now as TimestampMs },
+				onSignalSequenceMismatch: { status: "scheduled", scheduledAt: now },
 			},
 		});
 		if (!result) {
@@ -440,64 +394,7 @@ async function updateWorkflowRun(
 	}
 }
 
-async function notifyParentOfStateChangeIfNecessary(
-	context: NamespaceRequestContext,
-	childRun: {
-		id: string;
-		latestStateTransitionId: string;
-		parentWorkflowRunId: string;
-		status: TerminalWorkflowRunStatus;
-	},
-	now: number,
-	childRunCanceller: ChildRunCanceller,
-	txRepos: TxRepositories
-): Promise<void> {
-	const parentRunResult = await txRepos.workflowRun.getByIdWithState({
-		namespaceId: context.namespaceId,
-		id: childRun.parentWorkflowRunId,
-	});
-	if (!parentRunResult) {
-		throw new NotFoundError(`Workflow run not found: ${childRun.parentWorkflowRunId}`);
-	}
-
-	const { run: parentRun, state: parentRunState } = parentRunResult;
-
-	if (
-		parentRunState.status === "awaiting_child_workflow" &&
-		parentRunState.childWorkflowRunId === childRun.id &&
-		parentRunState.childWorkflowRunStatus === childRun.status
-	) {
-		context.logger.info("Notifying parent of child state change", {
-			"aiki.parentRunId": parentRun.id,
-			"aiki.childRunId": childRun.id,
-			"aiki.status": childRun.status,
-		});
-
-		await txRepos.childWorkflowRunWait.insert({
-			id: ulid(),
-			parentWorkflowRunId: parentRun.id,
-			childWorkflowRunId: childRun.id,
-			childWorkflowRunStatus: parentRunState.childWorkflowRunStatus,
-			status: "completed",
-			completedAt: now as TimestampMs,
-			childWorkflowRunStateTransitionId: childRun.latestStateTransitionId,
-		});
-
-		await transitionStateInTx(
-			context,
-			{
-				type: "optimistic",
-				id: parentRun.id,
-				state: { status: "scheduled", scheduledInMs: 0, reason: "child_workflow" },
-				expectedRevision: parentRun.revision,
-			},
-			childRunCanceller,
-			txRepos
-		);
-	}
-}
-
-export function convertDurationToTimestamp(request: WorkflowRunStateRequest, now: number): WorkflowRunState {
+export function convertDurationToTimestamp(request: WorkflowRunStateRequest, now: TimestampMs): WorkflowRunState {
 	if (request.status === "scheduled") {
 		return {
 			status: "scheduled",
@@ -553,7 +450,6 @@ export function convertDurationToTimestamp(request: WorkflowRunStateRequest, now
 		return {
 			status: request.status,
 			childWorkflowRunId: request.childWorkflowRunId,
-			childWorkflowRunStatus: request.childWorkflowRunStatus,
 			timeoutAt: now + request.timeoutInMs,
 		};
 	}

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -220,6 +220,126 @@ describe("WorkflowRunService cancelByIds", () => {
 			expect(sleeps).toEqual([expect.objectContaining({ name: "nap", status: "cancelled", cancelledAt })]);
 		}));
 
+	test("cancelling a child writes the terminal wait row", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const { service } = createService(repos);
+			await service.cancelByIds(context, { ids: [child.runId] });
+
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parent.runId)).toEqual([
+				expect.objectContaining({
+					parentWorkflowRunId: parent.runId,
+					childWorkflowRunId: child.runId,
+					childWorkflowRunStatus: "cancelled",
+					status: "completed",
+					childWorkflowRunState: { status: "cancelled" },
+				}),
+			]);
+		}));
+
+	test("cancelling a child bumps its parent's signal sequence", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const { service } = createService(repos);
+			await service.cancelByIds(context, { ids: [child.runId] });
+
+			const parentRecord = await repos.workflowRun.getByIdWithState({
+				namespaceId: context.namespaceId,
+				id: parent.runId,
+			});
+			expect(parentRecord).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parent.runId,
+						revision: parent.revisionWhenClaimed,
+						signalSequence: 1,
+					}),
+					state: { status: "running" },
+				})
+			);
+		}));
+
+	test("cancelling two children together bumps their parent once", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const firstChild = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+			const secondChild = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const { service } = createService(repos);
+			await service.cancelByIds(context, { ids: [firstChild.runId, secondChild.runId] });
+
+			const parentRecord = await repos.workflowRun.getByIdWithState({
+				namespaceId: context.namespaceId,
+				id: parent.runId,
+			});
+			expect(parentRecord).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parent.runId,
+						revision: parent.revisionWhenClaimed,
+						signalSequence: 1,
+					}),
+					state: { status: "running" },
+				})
+			);
+		}));
+
+	test("cancelling a child wakes a parent parked on it", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const { service, stateMachine } = createService(repos);
+			const parked = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: parent.runId,
+				state: {
+					status: "awaiting_child_workflow",
+					childWorkflowRunId: child.runId,
+				},
+				expectedRevision: parent.revisionWhenClaimed,
+				expectedSignalSequence: 0,
+			});
+
+			const cancelledAt = Date.now();
+			await withFakeClock(cancelledAt, () => service.cancelByIds(context, { ids: [child.runId] }));
+
+			const parentRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: context.namespaceId,
+				id: parent.runId,
+			});
+			expect(parentRun).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parent.runId,
+						status: "scheduled",
+						revision: parked.revision + 1,
+						signalSequence: 1,
+					}),
+					state: { status: "scheduled", reason: "child_workflow", scheduledAt: cancelledAt },
+				})
+			);
+		}));
+
 	Object.entries({
 		cancelled: (context, stateMachine, seed) =>
 			stateMachine.transitionState(context, {

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -16,11 +16,10 @@ import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type {
 	ChildWorkflowRunInfo,
-	ChildWorkflowRunWait,
+	ChildWorkflowRunWaits,
 	EventWait,
 	Sleep,
 	TerminalWorkflowRunState,
-	TerminalWorkflowRunStatus,
 	WorkflowRunId,
 	WorkflowRunRecord,
 	WorkflowRunState,
@@ -32,12 +31,15 @@ import { ulid } from "ulidx";
 
 import { WorkflowRunReferenceConflictError, WorkflowRunRevisionConflictError } from "../errors";
 import type { Repositories, TxRepositories } from "../infra/db/types";
+import type { ChildRunWaitWithState } from "../infra/db/types/child-workflow-run-wait";
 import type { EventWaitRow } from "../infra/db/types/event-wait";
 import type { SleepRow } from "../infra/db/types/sleep";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { ChildRunWithWorkflow, WorkflowRunWithWorkflowAndState } from "../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../middleware/context";
 import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
+import { deliverTerminatedSignalToParentRun, type TerminatedChildRun } from "../service/deliver-terminated-signals";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
 
 export interface WorkflowRunServiceDeps {
@@ -407,19 +409,21 @@ async function createWorkflowRunInTx(
 }
 
 async function cancelByIdsInTx(
-	{ namespaceId, logger }: NamespaceRequestContext,
+	context: NamespaceRequestContext,
 	ids: NonEmptyArray<string>,
 	txRepos: TxRepositories,
 	childRunCanceller: ChildRunCanceller
 ) {
+	const { namespaceId, logger } = context;
 	const cancelledRuns = await txRepos.workflowRun.bulkTransitionToCancelledInNamespace(namespaceId, ids);
 	if (!isNonEmptyArray(cancelledRuns)) {
 		return { cancelledIds: [] };
 	}
 	const cancelledRunIds = cancelledRuns.map((run) => run.id) as NonEmptyArray<string>;
 
+	const now = Date.now() as TimestampMs;
 	await discardStaleTasks(cancelledRunIds, ["running", "awaiting_retry"], txRepos);
-	await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, Date.now() as TimestampMs);
+	await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now);
 	await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
 	const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
@@ -428,6 +432,7 @@ async function cancelByIdsInTx(
 		update: { stateTransitionId: string };
 	}[] = [];
 	const cancelledRunsMeta: CancelledRunMeta[] = [];
+	const cancelledRunsHavingParent: TerminatedChildRun[] = [];
 
 	for (const run of cancelledRuns) {
 		const stateTransitionId = ulid();
@@ -445,11 +450,24 @@ async function cancelByIdsInTx(
 			id: run.id,
 			pool: run.options?.pool,
 		});
+		if (run.parentWorkflowRunId !== null) {
+			cancelledRunsHavingParent.push({
+				namespaceId,
+				id: run.id,
+				latestStateTransitionId: stateTransitionId,
+				parentWorkflowRunId: run.parentWorkflowRunId,
+				status: "cancelled",
+			});
+		}
 	}
 
 	if (isNonEmptyArray(cancelStateTransitionEntries) && isNonEmptyArray(cancelledRunStateTransitionUpdates)) {
 		await txRepos.stateTransition.appendBatch(cancelStateTransitionEntries);
 		await txRepos.workflowRun.bulkSetLatestStateTransitionId(cancelledRunStateTransitionUpdates);
+	}
+
+	if (isNonEmptyArray(cancelledRunsHavingParent)) {
+		await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, logger);
 	}
 
 	if (isNonEmptyArray(cancelledRunsMeta)) {
@@ -459,15 +477,19 @@ async function cancelByIdsInTx(
 	return { cancelledIds: cancelledRunIds };
 }
 
-type WorkflowRunWithWorkflowAndState = NonNullable<
-	Awaited<ReturnType<Repositories["workflowRun"]["getByIdWithWorkflowAndState"]>>
->;
-
 async function getWorkflowRun(
 	repos: Repositories,
 	namespaceId: NamespaceId,
 	{ run, workflow, state }: WorkflowRunWithWorkflowAndState
 ): Promise<WorkflowRunRecord> {
+	// The run row (carrying signalSequence) is must be read before these rows.
+	// A signal landing between the two reads then shows up in the read event_wait/child_workflow_run_wait
+	// rows but not in the read signalSequence (it will be stale).
+	// A park request using using the stale signalSequence simply reschedules — safe.
+	// In the reverse order i.e. these rows being read before the run row, the signalSequence
+	// will be current but there will be no corresponding event_wait/child_workflow_run_wait rows is
+	// catastrophic because the wait would find no rows to replay against, then attempt park, which succeeds
+	// because the expectedSignalSequence matches, therefore, sleeping through a signal that is already recorded.
 	const [taskRows, sleepRows, eventWaitRows, childRunRows, childWorkflowRunWaitRows] = await Promise.all([
 		repos.task.listByWorkflowRunIdWithState(run.id),
 		repos.sleep.listByWorkflowRunId(run.id as WorkflowRunId),
@@ -608,25 +630,19 @@ function buildEventWaitsByName(eventWaitRows: EventWaitRow[]): Record<string, Ev
 }
 
 function buildChildWorkflowRunsByAddress(
-	childRuns: Awaited<ReturnType<Repositories["workflowRun"]["getChildRunsWithWorkflow"]>>,
-	childRunWaits: Awaited<ReturnType<Repositories["childWorkflowRunWait"]["listByParentRunIdWithChildState"]>>
+	childRuns: ChildRunWithWorkflow[],
+	childRunWaits: ChildRunWaitWithState[]
 ): Record<string, ChildWorkflowRunInfo[]> {
-	const waitsByChildRunId = new Map<WorkflowRunId, Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>>();
+	const waitsByChildRunId = new Map<WorkflowRunId, ChildWorkflowRunWaits>();
 
 	for (const childRunWait of childRunWaits) {
 		const childRunId = childRunWait.childWorkflowRunId as WorkflowRunId;
 
 		let waits = waitsByChildRunId.get(childRunId);
 		if (!waits) {
-			waits = {
-				cancelled: [],
-				completed: [],
-				failed: [],
-			};
+			waits = { timeouts: [] };
 			waitsByChildRunId.set(childRunId, waits);
 		}
-
-		const { childWorkflowRunStatus } = childRunWait;
 
 		switch (childRunWait.status) {
 			case "completed": {
@@ -638,11 +654,7 @@ function buildChildWorkflowRunsByAddress(
 					throw new Error(`Child workflow run wait ${childRunWait.id} completed but no child run state`);
 				}
 
-				waits[childWorkflowRunStatus].push({
-					status: childRunWait.status,
-					completedAt: completedAt,
-					childWorkflowRunState: childWorkflowRunState as TerminalWorkflowRunState,
-				});
+				waits.terminal = { state: childWorkflowRunState as TerminalWorkflowRunState, completedAt };
 				break;
 			}
 			case "timeout": {
@@ -651,10 +663,7 @@ function buildChildWorkflowRunsByAddress(
 					throw new Error(`Child workflow run wait ${childRunWait.id} timed out but no timedOutAt timestamp`);
 				}
 
-				waits[childWorkflowRunStatus].push({
-					status: childRunWait.status,
-					timedOutAt: timedOutAt,
-				});
+				waits.timeouts.push({ timedOutAt });
 				break;
 			}
 			default:
@@ -676,11 +685,7 @@ function buildChildWorkflowRunsByAddress(
 			name: childWorkflow.name,
 			versionId: childWorkflow.versionId,
 			inputHash: childRun.inputHash,
-			waits: waitsByChildRunId.get(childRun.id as WorkflowRunId) ?? {
-				cancelled: [],
-				completed: [],
-				failed: [],
-			},
+			waits: waitsByChildRunId.get(childRun.id as WorkflowRunId) ?? { timeouts: [] },
 		};
 
 		const addressChildRuns = childRunsByAddress[childRunAddress];

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -36,6 +36,7 @@ export interface SeedRunDeps {
 
 interface SeedRunOverrides {
 	options?: WorkflowStartOptions;
+	parent?: { workflowRunId: string; expectedRevision: number };
 }
 
 export async function seedPooledScheduledRun(deps: Pick<SeedRunDeps, "repos" | "namespaceRequestContext">) {
@@ -59,6 +60,7 @@ export async function seedScheduledRun(
 		input,
 		inputHash: { value: await hashInput(input) },
 		options: overrides?.options,
+		parent: overrides?.parent,
 	});
 
 	return { runId, revisionWhenScheduled: 0, attemptsWhenScheduled: 1 };

--- a/sdk/workflow/src/run/handle-child.test.ts
+++ b/sdk/workflow/src/run/handle-child.test.ts
@@ -1,37 +1,71 @@
 import { withFakeClient } from "@aikirun/testing/client";
 import { runningWorkflowRunRecordFactory, workflowRunStateByStatus } from "@aikirun/testing/data-factory/workflow/run";
-import type { ChildWorkflowRunWait, TerminalWorkflowRunStatus } from "@aikirun/types/workflow/run";
+import type { ChildWorkflowRunWaits } from "@aikirun/types/workflow/run";
 import { WorkflowRunSuspendedError } from "@aikirun/types/workflow/run";
 
 import { workflowRunHandle } from "./handle";
 import { childWorkflowRunHandle } from "./handle-child";
 import { describe, expect, test } from "bun:test";
 
-function childWaits(
-	waits: Partial<Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>>
-): Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]> {
+function childWaits(waits: Partial<ChildWorkflowRunWaits>): ChildWorkflowRunWaits {
 	return {
-		cancelled: waits.cancelled ?? [],
-		completed: waits.completed ?? [],
-		failed: waits.failed ?? [],
+		timeouts: waits.timeouts ?? [],
+		...(waits.terminal !== undefined ? { terminal: waits.terminal } : {}),
 	};
 }
 
 describe("childWorkflowRunHandle", () => {
-	describe("waitForStatus", () => {
-		test("returns success with the child state when it reached the expected status", () =>
+	describe("wait", () => {
+		test("resolves with the child's terminal state", () =>
 			withFakeClient(async (client) => {
 				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
 				const parentHandle = workflowRunHandle(client, parentRecord);
 				const waits = childWaits({
-					completed: [
-						{ status: "completed", completedAt: 0, childWorkflowRunState: { status: "completed", output: "done" } },
-					],
+					terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
 				});
 				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
 
-				expect(await childHandle.waitForStatus("completed")).toEqual({
+				expect(await childHandle.wait()).toEqual({
+					success: true,
+					state: { status: "completed", output: "done" },
+				});
+			}));
+
+		test("resolves with whatever terminal state the child reached", () =>
+			withFakeClient(async (client) => {
+				const parentRecord = runningWorkflowRunRecordFactory.build();
+				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const waits = childWaits({
+					terminal: {
+						state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+						completedAt: 1_000,
+					},
+				});
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+
+				expect(await childHandle.wait()).toEqual({
+					success: true,
+					state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+				});
+			}));
+
+		test("repeated waits read the same terminal outcome", () =>
+			withFakeClient(async (client) => {
+				const parentRecord = runningWorkflowRunRecordFactory.build();
+				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const waits = childWaits({
+					terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
+				});
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+
+				expect(await childHandle.wait()).toEqual({
+					success: true,
+					state: { status: "completed", output: "done" },
+				});
+				expect(await childHandle.wait()).toEqual({
 					success: true,
 					state: { status: "completed", output: "done" },
 				});
@@ -42,32 +76,34 @@ describe("childWorkflowRunHandle", () => {
 				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
 				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({ completed: [{ status: "timeout", timedOutAt: 0 }] });
+				const waits = childWaits({ timeouts: [{ timedOutAt: 1_000 }] });
 				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
 
-				expect(await childHandle.waitForStatus("completed", { timeout: { minutes: 5 } })).toEqual({
+				expect(await childHandle.wait({ timeout: { minutes: 5 } })).toEqual({
 					success: false,
 					cause: "timeout",
 				});
 			}));
 
-		test("returns run_terminated when the child reached a different terminal status", () =>
+		test("consumes the recorded timeout before reading the terminal outcome", () =>
 			withFakeClient(async (client) => {
 				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
 				const parentHandle = workflowRunHandle(client, parentRecord);
 				const waits = childWaits({
-					completed: [
-						{
-							status: "completed",
-							completedAt: 0,
-							childWorkflowRunState: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
-						},
-					],
+					timeouts: [{ timedOutAt: 1_000 }],
+					terminal: { state: { status: "completed", output: "done" }, completedAt: 2_000 },
 				});
 				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
 
-				expect(await childHandle.waitForStatus("completed")).toEqual({ success: false, cause: "run_terminated" });
+				expect(await childHandle.wait({ timeout: { minutes: 5 } })).toEqual({
+					success: false,
+					cause: "timeout",
+				});
+				expect(await childHandle.wait()).toEqual({
+					success: true,
+					state: { status: "completed", output: "done" },
+				});
 			}));
 
 		test("transitions the parent to awaiting_child_workflow and suspends when no wait is recorded", () =>
@@ -84,7 +120,6 @@ describe("childWorkflowRunHandle", () => {
 						state: {
 							status: "awaiting_child_workflow",
 							childWorkflowRunId: childRecord.id,
-							childWorkflowRunStatus: "completed",
 						},
 						expectedRevision: 0,
 						expectedSignalSequence: 0,
@@ -92,7 +127,7 @@ describe("childWorkflowRunHandle", () => {
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
 				);
 
-				expect(childHandle.waitForStatus("completed")).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
+				expect(childHandle.wait()).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
 			}));
 
 		test("carries the timeout into the parent transition", () =>
@@ -109,7 +144,6 @@ describe("childWorkflowRunHandle", () => {
 						state: {
 							status: "awaiting_child_workflow",
 							childWorkflowRunId: childRecord.id,
-							childWorkflowRunStatus: "completed",
 							timeoutInMs: 300_000,
 						},
 						expectedRevision: 0,
@@ -118,9 +152,7 @@ describe("childWorkflowRunHandle", () => {
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
 				);
 
-				expect(childHandle.waitForStatus("completed", { timeout: { minutes: 5 } })).rejects.toBeInstanceOf(
-					WorkflowRunSuspendedError
-				);
+				expect(childHandle.wait({ timeout: { minutes: 5 } })).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
 			}));
 
 		test("maps a parent-transition conflict to a suspension", () =>
@@ -137,7 +169,6 @@ describe("childWorkflowRunHandle", () => {
 						state: {
 							status: "awaiting_child_workflow",
 							childWorkflowRunId: childRecord.id,
-							childWorkflowRunStatus: "completed",
 						},
 						expectedRevision: 0,
 						expectedSignalSequence: 0,
@@ -145,31 +176,7 @@ describe("childWorkflowRunHandle", () => {
 					{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
 				);
 
-				expect(childHandle.waitForStatus("completed")).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
-			}));
-
-		test("advances the cursor across calls for the same status", () =>
-			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
-				const childRecord = runningWorkflowRunRecordFactory.build();
-				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({
-					completed: [
-						{ status: "completed", completedAt: 0, childWorkflowRunState: { status: "completed", output: "first" } },
-						{
-							status: "completed",
-							completedAt: 0,
-							childWorkflowRunState: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
-						},
-					],
-				});
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
-
-				expect(await childHandle.waitForStatus("completed")).toEqual({
-					success: true,
-					state: { status: "completed", output: "first" },
-				});
-				expect(await childHandle.waitForStatus("completed")).toEqual({ success: false, cause: "run_terminated" });
+				expect(childHandle.wait()).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
 			}));
 	});
 

--- a/sdk/workflow/src/run/handle-child.ts
+++ b/sdk/workflow/src/run/handle-child.ts
@@ -4,8 +4,8 @@ import type { Logger } from "@aikirun/lib/logger";
 import type { Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import {
-	type ChildWorkflowRunWait,
-	type TerminalWorkflowRunStatus,
+	type ChildWorkflowRunWaits,
+	type TerminalWorkflowRunState,
 	type WorkflowRunId,
 	type WorkflowRunRecord,
 	WorkflowRunRevisionConflictError,
@@ -13,18 +13,13 @@ import {
 } from "@aikirun/types/workflow/run";
 
 import type { EventsDefinition } from "./event";
-import {
-	type WorkflowRunHandle,
-	type WorkflowRunWaitResult,
-	type WorkflowRunWaitResultSuccess,
-	workflowRunHandle,
-} from "./handle";
+import { type WorkflowRunHandle, workflowRunHandle } from "./handle";
 
 export function childWorkflowRunHandle<Input, Output, Context, TEvents extends EventsDefinition>(
 	client: Client<Context>,
 	run: WorkflowRunRecord<Input, Output>,
 	parentRunHandle: WorkflowRunHandle<unknown, unknown, Context, EventsDefinition>,
-	waits: Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>,
+	parentRunWaitsOnChild: ChildWorkflowRunWaits,
 	logger: Logger,
 	eventsDefinition?: TEvents
 ): ChildWorkflowRunHandle<Input, Output, Context, TEvents> {
@@ -34,7 +29,7 @@ export function childWorkflowRunHandle<Input, Output, Context, TEvents extends E
 		run: handle.run,
 		events: handle.events,
 		refresh: handle.refresh.bind(handle),
-		waitForStatus: createStatusWaiter(handle, parentRunHandle, waits, logger),
+		wait: createWaiter(handle, parentRunHandle, parentRunWaitsOnChild, logger),
 		cancel: handle.cancel.bind(handle),
 		pause: handle.pause.bind(handle),
 		resume: handle.resume.bind(handle),
@@ -50,130 +45,92 @@ export type ChildWorkflowRunHandle<Input, Output, Context, TEvents extends Event
 	/**
 	 * Waits for the child workflow run to reach a terminal status.
 	 *
-	 * This method suspends the parent workflow until the child reaches the expected terminal status
-	 * or the optional timeout elapses.
+	 * This method suspends the parent workflow until the child reaches any terminal status
+	 * (`completed`, `failed`, or `cancelled`) or the optional timeout elapses.
 	 *
 	 * When the parent resumes, the result is deterministically replayed from stored wait results.
 	 *
 	 * Returns a result object:
-	 * - `{ success: true, state }` - child reached the expected status
-	 * - `{ success: false, cause }` - child did not reach status
+	 * - `{ success: true, state }` - the child reached a terminal status; `state.status` says which
+	 * - `{ success: false, cause: "timeout" }` - the timeout elapsed (only when a timeout is provided)
 	 *
-	 * Possible failure causes:
-	 * - `"run_terminated"` - child reached a different terminal state than expected
-	 * - `"timeout"` - timeout elapsed (only when timeout option provided)
-	 *
-	 * @param status - The target terminal status to wait for
 	 * @param options - Optional configuration with timeout
 	 *
 	 * @example
-	 * // Wait indefinitely for child to complete
-	 * const result = await childHandle.waitForStatus("completed");
-	 * if (result.success) {
+	 * // Wait indefinitely for the child to finish
+	 * const result = await childHandle.wait();
+	 * if (result.state.status === "completed") {
 	 *   console.log(result.state.output);
 	 * } else {
-	 *   console.log(`Child terminated: ${result.cause}`);
+	 *   console.log(`Child ended ${result.state.status}`);
 	 * }
 	 *
 	 * @example
 	 * // Wait with a timeout
-	 * const result = await childHandle.waitForStatus("completed", {
-	 *   timeout: { minutes: 5 }
-	 * });
-	 * if (!result.success && result.cause === "timeout") {
+	 * const result = await childHandle.wait({ timeout: { minutes: 5 } });
+	 * if (!result.success) {
 	 *   console.log("Child workflow took too long");
 	 * }
 	 */
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options?: ChildWorkflowRunWaitOptions<false>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, false>>;
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: ChildWorkflowRunWaitOptions<true>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, false>>;
+	wait(options?: ChildWorkflowRunWaitOptions<false>): Promise<ChildWorkflowRunWaitResult<Output, false>>;
+	wait(options: ChildWorkflowRunWaitOptions<true>): Promise<ChildWorkflowRunWaitResult<Output, true>>;
 };
 
 export interface ChildWorkflowRunWaitOptions<Timed extends boolean> {
 	timeout?: Timed extends true ? DurationObject : never;
 }
 
-function createStatusWaiter<Input, Output, Context, TEvents extends EventsDefinition>(
+export type ChildWorkflowRunWaitResult<Output, Timed extends boolean> = Timed extends true
+	?
+			| {
+					success: true;
+					state: TerminalWorkflowRunState<Output>;
+			  }
+			| {
+					success: false;
+					cause: "timeout";
+			  }
+	: {
+			success: true;
+			state: TerminalWorkflowRunState<Output>;
+		};
+
+function createWaiter<Input, Output, Context, TEvents extends EventsDefinition>(
 	handle: WorkflowRunHandle<Input, Output, Context, TEvents>,
 	parentRunHandle: WorkflowRunHandle<unknown, unknown, Context, EventsDefinition>,
-	waits: Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>,
+	parentRunWaitsOnChild: ChildWorkflowRunWaits,
 	logger: Logger
 ) {
-	const nextIndexByStatus: Record<TerminalWorkflowRunStatus, number> = {
-		cancelled: 0,
-		completed: 0,
-		failed: 0,
-	};
+	let nextTimeoutIndex = 0;
 
-	async function waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options?: ChildWorkflowRunWaitOptions<false>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, false>>;
+	async function wait(options?: ChildWorkflowRunWaitOptions<false>): Promise<ChildWorkflowRunWaitResult<Output, false>>;
+	async function wait(options: ChildWorkflowRunWaitOptions<true>): Promise<ChildWorkflowRunWaitResult<Output, true>>;
 
-	async function waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: ChildWorkflowRunWaitOptions<true>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, false>>;
-
-	async function waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		expectedStatus: Status,
+	async function wait(
 		options?: ChildWorkflowRunWaitOptions<boolean>
-	): Promise<WorkflowRunWaitResult<Status, Output, boolean, false>> {
+	): Promise<ChildWorkflowRunWaitResult<Output, boolean>> {
 		// TODO: refresh first? like how event waits do it
-
-		const nextIndex = nextIndexByStatus[expectedStatus];
 
 		const { run } = handle;
 
-		const childWorkflowRunWaits = waits[expectedStatus];
-		const existingChildWorkflowRunWait = childWorkflowRunWaits[nextIndex];
+		const timedOutWait = parentRunWaitsOnChild.timeouts[nextTimeoutIndex];
+		if (timedOutWait) {
+			nextTimeoutIndex++;
 
-		if (existingChildWorkflowRunWait) {
-			nextIndexByStatus[expectedStatus] = nextIndex + 1;
-
-			if (existingChildWorkflowRunWait.status === "timeout") {
-				logger.debug("Timed out waiting for child workflow status", {
-					"aiki.childWorkflowExpectedStatus": expectedStatus,
-				});
-				return {
-					success: false,
-					cause: "timeout",
-				};
-			}
-			existingChildWorkflowRunWait.status satisfies "completed";
-
-			const childWorkflowRunStatus = existingChildWorkflowRunWait.childWorkflowRunState.status;
-			if (childWorkflowRunStatus === expectedStatus) {
-				return {
-					success: true,
-					state: existingChildWorkflowRunWait.childWorkflowRunState as WorkflowRunWaitResultSuccess<Status, Output>,
-				};
-			}
-
-			childWorkflowRunStatus satisfies TerminalWorkflowRunStatus;
-
-			logger.debug("Child workflow run reached terminal state", {
-				"aiki.childWorkflowTerminalStatus": childWorkflowRunStatus,
-			});
+			logger.debug("Timed out waiting for child workflow");
 			return {
 				success: false,
-				cause: "run_terminated",
+				cause: "timeout",
 			};
 		}
 
-		// TODO: if the child workflow is already in the expectedStatus or a terminal status,
-		// 		 we might return early, but it is tricky and could lead to bugs.
-		// Example:
-		// - wait for child to complete
-		// - realises child already completed, so return early
-		// - on replay, wait for child to complete, but child is not longer in completed state
-		// - now it starts waiting, which is a different outcome from the first run
-		// For now, let's persist this waiting in the server, so that the replay will work nicely
+		const { terminal } = parentRunWaitsOnChild;
+		if (terminal) {
+			return {
+				success: true,
+				state: terminal.state as TerminalWorkflowRunState<Output>,
+			};
+		}
 
 		const timeoutInMs = options?.timeout && toMilliseconds(options.timeout);
 
@@ -181,11 +138,9 @@ function createStatusWaiter<Input, Output, Context, TEvents extends EventsDefini
 			await parentRunHandle[INTERNAL].transitionState({
 				status: "awaiting_child_workflow",
 				childWorkflowRunId: run.id,
-				childWorkflowRunStatus: expectedStatus,
 				timeoutInMs,
 			});
 			logger.info("Waiting for child Workflow", {
-				"aiki.childWorkflowExpectedStatus": expectedStatus,
 				...(timeoutInMs !== undefined ? { "aiki.timeoutInMs": timeoutInMs } : {}),
 			});
 		} catch (err) {
@@ -198,5 +153,5 @@ function createStatusWaiter<Input, Output, Context, TEvents extends EventsDefini
 		throw new WorkflowRunSuspendedError(parentRunHandle.run.id as WorkflowRunId);
 	}
 
-	return waitForStatus;
+	return wait;
 }

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -239,10 +239,10 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			versionId: this.versionId,
 			referenceId: referenceId ?? inputHash.value,
 		});
-		const replayManifest = parentRun[INTERNAL].replayManifest;
+		const parentRunReplayManifest = parentRun[INTERNAL].replayManifest;
 
-		if (replayManifest.hasUnconsumedEntries()) {
-			const existingRunInfo = replayManifest.consumeNextChildWorkflowRun(address);
+		if (parentRunReplayManifest.hasUnconsumedEntries()) {
+			const existingRunInfo = parentRunReplayManifest.consumeNextChildWorkflowRun(address);
 			if (existingRunInfo) {
 				const { run: existingRun } = await client.api.workflowRun.getByIdV1({ id: existingRunInfo.id });
 
@@ -262,7 +262,13 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 				);
 			}
 
-			await this.throwNonDeterminismError(parentRun, parentRunHandle, inputHash.value, referenceId, replayManifest);
+			await this.throwNonDeterminismError(
+				parentRun,
+				parentRunHandle,
+				inputHash.value,
+				referenceId,
+				parentRunReplayManifest
+			);
 		}
 
 		const pool = parentRun.options.pool;
@@ -297,11 +303,7 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			client,
 			newRun as WorkflowRunRecord<Input, Output>,
 			parentRun[INTERNAL].handle,
-			{
-				cancelled: [],
-				completed: [],
-				failed: [],
-			},
+			{ timeouts: [] },
 			logger,
 			this[INTERNAL].eventsDefinition
 		);
@@ -312,9 +314,9 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 		parentRunHandle: WorkflowRunHandle<unknown, unknown, Context, EventsDefinition>,
 		inputHash: string,
 		referenceId: string | undefined,
-		manifest: ReplayManifest
+		parentRunReplayManifest: ReplayManifest
 	): Promise<never> {
-		const unconsumedManifestEntries = manifest.getUnconsumedEntries();
+		const unconsumedManifestEntries = parentRunReplayManifest.getUnconsumedEntries();
 
 		const logMeta: Record<string, unknown> = {
 			"aiki.workflowName": this.name,

--- a/testing/src/data-factory/workflow/run.ts
+++ b/testing/src/data-factory/workflow/run.ts
@@ -26,7 +26,6 @@ export const workflowRunStateByStatus: {
 	awaiting_child_workflow: {
 		status: "awaiting_child_workflow",
 		childWorkflowRunId: "child-1",
-		childWorkflowRunStatus: "completed",
 	},
 	stalled: { status: "stalled" },
 	cancelled: { status: "cancelled" },
@@ -40,9 +39,7 @@ export const childWorkflowRunInfoFactory = Factory.define<ChildWorkflowRunInfo>(
 	versionId: "1.0.0",
 	inputHash: "hash",
 	waits: {
-		cancelled: [],
-		completed: [],
-		failed: [],
+		timeouts: [],
 	},
 }));
 

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -202,7 +202,6 @@ export type WorkflowRunStateAwaitingRetry =
 export interface WorkflowRunStateAwaitingChildWorkflow extends WorkflowRunStateBase {
 	status: "awaiting_child_workflow";
 	childWorkflowRunId: string;
-	childWorkflowRunStatus: TerminalWorkflowRunStatus;
 	timeoutAt?: number;
 }
 
@@ -260,7 +259,10 @@ export type WorkflowRunStateInComplete =
 
 export type WorkflowRunState<Output = unknown> = WorkflowRunStateInComplete | WorkflowRunStateCompleted<Output>;
 
-export type TerminalWorkflowRunState = Extract<WorkflowRunState, { status: "cancelled" | "completed" | "failed" }>;
+export type TerminalWorkflowRunState<Output = unknown> = Extract<
+	WorkflowRunState<Output>,
+	{ status: "cancelled" | "completed" | "failed" }
+>;
 
 export interface WorkflowRunRecord<Input = unknown, Output = unknown> {
 	id: string;
@@ -295,25 +297,15 @@ export interface ChildWorkflowRunInfo {
 	name: string;
 	versionId: string;
 	inputHash: string;
-	waits: Record<TerminalWorkflowRunStatus, ChildWorkflowRunWait[]>;
+	waits: ChildWorkflowRunWaits;
 }
 
-export const CHILD_WORKFLOW_RUN_WAIT_STATUSES = ["completed", "timeout"] as const;
-export type ChildWorkflowRunWaitStatus = (typeof CHILD_WORKFLOW_RUN_WAIT_STATUSES)[number];
-
-export interface ChildWorkflowRunWaitBase {
-	status: ChildWorkflowRunWaitStatus;
+export interface ChildWorkflowRunWaits {
+	timeouts: {
+		timedOutAt: number;
+	}[];
+	terminal?: {
+		state: TerminalWorkflowRunState;
+		completedAt: number;
+	};
 }
-
-export interface ChildWorkflowRunWaitCompleted extends ChildWorkflowRunWaitBase {
-	status: "completed";
-	completedAt: number;
-	childWorkflowRunState: TerminalWorkflowRunState;
-}
-
-export interface ChildWorkflowRunWaitTimeout extends ChildWorkflowRunWaitBase {
-	status: "timeout";
-	timedOutAt: number;
-}
-
-export type ChildWorkflowRunWait = ChildWorkflowRunWaitCompleted | ChildWorkflowRunWaitTimeout;


### PR DESCRIPTION
## Problem

When a workflow calls `wait()` on a child handle, the worker checks the parent's record for a stored answer. If there is none, it parks the parent: transitions it to `awaiting_child_workflow`, naming the child. When the child later reaches a terminal state, its transition wakes the parent — but only if the parent is already parked on that child, awaiting exactly that status.

That leaves three ways a parent sleeps through its child finishing:

| the child finishes | what happens today |
|---|---|
| between the worker's check and the park committing | the lost-wake-up race from #173: the two transactions share no written row, both commit, the parent parks on a finished child | | at a different terminal status than the wait named | the exact-status match never fires | | through a bulk cancellation (cancel by ids, the recurring daemon's `cancel_previous`) | those paths never check the parent |

Without a timeout, each is parked forever.

## Solution

A child reaching a terminal state is a sender, exactly like the send-event endpoint in #173.

**The terminal transaction bumps the parent's sequence.** Its first statement against the parent row increments `signal_sequence`, takes the row lock, and reads the state after it. A park in flight either committed before the bump — the wake sees it — or lands after, and its guard sees a moved sequence and reschedules. Every terminal path delivers this, the two bulk cancellation paths included, in batch: one insert, one bump per distinct parent, one revision-guarded bulk transition for the parents found parked.

**It also writes the outcome down, unconditionally.** One `child_workflow_run_wait` row per terminal child — the status it reached and its terminal state — whether or not anyone is waiting, like the sender writing the event row before asking who is listening. Each window is then covered by exactly one mechanism:

| the child finishes | what catches it |
|---|---|
| before the worker's check | the outcome row — the wait resolves without parking | | between the check and the park | the guard — the park lands as `scheduled` and replays | | after the park | the wake — now on any terminal status |

The park path no longer reads the child, and the wake only reschedules; the replay reads the outcome from the row.

**`wait()` replaces `waitForStatus(status)`.** Any terminal status resolves the wait, so the status argument no longer did anything:

```typescript
// before
const result = await childHandle.waitForStatus("completed");
if (result.success) use(result.state.output); // else cause: "run_terminated" | "timeout"

// after
const { state } = await childHandle.wait();
if (state.status === "completed") use(state.output); // timeout is the only failure
```

**The record stores one timeout queue and one outcome per child.** A timeout belongs to one wait and is consumed by position. The outcome is a permanent fact, read by every wait after the timeouts — a repeat wait succeeds again from the same entry, where today the server mints a duplicate row per repeat:

```typescript
// before
waits: Record<"completed" | "failed" | "cancelled", ChildWorkflowRunWait[]>

// after
waits: {
	timeouts: { timedOutAt: number }[];
	terminal?: { state: TerminalWorkflowRunState; completedAt: number };
}
```

The dashboard resolves a child's status from `terminal`, which fixes a display bug: it used to report the awaited status, so a child that failed while its parent awaited `completed` showed as completed.

## Migration

0025 deletes the resolved-wait rows and backfills one outcome row per already-terminal child from its latest state transition — a child has exactly one terminal transition, so previously resolved waits replay to the same outcomes. 0026 nulls the awaited status on historical timeout rows and tightens the check constraints to the new shape.

## Breaking changes

- Child handles: `wait(options?)` replaces `waitForStatus(status, options?)`; the `run_terminated` cause is gone.
- `awaiting_child_workflow` no longer carries `childWorkflowRunStatus`.
- The run record's `ChildWorkflowRunInfo.waits` shape changed as above.
- Migrations 0025/0026 rewrite `child_workflow_run_wait`: resolved-wait rows are dropped and replaced by backfilled outcome rows.