### PR TITLE
Child wait record and wake timers

### DIFF
--- a/app/dashboard/src/components/run-detail/ExecutionTab.tsx
+++ b/app/dashboard/src/components/run-detail/ExecutionTab.tsx
@@ -93,7 +93,12 @@ export function ExecutionTab({ run, scrollToTaskId }: ExecutionTabProps) {
 				<>
 					<SectionHeader label="Child Workflows" />
 					{childWorkflows.map((child) => (
-						<ChildWorkflowCard key={child.id} child={child} isAwaited={child.id === awaitingChildId} />
+						<ChildWorkflowCard
+							key={child.id}
+							child={child}
+							waits={run.childWorkflowRunWaits[child.id]}
+							isAwaited={child.id === awaitingChildId}
+						/>
 					))}
 				</>
 			)}
@@ -310,11 +315,11 @@ function TaskText({ text, color }: { text: string; color: string }) {
 
 // ── Child workflows ───────────────────────────────────────────────────────────
 
-function resolveChildStatus(child: ChildWorkflowRunInfo): {
+function resolveChildStatus(waits: ChildWorkflowRunWaits | undefined): {
 	status: TerminalWorkflowRunStatus | "running";
 	resolvedWait: TerminalChildWait | null;
 } {
-	const terminal = child.waits.terminal;
+	const terminal = waits?.terminal;
 	if (terminal) {
 		return { status: terminal.state.status, resolvedWait: terminal };
 	}
@@ -335,8 +340,16 @@ function childStatusGlyph(status: TerminalWorkflowRunStatus | "running"): string
 	return "⑂";
 }
 
-function ChildWorkflowCard({ child, isAwaited }: { child: ChildWorkflowRunInfo; isAwaited: boolean }) {
-	const { status, resolvedWait } = resolveChildStatus(child);
+function ChildWorkflowCard({
+	child,
+	waits,
+	isAwaited,
+}: {
+	child: ChildWorkflowRunInfo;
+	waits: ChildWorkflowRunWaits | undefined;
+	isAwaited: boolean;
+}) {
+	const { status, resolvedWait } = resolveChildStatus(waits);
 	const { tint: color, text: textColor } = childStatusColor(status);
 	const glyph = childStatusGlyph(status);
 	const hasResolvedOutput = resolvedWait !== null;

--- a/app/dashboard/src/components/run-detail/timeline-lookups.ts
+++ b/app/dashboard/src/components/run-detail/timeline-lookups.ts
@@ -1,4 +1,4 @@
-import type { ChildWorkflowRunInfo, EventWait, Sleep } from "@aikirun/types/workflow/run";
+import type { ChildWorkflowRunInfo, ChildWorkflowRunWaits, EventWait, Sleep } from "@aikirun/types/workflow/run";
 import type { StateTransition } from "@aikirun/types/workflow/state-transition";
 import type { TaskInfo } from "@aikirun/types/workflow/task";
 
@@ -33,6 +33,7 @@ export function buildTimelineLookups(
 	eventWaits: Record<string, EventWait<unknown>[]>,
 	sleeps: Record<string, Sleep[]>,
 	childWorkflowRuns: Record<string, ChildWorkflowRunInfo>,
+	childWorkflowRunWaits: Record<string, ChildWorkflowRunWaits>,
 	taskById: Map<string, TaskInfo>
 ): TimelineLookups {
 	const childWorkflowById = new Map<string, ChildWorkflowRunInfo>();
@@ -127,7 +128,7 @@ export function buildTimelineLookups(
 							break;
 						}
 						// A wake means the child reached a terminal state; the terminal wait carries it.
-						const terminal = childWorkflowById.get(childId)?.waits.terminal;
+						const terminal = childWorkflowRunWaits[childId]?.terminal;
 						if (terminal) {
 							context.childWorkflowStatus = terminal.state.status;
 						}

--- a/app/dashboard/src/pages/RunDetail.tsx
+++ b/app/dashboard/src/pages/RunDetail.tsx
@@ -170,6 +170,7 @@ export function RunDetail() {
 			currentRun.eventWaits,
 			currentRun.sleeps,
 			childWorkflowRuns,
+			currentRun.childWorkflowRunWaits,
 			taskById
 		);
 	}, [transitions?.transitions, currentRun, childWorkflowRuns, taskById]);

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -146,15 +146,16 @@ const childWorkflowRunInfoSchema = type({
 	name: "string > 0",
 	versionId: "string > 0",
 	inputHash: "string > 0",
-	waits: type({
-		timeouts: type({
-			timedOutAt: "number > 0",
-		}).array(),
-		"terminal?": type({
-			state: terminalWorkflowRunStateSchema,
-			completedAt: "number > 0",
-		}).or("undefined"),
-	}),
+});
+
+const childWorkflowRunWaitsSchema = type({
+	timeouts: type({
+		timedOutAt: "number > 0",
+	}).array(),
+	"terminal?": type({
+		state: terminalWorkflowRunStateSchema,
+		completedAt: "number > 0",
+	}).or("undefined"),
 });
 
 export const workflowRunRecordSchema = type({
@@ -176,6 +177,7 @@ export const workflowRunRecordSchema = type({
 	sleeps: type({ "[string]": sleepSchema.array() }),
 	eventWaits: type({ "[string]": eventWaitSchema.array() }),
 	childWorkflowRuns: type({ "[string]": childWorkflowRunInfoSchema.array() }),
+	childWorkflowRunWaits: type({ "[string]": childWorkflowRunWaitsSchema }),
 	"parentWorkflowRunId?": "string > 0 | undefined",
 });
 

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
@@ -1,0 +1,410 @@
+import { noopLogger } from "@aikirun/lib/logger";
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+import {
+	processImminentChildRunWaitTimedOutRuns,
+	queueChildRunWaitTimedOutRuns,
+} from "./imminent-child-run-wait-timed-out-runs";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { computeRank } from "../lib/rank";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createWorkflowRunStateMachine } from "../service/state-machine/workflow-run";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness, type DaemonHarnessDeps } from "../testing/harness";
+import { seedClaimedRun, seedScheduledRun } from "../testing/seed/run";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build();
+
+const EPOCH_MS = 1 as TimestampMs;
+const ONE_HOUR_MS = 1 * 60 * 60 * 1000;
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+// Creates a running parent, creates a scheduled child under it, and parks the parent on that child.
+async function parkParentOnChild(deps: DaemonHarnessDeps, params?: { timeoutInMs?: number }) {
+	const { context, repos, publisher } = deps;
+	const parent = await seedClaimedRun({ daemonContext: context, namespaceRequestContext, repos, publisher });
+	const child = await seedScheduledRun(
+		{ namespaceRequestContext, repos },
+		{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+	);
+
+	const stateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller: createChildRunCanceller() });
+	const parked = await stateMachine.transitionState(namespaceRequestContext, {
+		type: "optimistic",
+		id: parent.runId,
+		state: {
+			status: "awaiting_child_workflow",
+			childWorkflowRunId: child.runId,
+			timeoutInMs: params?.timeoutInMs,
+		},
+		expectedRevision: parent.revisionWhenClaimed,
+		expectedSignalSequence: 0,
+	});
+
+	return {
+		parentRunId: parent.runId,
+		childRunId: child.runId,
+		attemptsWhenClaimed: parent.attemptsWhenClaimed,
+		revisionWhenParked: parked.revision,
+		workflowSource: parent.workflowSource,
+		workflowName: parent.workflowName,
+		workflowVersionId: parent.workflowVersionId,
+	};
+}
+
+describe("processImminentChildRunWaitTimedOutRuns", () => {
+	test("queues a parent whose child wait timed out", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			// Parked at the epoch with a 1ms timeout: the deadline is overdue for any daemon
+			// pass under the real clock.
+			const { parentRunId, revisionWhenParked } = await withFakeClock(EPOCH_MS, () =>
+				parkParentOnChild(deps, { timeoutInMs: 1 })
+			);
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentRunId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: parentRunId, status: "queued", revision: revisionWhenParked + 1 }),
+					state: { status: "queued", reason: "child_workflow_wait_timeout" },
+				})
+			);
+		}));
+
+	test("records the timed-out wait without a terminal outcome for the child", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const { parentRunId, childRunId } = await withFakeClock(EPOCH_MS, () =>
+				parkParentOnChild(deps, { timeoutInMs: 1 })
+			);
+
+			const timedOutAt = Date.now() as TimestampMs;
+			await withFakeClock(timedOutAt, () =>
+				processImminentChildRunWaitTimedOutRuns(
+					context,
+					{ repos },
+					{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				)
+			);
+
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parentRunId)).toEqual([
+				expect.objectContaining({
+					parentWorkflowRunId: parentRunId,
+					childWorkflowRunId: childRunId,
+					status: "timeout",
+					timedOutAt,
+					completedAt: null,
+					childWorkflowRunStatus: null,
+					childWorkflowRunStateTransitionId: null,
+					childWorkflowRunState: null,
+				}),
+			]);
+		}));
+
+	test("mints a fresh pending outbox row ranked at the wait's deadline", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const { parentRunId, workflowSource, workflowName, workflowVersionId } = await withFakeClock(EPOCH_MS, () =>
+				parkParentOnChild(deps, { timeoutInMs: 1 })
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: parentRunId,
+				})
+			).toBeNull();
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: parentRunId,
+				})
+			).toEqual(
+				expect.objectContaining({
+					workflowRunId: parentRunId,
+					status: "pending",
+					workflowSource,
+					workflowName,
+					workflowVersionId,
+					// computeRank(timeoutAt = EPOCH_MS + 1, default priority 9) = 2 * 10 + 9.
+					rank: 29,
+					nextPublishAttemptRank: 29,
+				})
+			);
+		}));
+
+	test("charges no execution attempt for the timed-out wait", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const { parentRunId, attemptsWhenClaimed } = await withFakeClock(EPOCH_MS, () =>
+				parkParentOnChild(deps, { timeoutInMs: 1 })
+			);
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentRunId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: parentRunId, status: "queued", attempts: attemptsWhenClaimed }),
+				})
+			);
+		}));
+
+	test("publishes the fresh outbox row when a publisher is wired", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { parentRunId } = await withFakeClock(EPOCH_MS, () => parkParentOnChild(deps, { timeoutInMs: 1 }));
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos, publisher },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: parentRunId,
+				})
+			).toEqual(expect.objectContaining({ workflowRunId: parentRunId, status: "published" }));
+		}));
+
+	test("leaves a parent whose deadline has not passed parked", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const { parentRunId, revisionWhenParked } = await parkParentOnChild(deps, { timeoutInMs: ONE_HOUR_MS });
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentRunId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parentRunId,
+						status: "awaiting_child_workflow",
+						revision: revisionWhenParked,
+					}),
+				})
+			);
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parentRunId)).toEqual([]);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: parentRunId,
+				})
+			).toBeNull();
+		}));
+
+	test("never times out a wait parked without a deadline", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			// Parked at the epoch: any deadline this old would be overdue — only the absent
+			// timeout spares the parent.
+			const { parentRunId, revisionWhenParked } = await withFakeClock(EPOCH_MS, () => parkParentOnChild(deps));
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentRunId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parentRunId,
+						status: "awaiting_child_workflow",
+						revision: revisionWhenParked,
+					}),
+				})
+			);
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parentRunId)).toEqual([]);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: parentRunId,
+				})
+			).toBeNull();
+		}));
+
+	test("queues the due wait and hands the imminent one to the timer priority queue", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const due = await withFakeClock(EPOCH_MS, () => parkParentOnChild(deps, { timeoutInMs: 1 }));
+
+			const parkedAt = Date.now() as TimestampMs;
+			const imminent = await withFakeClock(parkedAt, () => parkParentOnChild(deps, { timeoutInMs: ONE_HOUR_MS }));
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// Frozen at the park instant: the due wait's deadline is behind now, the imminent
+			// one an hour ahead but inside the two-hour lookahead window.
+			await withFakeClock(parkedAt, () =>
+				processImminentChildRunWaitTimedOutRuns(
+					context,
+					{ repos, timerPriorityQueue },
+					{ limit: 100, lookaheadWindowMs: 2 * ONE_HOUR_MS, republishBackoff }
+				)
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{
+					type: "child_wait_timeout",
+					id: imminent.parentRunId,
+					rank: computeRank({ dueAt: parkedAt + ONE_HOUR_MS }),
+				},
+			]);
+
+			const dueRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: due.parentRunId,
+			});
+			expect(dueRun).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: due.parentRunId, status: "queued" }),
+					state: { status: "queued", reason: "child_workflow_wait_timeout" },
+				})
+			);
+
+			const imminentRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: imminent.parentRunId,
+			});
+			expect(imminentRun).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: imminent.parentRunId,
+						status: "awaiting_child_workflow",
+						revision: imminent.revisionWhenParked,
+					}),
+				})
+			);
+		}));
+
+	test("drains every due wait when they outnumber the limit", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const parked = await withFakeClock(EPOCH_MS, async () => [
+				await parkParentOnChild(deps, { timeoutInMs: 1 }),
+				await parkParentOnChild(deps, { timeoutInMs: 1 }),
+				await parkParentOnChild(deps, { timeoutInMs: 1 }),
+			]);
+
+			await processImminentChildRunWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 2, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			for (const { parentRunId } of parked) {
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: parentRunId,
+				});
+				expect(run).toEqual(
+					expect.objectContaining({ run: expect.objectContaining({ id: parentRunId, status: "queued" }) })
+				);
+			}
+		}));
+});
+
+describe("queueChildRunWaitTimedOutRuns", () => {
+	test("skips a parent that moved after the listing without holding back the rest of the batch", () =>
+		withHarness(async (deps) => {
+			const { context, repos } = deps;
+			const parentA = await withFakeClock(EPOCH_MS, () => parkParentOnChild(deps, { timeoutInMs: 1 }));
+			const parentB = await withFakeClock(EPOCH_MS, () => parkParentOnChild(deps, { timeoutInMs: 1 }));
+
+			const listedRuns = await repos.workflowRun.listChildRunWaitTimedOutRuns(context, Date.now() as TimestampMs, 100);
+			expect(listedRuns.map((run) => run.id).sort()).toEqual([parentA.parentRunId, parentB.parentRunId].sort());
+
+			const rankedRuns = listedRuns.map((run) => ({ ...run, rank: computeRank({ dueAt: run.dueAt }) }));
+			const listedA = rankedRuns.find((run) => run.id === parentA.parentRunId);
+			const listedB = rankedRuns.find((run) => run.id === parentB.parentRunId);
+			if (!listedA || !listedB) {
+				throw new Error("Both parked parents must be listed as due");
+			}
+
+			// The first pass queues A, moving it past the listing's revision snapshot.
+			await queueChildRunWaitTimedOutRuns(context, repos, undefined, republishBackoff, [listedA]);
+
+			// The replayed batch still carries A at its parked revision — the race the
+			// revision guard settles.
+			await queueChildRunWaitTimedOutRuns(context, repos, undefined, republishBackoff, [listedA, listedB]);
+
+			// A keeps the single first-pass timeout row and the single revision bump.
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parentA.parentRunId)).toEqual([
+				expect.objectContaining({ parentWorkflowRunId: parentA.parentRunId, status: "timeout" }),
+			]);
+			const runA = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentA.parentRunId,
+			});
+			expect(runA).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parentA.parentRunId,
+						status: "queued",
+						revision: parentA.revisionWhenParked + 1,
+					}),
+				})
+			);
+
+			// B, untouched by the first pass, is queued by the second.
+			const runB = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: parentB.parentRunId,
+			});
+			expect(runB).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: parentB.parentRunId,
+						status: "queued",
+						revision: parentB.revisionWhenParked + 1,
+					}),
+					state: { status: "queued", reason: "child_workflow_wait_timeout" },
+				})
+			);
+			expect(await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parentB.parentRunId)).toEqual([
+				expect.objectContaining({ parentWorkflowRunId: parentB.parentRunId, status: "timeout" }),
+			]);
+		}));
+});

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -546,7 +546,9 @@ async function cancelPreviousAndInsertRunsInTx(
 			await txRepos.workflowRun.bulkSetLatestStateTransitionId(cancelledRunStateTransitionIdUpdates);
 		}
 		if (isNonEmptyArray(cancelledRunsHavingParent)) {
-			await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, context.logger);
+			// No imminent timer queue: schedule occurrences have no parents today, so this wakes
+			// nobody. If occurrences ever gain parents, thread the queue through the daemon deps.
+			await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, context.logger, undefined);
 		}
 		if (isNonEmptyArray(cancelledRunsMeta)) {
 			await childRunCanceller.cancel(cancelledRunsMeta, txRepos, context.logger);

--- a/sdk/server/src/infra/db/pg/repository/lib/keyset-stream.ts
+++ b/sdk/server/src/infra/db/pg/repository/lib/keyset-stream.ts
@@ -1,4 +1,4 @@
-import { and, gt, or, type SQL, sql } from "drizzle-orm";
+import { and, Column, gt, or, type SQL, sql } from "drizzle-orm";
 import type { PgColumn } from "drizzle-orm/pg-core";
 
 import type { KeysetStreamCursor } from "../../../../../lib/keyset-stream";
@@ -22,9 +22,12 @@ export function keysetStreamCursorFilter(
 	if (!cursor) {
 		return undefined;
 	}
+	// A raw `sql` param skips the column's driver mapping, so apply it here when the order
+	// column has one — a timestamp column binds an ISO string, not the ms number.
+	const order = orderCol instanceof Column ? orderCol.mapToDriverValue(cursor.order) : cursor.order;
 	return or(
-		sql`${orderCol} > ${cursor.order}`,
-		and(sql`${orderCol} = ${cursor.order}`, gt(idCol, cursor.id)),
-		and(sql`${orderCol} < ${cursor.order}`, gt(idCol, cursor.maxSeenId))
+		sql`${orderCol} > ${order}`,
+		and(sql`${orderCol} = ${order}`, gt(idCol, cursor.id)),
+		and(sql`${orderCol} < ${order}`, gt(idCol, cursor.maxSeenId))
 	);
 }

--- a/sdk/server/src/infra/db/workflow-run.integration.test.ts
+++ b/sdk/server/src/infra/db/workflow-run.integration.test.ts
@@ -1,10 +1,13 @@
 import type { TimestampMs } from "@aikirun/lib/timestamp";
+import type { FakePublisher } from "@aikirun/testing/infra/queue";
 import type { WaitingForSignalWorkflowRunStatus, WorkflowRunId } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import type { Repositories } from "./types";
 import type { DueWorkflowRun } from "./types/workflow-run";
 import { describe, expect, test } from "bun:test";
+import type { NamespaceRequestContext } from "../../middleware/context";
+import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../../testing/harness";
 import { seedAwaitingEventRun, seedClaimedRun, seedCompletedRun } from "../../testing/seed/run";
@@ -452,5 +455,121 @@ describe("incrementSignalSequence", () => {
 					id: "run-missing" as WorkflowRunId,
 				})
 			).toBeNull();
+		}));
+});
+
+// Seeds a claimed run with its ulid minted at the frozen `mintedAtMs` — later instants mint
+// larger ids, pinning the id order the cursor walk depends on — then parks it on a child wait
+// due at `timeoutAt`.
+async function parkRunOnChildWait(
+	deps: { context: NamespaceRequestContext; repos: Repositories; publisher: FakePublisher },
+	params: { mintedAtMs: TimestampMs; timeoutAt: TimestampMs }
+): Promise<string> {
+	const { context, repos, publisher } = deps;
+	const { runId, revisionWhenClaimed } = await withFakeClock(params.mintedAtMs, () =>
+		seedClaimedRun({ namespaceRequestContext: context, repos, publisher })
+	);
+
+	await repos.workflowRun.update({
+		waitForSignal: true,
+		filter: {
+			namespaceId: context.namespaceId,
+			id: runId as WorkflowRunId,
+			revision: revisionWhenClaimed,
+			signalSequence: 0,
+		},
+		updates: {
+			attempts: 1,
+			latestStateTransitionId: ulid(),
+			onSignalSequenceMatch: { status: "awaiting_child_workflow", timeoutAt: params.timeoutAt },
+			onSignalSequenceMismatch: { status: "scheduled", scheduledAt: Date.now() as TimestampMs },
+		},
+	});
+
+	return runId;
+}
+
+describe("listChildRunWaitTimedOutRuns cursor paging", () => {
+	test("resumes past the frontier to later deadlines", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const deps = { context, repos, publisher };
+			const runA = await parkRunOnChildWait(deps, {
+				mintedAtMs: 1_000 as TimestampMs,
+				timeoutAt: 1_000_000 as TimestampMs,
+			});
+			const runB = await parkRunOnChildWait(deps, {
+				mintedAtMs: 2_000 as TimestampMs,
+				timeoutAt: 2_000_000 as TimestampMs,
+			});
+			const runC = await parkRunOnChildWait(deps, {
+				mintedAtMs: 3_000 as TimestampMs,
+				timeoutAt: 3_000_000 as TimestampMs,
+			});
+
+			const daemonContext = daemonContextFactory.build();
+			const before = 3_000_000 as TimestampMs;
+
+			expect(await repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContext, before, 2)).toEqual([
+				expect.objectContaining({ id: runA, dueAt: 1_000_000 }),
+				expect.objectContaining({ id: runB, dueAt: 2_000_000 }),
+			]);
+
+			expect(
+				await repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContext, before, 2, {
+					order: 2_000_000,
+					id: runB,
+					maxSeenId: runB,
+				})
+			).toEqual([expect.objectContaining({ id: runC, dueAt: 3_000_000 })]);
+		}));
+
+	test("splits deadline ties by id across pages", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const deps = { context, repos, publisher };
+			const sharedDeadline = 1_000_000 as TimestampMs;
+			const runA = await parkRunOnChildWait(deps, { mintedAtMs: 1_000 as TimestampMs, timeoutAt: sharedDeadline });
+			const runB = await parkRunOnChildWait(deps, { mintedAtMs: 2_000 as TimestampMs, timeoutAt: sharedDeadline });
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(await repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContext, sharedDeadline, 1)).toEqual([
+				expect.objectContaining({ id: runA, dueAt: sharedDeadline }),
+			]);
+
+			expect(
+				await repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContext, sharedDeadline, 1, {
+					order: sharedDeadline,
+					id: runA,
+					maxSeenId: runA,
+				})
+			).toEqual([expect.objectContaining({ id: runB, dueAt: sharedDeadline })]);
+		}));
+
+	test("returns a run behind the frontier when its id is newer than any seen", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const deps = { context, repos, publisher };
+			// Already-walked bystander: due behind the frontier with an id below maxSeenId, so
+			// the late-insert clause must not resurrect it.
+			await parkRunOnChildWait(deps, { mintedAtMs: 1_000 as TimestampMs, timeoutAt: 1_000_000 as TimestampMs });
+			const runB = await parkRunOnChildWait(deps, {
+				mintedAtMs: 2_000 as TimestampMs,
+				timeoutAt: 2_000_000 as TimestampMs,
+			});
+			// Minted after the walk passed its deadline: due behind the frontier, ulid above
+			// maxSeenId — the late insert the third clause exists for.
+			const lateRun = await parkRunOnChildWait(deps, {
+				mintedAtMs: 3_000 as TimestampMs,
+				timeoutAt: 1_500_000 as TimestampMs,
+			});
+
+			const daemonContext = daemonContextFactory.build();
+
+			expect(
+				await repos.workflowRun.listChildRunWaitTimedOutRuns(daemonContext, 3_000_000 as TimestampMs, 10, {
+					order: 2_000_000,
+					id: runB,
+					maxSeenId: runB,
+				})
+			).toEqual([expect.objectContaining({ id: lateRun, dueAt: 1_500_000 })]);
 		}));
 });

--- a/sdk/server/src/lib/keyset-stream.test.ts
+++ b/sdk/server/src/lib/keyset-stream.test.ts
@@ -1,0 +1,55 @@
+import { createKeysetStreamCursorAdvancer } from "./keyset-stream";
+import { describe, expect, test } from "bun:test";
+
+const advanceCursor = createKeysetStreamCursorAdvancer<{ order: number; id: string }>({
+	getOrder: (item) => item.order,
+	getId: (item) => item.id,
+});
+
+describe("createKeysetStreamCursorAdvancer", () => {
+	test("the first row initializes the cursor", () => {
+		expect(advanceCursor(undefined, { order: 100, id: "id-2" })).toEqual({
+			order: 100,
+			id: "id-2",
+			maxSeenId: "id-2",
+		});
+	});
+
+	test("a row past the frontier moves the frontier onto it", () => {
+		const cursor = { order: 100, id: "id-1", maxSeenId: "id-1" };
+		expect(advanceCursor(cursor, { order: 200, id: "id-2" })).toEqual({
+			order: 200,
+			id: "id-2",
+			maxSeenId: "id-2",
+		});
+	});
+
+	test("a row tied with the frontier's order still moves the frontier", () => {
+		const cursor = { order: 100, id: "id-1", maxSeenId: "id-1" };
+		expect(advanceCursor(cursor, { order: 100, id: "id-2" })).toEqual({
+			order: 100,
+			id: "id-2",
+			maxSeenId: "id-2",
+		});
+	});
+
+	test("a late-inserted row behind the frontier grows only maxSeenId", () => {
+		const cursor = { order: 200, id: "id-2", maxSeenId: "id-2" };
+		expect(advanceCursor(cursor, { order: 100, id: "id-3" })).toEqual({
+			order: 200,
+			id: "id-2",
+			maxSeenId: "id-3",
+		});
+	});
+
+	test("maxSeenId does not shrink when the frontier moves onto an older id", () => {
+		// maxSeenId can sit above the frontier id: an earlier late-inserted row raised it
+		// to id-9 while leaving the frontier at (100, id-1).
+		const cursor = { order: 100, id: "id-1", maxSeenId: "id-9" };
+		expect(advanceCursor(cursor, { order: 200, id: "id-2" })).toEqual({
+			order: 200,
+			id: "id-2",
+			maxSeenId: "id-9",
+		});
+	});
+});

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -12,6 +12,7 @@ import { ulid } from "ulidx";
 
 import type { TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 
 export interface TerminatedChildRun {
 	namespaceId: NamespaceId;
@@ -31,7 +32,8 @@ export async function deliverTerminatedSignalToParentRun(
 	runs: NonEmptyArray<TerminatedChildRun>,
 	now: TimestampMs,
 	txRepos: TxRepositories,
-	logger: Logger
+	logger: Logger,
+	imminentRunTimerQueue: ImminentRunTimerQueue | undefined
 ): Promise<void> {
 	await txRepos.childWorkflowRunWait.insert(
 		runs.map((run) => ({
@@ -128,6 +130,12 @@ export async function deliverTerminatedSignalToParentRun(
 	}
 	if (isNonEmptyArray(parentRunStateTransitionEntriesToInsert)) {
 		await txRepos.stateTransition.appendBatch(parentRunStateTransitionEntriesToInsert);
+	}
+
+	if (imminentRunTimerQueue) {
+		txRepos.onCommit(() =>
+			imminentRunTimerQueue.add(asNonEmptyArray(scheduledParentRunIds.map((id) => ({ id, scheduledAt: now }))))
+		);
 	}
 
 	logger.info("Woke parents parked on terminal children", { "aiki.parentRunIds": scheduledParentRunIds });

--- a/sdk/server/src/service/event.integration.test.ts
+++ b/sdk/server/src/service/event.integration.test.ts
@@ -1,10 +1,15 @@
+import { asConfigProvider } from "@aikirun/lib/config";
 import { NotFoundError } from "@aikirun/lib/error";
+import { noopLogger } from "@aikirun/lib/logger";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
 import { createWorkflowRunStateMachine } from "./state-machine/workflow-run";
 import { describe, expect, test } from "bun:test";
 import type { Repositories } from "../infra/db/types";
+import { createImminentRunTimerQueue, type ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
+import { computeRank } from "../lib/rank";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
 import { createEventService } from "../service/event";
 import { withFakeClock } from "../testing/clock";
@@ -13,9 +18,9 @@ import { seedAwaitingEventRun, seedClaimedRun, seedSleepingRun } from "../testin
 
 const withHarness = createServiceHarness();
 
-function createService(repos: Repositories) {
+function createService(repos: Repositories, imminentRunTimerQueue?: ImminentRunTimerQueue) {
 	const childRunCanceller = createChildRunCanceller();
-	const workflowRunStateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller });
+	const workflowRunStateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller, imminentRunTimerQueue });
 	return createEventService({ repos, workflowRunStateMachine });
 }
 
@@ -128,6 +133,38 @@ describe("EventService sendEventToWorkflowRun waking a parked run", () => {
 					state: { status: "scheduled", reason: "event", scheduledAt: sentAt },
 				})
 			);
+		}));
+
+	test("adds the woken run's timer to the priority queue", () =>
+		withHarness(async ({ repos, context, publisher }) => {
+			const { runId } = await seedAwaitingEventRun(
+				{ repos, namespaceRequestContext: context, publisher },
+				{ eventName: "orderShipped" }
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const eventService = createService(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const sentAt = Date.now() as TimestampMs;
+			await withFakeClock(sentAt, () =>
+				eventService.sendEventToWorkflowRun(context, {
+					runId: runId as WorkflowRunId,
+					eventName: "orderShipped",
+					data: { trackingId: "TRK-1" },
+					reference: undefined,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: sentAt }) },
+			]);
 		}));
 
 	test("leaves a run parked on a different event name parked", () =>

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -1,3 +1,4 @@
+import { createBinaryLatch } from "@aikirun/lib/async";
 import { asConfigProvider } from "@aikirun/lib/config";
 import { NotFoundError } from "@aikirun/lib/error";
 import { noopLogger } from "@aikirun/lib/logger";
@@ -10,12 +11,12 @@ import { describe, expect, test } from "bun:test";
 import { processImminentScheduledRuns } from "../../daemon/imminent-scheduled-runs";
 import { processImminentSleepElapsedRuns } from "../../daemon/imminent-sleep-elapsed-runs";
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../../errors";
-import type { Repositories } from "../../infra/db/types";
+import type { Repositories, TxRepositories } from "../../infra/db/types";
 import { createImminentRunTimerQueue, type ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
 import { computeRank } from "../../lib/rank";
 import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
-import { createServiceHarness } from "../../testing/harness";
+import { createServiceHarness, withRepos } from "../../testing/harness";
 import { claimRun, seedClaimedRun, seedCompletedRun, seedScheduledRun, seedStalledRun } from "../../testing/seed/run";
 import { createChildRunCanceller } from "../cancel-child-runs";
 import { createEventService } from "../event";
@@ -604,6 +605,83 @@ describe("WorkflowRunStateMachine redelivery", () => {
 });
 
 describe("WorkflowRunStateMachine signal sequence guarded parking", () => {
+	test("an event committing between the park's read and its guarded write reschedules instead of parking", () =>
+		withHarness(async ({ context, repos, publisher }) =>
+			withRepos(async (secondaryRepos) => {
+				const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
+					namespaceRequestContext: context,
+					repos,
+					publisher,
+				});
+
+				const parkReachedGuardedWrite = createBinaryLatch();
+				const eventCommitted = createBinaryLatch();
+
+				const stateMachine = createStateMachine(repos);
+				const parkedAt = Date.now();
+				const result = await withFakeClock(parkedAt, async () => {
+					// The park pauses at its guarded write, after its read and revision precheck
+					// have passed — the window the send lands in.
+					const parkPromise = repos.transaction(async (txRepos) => {
+						const pausingTxRepos: TxRepositories = {
+							...txRepos,
+							workflowRun: {
+								...txRepos.workflowRun,
+								update: async (params) => {
+									parkReachedGuardedWrite.signal();
+									await eventCommitted.wait();
+									return txRepos.workflowRun.update(params);
+								},
+							},
+						};
+
+						return stateMachine.transitionState(
+							context,
+							{
+								type: "optimistic",
+								id: runId,
+								state: { status: "awaiting_event", eventName: "paymentReceived" },
+								expectedRevision: revisionWhenClaimed,
+								expectedSignalSequence: 0,
+							},
+							pausingTxRepos
+						);
+					});
+					await parkReachedGuardedWrite.wait();
+
+					await createEventService({
+						repos: secondaryRepos,
+						workflowRunStateMachine: createStateMachine(secondaryRepos),
+					}).sendEventToWorkflowRun(context, {
+						runId: runId as WorkflowRunId,
+						eventName: "paymentReceived",
+						data: { amount: 25 },
+						reference: undefined,
+					});
+					eventCommitted.signal();
+
+					return parkPromise;
+				});
+
+				expect(result).toEqual({
+					revision: revisionWhenClaimed + 1,
+					state: { status: "scheduled", reason: "event", scheduledAt: parkedAt },
+					attempts: attemptsWhenClaimed,
+				});
+
+				const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+				expect(run).toEqual(
+					expect.objectContaining({
+						run: expect.objectContaining({ id: runId, status: "scheduled", revision: result.revision }),
+						state: { status: "scheduled", reason: "event", scheduledAt: parkedAt },
+					})
+				);
+				expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+					expect.objectContaining({ workflowRunId: runId, name: "paymentReceived", status: "received" }),
+				]);
+			})
+		));
+
 	test("a park with the run's current signal sequence parks it", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedClaimedRun({
@@ -892,7 +970,7 @@ describe("WorkflowRunStateMachine child terminal signals", () => {
 				);
 			}));
 
-		test(`a child reaching ${status} wakes a parent parked on it`, () =>
+		test(`a child reaching ${status} wakes a parent parked on it and adds its timer to the priority queue`, () =>
 			withHarness(async ({ context, repos, publisher }) => {
 				const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
 				const child = await seedClaimedRun(
@@ -900,7 +978,15 @@ describe("WorkflowRunStateMachine child terminal signals", () => {
 					{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
 				);
 
-				const stateMachine = createStateMachine(repos);
+				const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+				const stateMachine = createStateMachine(
+					repos,
+					createImminentRunTimerQueue({
+						timerPriorityQueue,
+						configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+						logger: noopLogger,
+					})
+				);
 				const parked = await stateMachine.transitionState(context, {
 					type: "optimistic",
 					id: parent.runId,
@@ -927,6 +1013,9 @@ describe("WorkflowRunStateMachine child terminal signals", () => {
 						state: { status: "scheduled", reason: "child_workflow", scheduledAt: childTerminatedAt },
 					})
 				);
+				expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+					{ type: "scheduled", id: parent.runId, rank: computeRank({ dueAt: childTerminatedAt }) },
+				]);
 			}));
 	}
 });

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -263,7 +263,8 @@ async function transitionStateInTx(
 			],
 			now,
 			txRepos,
-			context.logger
+			context.logger,
+			imminentRunTimerQueue
 		);
 	}
 

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -300,6 +300,35 @@ describe("WorkflowRunService cancelByIds", () => {
 			);
 		}));
 
+	test("cancelling a child adds the woken parent's timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service, stateMachine } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: parent.runId,
+				state: { status: "awaiting_child_workflow", childWorkflowRunId: child.runId },
+				expectedRevision: parent.revisionWhenClaimed,
+				expectedSignalSequence: 0,
+			});
+
+			const cancelledAt = Date.now();
+			await withFakeClock(cancelledAt, () => service.cancelByIds(context, { ids: [child.runId] }));
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: parent.runId, rank: computeRank({ dueAt: cancelledAt }) },
+			]);
+		}));
+
 	test("cancelling a child wakes a parent parked on it", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -288,7 +288,9 @@ export const createWorkflowRunService = ({
 			return { cancelledIds: [] };
 		}
 
-		return repos.transaction(async (txRepos) => cancelByIdsInTx(context, ids, txRepos, childRunCanceller));
+		return repos.transaction(async (txRepos) =>
+			cancelByIdsInTx(context, ids, txRepos, childRunCanceller, imminentRunTimerQueue)
+		);
 	},
 
 	async hasTerminated(context: NamespaceRequestContext, runId: string, afterStateTransitionId: string) {
@@ -412,7 +414,8 @@ async function cancelByIdsInTx(
 	context: NamespaceRequestContext,
 	ids: NonEmptyArray<string>,
 	txRepos: TxRepositories,
-	childRunCanceller: ChildRunCanceller
+	childRunCanceller: ChildRunCanceller,
+	imminentRunTimerQueue?: ImminentRunTimerQueue
 ) {
 	const { namespaceId, logger } = context;
 	const cancelledRuns = await txRepos.workflowRun.bulkTransitionToCancelledInNamespace(namespaceId, ids);
@@ -467,7 +470,7 @@ async function cancelByIdsInTx(
 	}
 
 	if (isNonEmptyArray(cancelledRunsHavingParent)) {
-		await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, logger);
+		await deliverTerminatedSignalToParentRun(cancelledRunsHavingParent, now, txRepos, logger, imminentRunTimerQueue);
 	}
 
 	if (isNonEmptyArray(cancelledRunsMeta)) {
@@ -516,7 +519,8 @@ async function getWorkflowRun(
 		tasks: buildTasksByAddress(taskRows),
 		sleeps: buildSleepsByName(sleepRows),
 		eventWaits: buildEventWaitsByName(eventWaitRows),
-		childWorkflowRuns: buildChildWorkflowRunsByAddress(childRunRows, childWorkflowRunWaitRows),
+		childWorkflowRuns: buildChildWorkflowRunsByAddress(childRunRows),
+		childWorkflowRunWaits: buildChildWorkflowRunWaitsByRunId(childWorkflowRunWaitRows),
 		parentWorkflowRunId: run.parentWorkflowRunId ?? undefined,
 		scheduleId: run.scheduleId ?? undefined,
 	};
@@ -629,19 +633,18 @@ function buildEventWaitsByName(eventWaitRows: EventWaitRow[]): Record<string, Ev
 	return eventWaitsByName;
 }
 
-function buildChildWorkflowRunsByAddress(
-	childRuns: ChildRunWithWorkflow[],
+function buildChildWorkflowRunWaitsByRunId(
 	childRunWaits: ChildRunWaitWithState[]
-): Record<string, ChildWorkflowRunInfo[]> {
-	const waitsByChildRunId = new Map<WorkflowRunId, ChildWorkflowRunWaits>();
+): Record<string, ChildWorkflowRunWaits> {
+	const waitsByChildRunId: Record<string, ChildWorkflowRunWaits> = {};
 
 	for (const childRunWait of childRunWaits) {
-		const childRunId = childRunWait.childWorkflowRunId as WorkflowRunId;
+		const childRunId = childRunWait.childWorkflowRunId;
 
-		let waits = waitsByChildRunId.get(childRunId);
+		let waits = waitsByChildRunId[childRunId];
 		if (!waits) {
 			waits = { timeouts: [] };
-			waitsByChildRunId.set(childRunId, waits);
+			waitsByChildRunId[childRunId] = waits;
 		}
 
 		switch (childRunWait.status) {
@@ -671,6 +674,10 @@ function buildChildWorkflowRunsByAddress(
 		}
 	}
 
+	return waitsByChildRunId;
+}
+
+function buildChildWorkflowRunsByAddress(childRuns: ChildRunWithWorkflow[]): Record<string, ChildWorkflowRunInfo[]> {
 	const childRunsByAddress: Record<string, ChildWorkflowRunInfo[]> = {};
 
 	for (const { run: childRun, workflow: childWorkflow } of childRuns) {
@@ -685,7 +692,6 @@ function buildChildWorkflowRunsByAddress(
 			name: childWorkflow.name,
 			versionId: childWorkflow.versionId,
 			inputHash: childRun.inputHash,
-			waits: waitsByChildRunId.get(childRun.id as WorkflowRunId) ?? { timeouts: [] },
 		};
 
 		const addressChildRuns = childRunsByAddress[childRunAddress];

--- a/sdk/workflow/src/run/event.test.ts
+++ b/sdk/workflow/src/run/event.test.ts
@@ -45,7 +45,6 @@ describe("createEventWaiters", () => {
 			});
 			const definition = { orderShipped: event<{ trackingId: string }>() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 
 			const waiters = createEventWaiters(handle, definition, client.logger);
 
@@ -59,7 +58,6 @@ describe("createEventWaiters", () => {
 			});
 			const definition = { orderShipped: event() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 
 			const waiters = createEventWaiters(handle, definition, client.logger);
 
@@ -73,7 +71,6 @@ describe("createEventWaiters", () => {
 			});
 			const definition = { orderShipped: event({ schema: appendBangSchema }) };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 
 			const waiters = createEventWaiters(handle, definition, client.logger);
 
@@ -85,7 +82,6 @@ describe("createEventWaiters", () => {
 			const record = runningWorkflowRunRecordFactory.build({ revision: 0 });
 			const definition = { orderShipped: event() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 			client.api.workflowRun.transitionStateV1.once(
 				{
 					type: "optimistic",
@@ -107,7 +103,6 @@ describe("createEventWaiters", () => {
 			const record = runningWorkflowRunRecordFactory.build({ revision: 0 });
 			const definition = { orderShipped: event() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 			client.api.workflowRun.transitionStateV1.once(
 				{
 					type: "optimistic",
@@ -129,7 +124,6 @@ describe("createEventWaiters", () => {
 			const record = runningWorkflowRunRecordFactory.build({ revision: 0 });
 			const definition = { orderShipped: event() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: record });
 			client.api.workflowRun.transitionStateV1.rejectsOnce(
 				{
 					type: "optimistic",
@@ -158,9 +152,6 @@ describe("createEventWaiters", () => {
 			});
 			const definition = { orderShipped: event<string>() };
 			const handle = workflowRunHandle(client, record, definition);
-			client.api.workflowRun.getByIdV1
-				.once({ id: record.id }, { run: record })
-				.once({ id: record.id }, { run: record });
 
 			const waiters = createEventWaiters(handle, definition, client.logger);
 

--- a/sdk/workflow/src/run/event.ts
+++ b/sdk/workflow/src/run/event.ts
@@ -138,8 +138,6 @@ function createEventWaiter<TEvents extends EventsDefinition, Data>(
 	async function wait(options?: EventWaitOptions<false>): Promise<EventWaitResult<Data, false>>;
 	async function wait(options: EventWaitOptions<true>): Promise<EventWaitResult<Data, true>>;
 	async function wait(options?: EventWaitOptions<boolean>): Promise<EventWaitResult<Data, boolean>> {
-		await handle.refresh();
-
 		const eventWaits = handle.run.eventWaits[eventName] ?? [];
 
 		const existingEventWait = eventWaits[nextIndex] as EventWait<Data> | undefined;

--- a/sdk/workflow/src/run/handle-child.test.ts
+++ b/sdk/workflow/src/run/handle-child.test.ts
@@ -1,30 +1,26 @@
 import { withFakeClient } from "@aikirun/testing/client";
 import { runningWorkflowRunRecordFactory, workflowRunStateByStatus } from "@aikirun/testing/data-factory/workflow/run";
-import type { ChildWorkflowRunWaits } from "@aikirun/types/workflow/run";
 import { WorkflowRunSuspendedError } from "@aikirun/types/workflow/run";
 
 import { workflowRunHandle } from "./handle";
 import { childWorkflowRunHandle } from "./handle-child";
 import { describe, expect, test } from "bun:test";
 
-function childWaits(waits: Partial<ChildWorkflowRunWaits>): ChildWorkflowRunWaits {
-	return {
-		timeouts: waits.timeouts ?? [],
-		...(waits.terminal !== undefined ? { terminal: waits.terminal } : {}),
-	};
-}
-
 describe("childWorkflowRunHandle", () => {
 	describe("wait", () => {
 		test("resolves with the child's terminal state", () =>
 			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
-				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({
-					terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: {
+						[childRecord.id]: {
+							timeouts: [],
+							terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
+						},
+					},
 				});
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				expect(await childHandle.wait()).toEqual({
 					success: true,
@@ -34,16 +30,20 @@ describe("childWorkflowRunHandle", () => {
 
 		test("resolves with whatever terminal state the child reached", () =>
 			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
-				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({
-					terminal: {
-						state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
-						completedAt: 1_000,
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: {
+						[childRecord.id]: {
+							timeouts: [],
+							terminal: {
+								state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+								completedAt: 1_000,
+							},
+						},
 					},
 				});
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				expect(await childHandle.wait()).toEqual({
 					success: true,
@@ -53,13 +53,17 @@ describe("childWorkflowRunHandle", () => {
 
 		test("repeated waits read the same terminal outcome", () =>
 			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
-				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({
-					terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: {
+						[childRecord.id]: {
+							timeouts: [],
+							terminal: { state: { status: "completed", output: "done" }, completedAt: 1_000 },
+						},
+					},
 				});
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				expect(await childHandle.wait()).toEqual({
 					success: true,
@@ -73,11 +77,12 @@ describe("childWorkflowRunHandle", () => {
 
 		test("returns a timeout when the recorded wait timed out", () =>
 			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: { [childRecord.id]: { timeouts: [{ timedOutAt: 1_000 }] } },
+				});
 				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({ timeouts: [{ timedOutAt: 1_000 }] });
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				expect(await childHandle.wait({ timeout: { minutes: 5 } })).toEqual({
 					success: false,
@@ -87,14 +92,17 @@ describe("childWorkflowRunHandle", () => {
 
 		test("consumes the recorded timeout before reading the terminal outcome", () =>
 			withFakeClient(async (client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build();
 				const childRecord = runningWorkflowRunRecordFactory.build();
-				const parentHandle = workflowRunHandle(client, parentRecord);
-				const waits = childWaits({
-					timeouts: [{ timedOutAt: 1_000 }],
-					terminal: { state: { status: "completed", output: "done" }, completedAt: 2_000 },
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: {
+						[childRecord.id]: {
+							timeouts: [{ timedOutAt: 1_000 }],
+							terminal: { state: { status: "completed", output: "done" }, completedAt: 2_000 },
+						},
+					},
 				});
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, waits, client.logger);
+				const parentHandle = workflowRunHandle(client, parentRecord);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				expect(await childHandle.wait({ timeout: { minutes: 5 } })).toEqual({
 					success: false,
@@ -108,10 +116,12 @@ describe("childWorkflowRunHandle", () => {
 
 		test("transitions the parent to awaiting_child_workflow and suspends when no wait is recorded", () =>
 			withFakeClient((client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build({ revision: 0 });
 				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: { [childRecord.id]: { timeouts: [] } },
+				});
 				const parentHandle = workflowRunHandle(client, parentRecord);
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, childWaits({}), client.logger);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				client.api.workflowRun.transitionStateV1.once(
 					{
@@ -121,7 +131,7 @@ describe("childWorkflowRunHandle", () => {
 							status: "awaiting_child_workflow",
 							childWorkflowRunId: childRecord.id,
 						},
-						expectedRevision: 0,
+						expectedRevision: parentRecord.revision,
 						expectedSignalSequence: 0,
 					},
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
@@ -132,10 +142,12 @@ describe("childWorkflowRunHandle", () => {
 
 		test("carries the timeout into the parent transition", () =>
 			withFakeClient((client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build({ revision: 0 });
 				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: { [childRecord.id]: { timeouts: [] } },
+				});
 				const parentHandle = workflowRunHandle(client, parentRecord);
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, childWaits({}), client.logger);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				client.api.workflowRun.transitionStateV1.once(
 					{
@@ -146,7 +158,7 @@ describe("childWorkflowRunHandle", () => {
 							childWorkflowRunId: childRecord.id,
 							timeoutInMs: 300_000,
 						},
-						expectedRevision: 0,
+						expectedRevision: parentRecord.revision,
 						expectedSignalSequence: 0,
 					},
 					{ revision: 1, state: workflowRunStateByStatus.awaiting_child_workflow, attempts: parentRecord.attempts }
@@ -157,10 +169,12 @@ describe("childWorkflowRunHandle", () => {
 
 		test("maps a parent-transition conflict to a suspension", () =>
 			withFakeClient((client) => {
-				const parentRecord = runningWorkflowRunRecordFactory.build({ revision: 0 });
 				const childRecord = runningWorkflowRunRecordFactory.build();
+				const parentRecord = runningWorkflowRunRecordFactory.build({
+					childWorkflowRunWaits: { [childRecord.id]: { timeouts: [] } },
+				});
 				const parentHandle = workflowRunHandle(client, parentRecord);
-				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, childWaits({}), client.logger);
+				const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 				client.api.workflowRun.transitionStateV1.rejectsOnce(
 					{
@@ -170,7 +184,7 @@ describe("childWorkflowRunHandle", () => {
 							status: "awaiting_child_workflow",
 							childWorkflowRunId: childRecord.id,
 						},
-						expectedRevision: 0,
+						expectedRevision: parentRecord.revision,
 						expectedSignalSequence: 0,
 					},
 					{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
@@ -182,20 +196,18 @@ describe("childWorkflowRunHandle", () => {
 
 	test("exposes the child run", () =>
 		withFakeClient((client) => {
-			const parentRecord = runningWorkflowRunRecordFactory.build();
 			const childRecord = runningWorkflowRunRecordFactory.build();
-			const parentHandle = workflowRunHandle(client, parentRecord);
-			const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, childWaits({}), client.logger);
+			const parentHandle = workflowRunHandle(client, runningWorkflowRunRecordFactory.build());
+			const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 			expect(childHandle.run).toEqual(childRecord);
 		}));
 
 	test("cancels the child run, not the parent", () =>
 		withFakeClient(async (client) => {
-			const parentRecord = runningWorkflowRunRecordFactory.build();
 			const childRecord = runningWorkflowRunRecordFactory.build({ revision: 2 });
-			const parentHandle = workflowRunHandle(client, parentRecord);
-			const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, childWaits({}), client.logger);
+			const parentHandle = workflowRunHandle(client, runningWorkflowRunRecordFactory.build());
+			const childHandle = childWorkflowRunHandle(client, childRecord, parentHandle, client.logger);
 
 			client.api.workflowRun.transitionStateV1.once(
 				{ type: "pessimistic", id: childRecord.id, state: { status: "cancelled", explanation: "stop it" } },

--- a/sdk/workflow/src/run/handle-child.ts
+++ b/sdk/workflow/src/run/handle-child.ts
@@ -4,7 +4,6 @@ import type { Logger } from "@aikirun/lib/logger";
 import type { Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import {
-	type ChildWorkflowRunWaits,
 	type TerminalWorkflowRunState,
 	type WorkflowRunId,
 	type WorkflowRunRecord,
@@ -19,7 +18,6 @@ export function childWorkflowRunHandle<Input, Output, Context, TEvents extends E
 	client: Client<Context>,
 	run: WorkflowRunRecord<Input, Output>,
 	parentRunHandle: WorkflowRunHandle<unknown, unknown, Context, EventsDefinition>,
-	parentRunWaitsOnChild: ChildWorkflowRunWaits,
 	logger: Logger,
 	eventsDefinition?: TEvents
 ): ChildWorkflowRunHandle<Input, Output, Context, TEvents> {
@@ -29,7 +27,7 @@ export function childWorkflowRunHandle<Input, Output, Context, TEvents extends E
 		run: handle.run,
 		events: handle.events,
 		refresh: handle.refresh.bind(handle),
-		wait: createWaiter(handle, parentRunHandle, parentRunWaitsOnChild, logger),
+		wait: createWaiter(handle, parentRunHandle, logger),
 		cancel: handle.cancel.bind(handle),
 		pause: handle.pause.bind(handle),
 		resume: handle.resume.bind(handle),
@@ -98,7 +96,6 @@ export type ChildWorkflowRunWaitResult<Output, Timed extends boolean> = Timed ex
 function createWaiter<Input, Output, Context, TEvents extends EventsDefinition>(
 	handle: WorkflowRunHandle<Input, Output, Context, TEvents>,
 	parentRunHandle: WorkflowRunHandle<unknown, unknown, Context, EventsDefinition>,
-	parentRunWaitsOnChild: ChildWorkflowRunWaits,
 	logger: Logger
 ) {
 	let nextTimeoutIndex = 0;
@@ -109,11 +106,10 @@ function createWaiter<Input, Output, Context, TEvents extends EventsDefinition>(
 	async function wait(
 		options?: ChildWorkflowRunWaitOptions<boolean>
 	): Promise<ChildWorkflowRunWaitResult<Output, boolean>> {
-		// TODO: refresh first? like how event waits do it
-
 		const { run } = handle;
+		const waits = parentRunHandle.run.childWorkflowRunWaits[run.id] ?? { timeouts: [] };
 
-		const timedOutWait = parentRunWaitsOnChild.timeouts[nextTimeoutIndex];
+		const timedOutWait = waits.timeouts[nextTimeoutIndex];
 		if (timedOutWait) {
 			nextTimeoutIndex++;
 
@@ -124,7 +120,7 @@ function createWaiter<Input, Output, Context, TEvents extends EventsDefinition>(
 			};
 		}
 
-		const { terminal } = parentRunWaitsOnChild;
+		const { terminal } = waits;
 		if (terminal) {
 			return {
 				success: true,

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -256,7 +256,6 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 					client,
 					existingRun as WorkflowRunRecord<Input, Output>,
 					parentRun[INTERNAL].handle,
-					existingRunInfo.waits,
 					logger,
 					this[INTERNAL].eventsDefinition
 				);
@@ -303,7 +302,6 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			client,
 			newRun as WorkflowRunRecord<Input, Output>,
 			parentRun[INTERNAL].handle,
-			{ timeouts: [] },
 			logger,
 			this[INTERNAL].eventsDefinition
 		);

--- a/testing/src/data-factory/workflow/run.ts
+++ b/testing/src/data-factory/workflow/run.ts
@@ -38,9 +38,6 @@ export const childWorkflowRunInfoFactory = Factory.define<ChildWorkflowRunInfo>(
 	name: "child-run",
 	versionId: "1.0.0",
 	inputHash: "hash",
-	waits: {
-		timeouts: [],
-	},
 }));
 
 const baseWorkflowRunRecord = (sequence: number): Omit<WorkflowRunRecord, "state"> => ({
@@ -58,6 +55,7 @@ const baseWorkflowRunRecord = (sequence: number): Omit<WorkflowRunRecord, "state
 	sleeps: {},
 	eventWaits: {},
 	childWorkflowRuns: {},
+	childWorkflowRunWaits: {},
 });
 
 export const baseWorkflowRunRecordFactory = Factory.define<Omit<WorkflowRunRecord, "state">>(({ sequence }) =>

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -288,6 +288,7 @@ export interface WorkflowRunRecord<Input = unknown, Output = unknown> {
 	sleeps: Record<string, Sleep[]>;
 	eventWaits: Record<string, EventWait<unknown>[]>;
 	childWorkflowRuns: Record<string, ChildWorkflowRunInfo[]>;
+	childWorkflowRunWaits: Record<string, ChildWorkflowRunWaits>;
 	parentWorkflowRunId?: string;
 	scheduleId?: string;
 }
@@ -297,7 +298,6 @@ export interface ChildWorkflowRunInfo {
 	name: string;
 	versionId: string;
 	inputHash: string;
-	waits: ChildWorkflowRunWaits;
 }
 
 export interface ChildWorkflowRunWaits {


### PR DESCRIPTION
## Background

A run that starts a child workflow can wait on it. If the child is not yet terminal, the parent parks as `awaiting_child_workflow`, and the park is guarded by the run's signal sequence: a child finishing at the wrong moment reschedules the parent instead of losing the wake-up (#173, #174). `child_workflow_run_wait` rows are the durable record of these waits — the child's terminal transition writes a terminal row, and the child-wait timeout daemon writes a timeout row when a parked parent's deadline passes. On the worker, replay resolves a wait from the parent's run record: timeouts are consumed one per wait in order, and a wait that gets past them reads the child's terminal outcome.

Beside the polling scans, the server runs a timer path for latency. The timer priority queue is pluggable infrastructure holding run timers ranked by due time, and the due-timers consumer waits on it, processing each timer the moment it becomes due. The imminent-run timer queue is a filter in front of it: it adds a run's timer only when the run falls due within a lookahead window, and adds are best-effort — a dropped timer costs latency, and the polling scan remains the backstop. The polling daemons page through due rows with a keyset cursor ordered by (due time, id).

## Problem

Three gaps remained:

1. On the run record, a child's waits were embedded in the child-creation entry (`childWorkflowRuns`, keyed by call address), and the child handle captured that waits object once, when the handle was built. A refresh of the parent's record replaced the record but not the capture, so the handle kept reading a snapshot. Waits are facts about a (parent, child run) pair, not about a creation address — the embedding also forced the server to join wait rows into every child info entry it assembled.

2. A parent woken by its child reaching a terminal state only moves to `scheduled`. Delivery then waited for the scheduled-runs daemon's next scan, adding up to a full polling interval to every child wake-up.

3. Every event `wait()` call fetched the run record from the server before replaying. The signal-sequence guard already covers the race that fetch was for: an event arriving after the record was read moves the sequence, and the park lands as `scheduled` instead of parking. The fetch added a round trip to every wait without adding safety.

## Solution

**Child waits are a top-level map on the run record.**

```ts
// before
childWorkflowRuns: Record<string, ChildWorkflowRunInfo[]>;   // by address, each info embedding its waits

// after
childWorkflowRuns: Record<string, ChildWorkflowRunInfo[]>;   // by address
childWorkflowRunWaits: Record<string, ChildWorkflowRunWaits>; // by child run id
```

The child handle no longer captures a waits object. `wait()` reads `childWorkflowRunWaits[childRunId]` off the parent handle's current record, so a refreshed record is immediately visible to every child handle. The server assembles the map directly from wait rows, and the dashboard's child cards and timeline read the same map.

**Waking a parent also queues its timer.** The transaction that wakes parents parked on a terminal child now registers an on-commit hook offering each woken parent to the imminent-run timer queue, due immediately. The due-timers consumer picks the parent up right away; the scheduled-runs daemon scan remains the backstop. This covers the terminal state transition and cancellation paths. The recurring-runs daemon's occurrence cancellation passes no queue: schedule occurrences have no parents today, so there is nobody to wake.

**Event replay no longer fetches the record.** `wait()` replays from the record the worker holds and parks guarded. An event landing in the race window costs one reschedule — the same rare reschedule the guard design already accepts — instead of a fetch on every wait.

**Keyset cursor paging works past the first page.** The cursor filter compared the order column against the cursor's value with raw SQL parameters, which skip the column's driver mapping. Columns ordered by a timestamp map a millisecond number to an ISO string; the raw parameter bound the bare number, and the driver rejected it. Every timestamp-ordered daemon scan — scheduled runs, sleep wake-ups, retries, wait timeouts, stale outbox claims — crashed the moment one pass found more due rows than its page limit. The cursor's order value is now passed through the column's own mapping when the order key is a column, and bound as-is when it is a SQL expression.

## Breaking changes

The run record's wire schema changed: `waits` moved out of each `childWorkflowRuns` entry into the top-level `childWorkflowRunWaits` map, keyed by child run id.