### PR TITLE
Generic wait and final terminal states

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const handle = await trialV1.start(aikiClient, { userId: "user-123" });
 
 // Simulate the payment arriving
 await handle.events.paymentReceived.send();
-await handle.waitForStatus("completed");
+await handle.wait();
 
 await workerHandle.stop();
 await runtimeHandle.stop();

--- a/app/website/content/docs/architecture/overview.mdx
+++ b/app/website/content/docs/architecture/overview.mdx
@@ -110,7 +110,7 @@ Worker/Endpoint → Server → Storage
 
 1. Worker or endpoint updates workflow run state via server
 2. Server persists state to storage
-3. Clients observe progress through run handles (e.g. `handle.waitForStatus`)
+3. Clients observe progress through run handles (e.g. `handle.wait`)
 
 ## Next Steps
 

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -196,12 +196,12 @@ const handle = await workflowVersion.start(client, {
 console.log("Started:", handle.run.id);
 console.log("Status:", handle.run.state.status);
 
-// Wait for completion
-const result = await handle.waitForStatus("completed");
-if (result.success) {
+// Wait for the run to finish
+const result = await handle.wait();
+if (result.state.status === "completed") {
 	console.log("Output:", result.state.output);
 } else {
-	console.log("Failed:", result.cause);
+	console.log("Ended with:", result.state.status);
 }
 ```
 
@@ -245,25 +245,26 @@ The handle returned from `.start()` provides:
 | `run` | The workflow run data (id, state, input, output, etc.) |
 | `events` | Send events to the workflow |
 | `refresh()` | Refresh run data from the server |
-| `waitForStatus(status)` | Wait for a terminal status (`completed`, `failed`, `cancelled`) |
+| `wait()` | Wait for a terminal status (`completed`, `failed`, `cancelled`) |
 | `cancel(explanation?)` | Cancel the workflow run |
 | `pause()` | Pause the workflow |
 | `resume()` | Resume a paused workflow |
 | `wakeup()` | Wake a sleeping workflow |
 
-#### Waiting for Status
+#### Waiting for the Run to Finish
 
-The `waitForStatus()` method returns a result object:
+The `wait()` method resolves when the run reaches any terminal status; the state says
+which one. With a timeout, the result can also report that the timeout elapsed:
 
 ```typescript
-const result = await handle.waitForStatus("completed");
+const result = await handle.wait({ timeout: { minutes: 5 } });
 
-if (result.success) {
-	// Workflow reached the requested status
+if (!result.success) {
+	console.log("Timed out waiting for the run");
+} else if (result.state.status === "completed") {
 	console.log("Output:", result.state.output);
 } else {
-	// Workflow reached a different terminal status
-	console.log("Ended with:", result.cause);
+	console.log("Ended with:", result.state.status);
 }
 ```
 

--- a/app/website/content/docs/getting-started/quick-start.mdx
+++ b/app/website/content/docs/getting-started/quick-start.mdx
@@ -100,7 +100,7 @@ Start the workflow, then simulate the payment so the run completes without the f
 const handle = await trialV1.start(aikiClient, { userId: "user-123" });
 
 await handle.events.paymentReceived.send();
-await handle.waitForStatus("completed");
+await handle.wait();
 
 console.log("Run completed");
 
@@ -108,7 +108,7 @@ await workerHandle.stop();
 await runtimeHandle.stop();
 ```
 
-> **Tip:** `waitForStatus` waits indefinitely by default. To bound it, pass a timeout: `await handle.waitForStatus("completed", { timeout: { seconds: 60 } })`.
+> **Tip:** `wait` waits indefinitely by default. To bound it, pass a timeout: `await handle.wait({ timeout: { seconds: 60 } })`.
 
 ## Run
 
@@ -192,7 +192,7 @@ const handle = await trialV1.start(aikiClient, { userId: "user-123" });
 
 // Simulate the payment arriving
 await handle.events.paymentReceived.send();
-await handle.waitForStatus("completed");
+await handle.wait();
 
 console.log("Run completed");
 

--- a/examples/src/scenarios/cam-safe-append.ts
+++ b/examples/src/scenarios/cam-safe-append.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camAppendV1], async (client) => {
 	await delay(5_000);
 	cam.flags.append = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("completed");
-	const passed = result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "completed";
 	client.logger.info(`[CAM] Safe Append: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "completed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/cam-safe-removal.ts
+++ b/examples/src/scenarios/cam-safe-removal.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camRemovalV1], async (client) => {
 	await delay(5_000);
 	cam.flags.removal = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("completed");
-	const passed = result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "completed";
 	client.logger.info(`[CAM] Safe Removal: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "completed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/cam-safe-reorder.ts
+++ b/examples/src/scenarios/cam-safe-reorder.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camReorderV1], async (client) => {
 	await delay(5_000);
 	cam.flags.reorder = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("completed");
-	const passed = result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "completed";
 	client.logger.info(`[CAM] Safe Reorder: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "completed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/cam-unsafe-control-flow.ts
+++ b/examples/src/scenarios/cam-unsafe-control-flow.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camControlFlowV1], async (client) => {
 	await delay(5_000);
 	cam.flags.controlFlow = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("failed");
-	const passed = !result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "failed";
 	client.logger.info(`[CAM] Unsafe Control Flow: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "failed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/cam-unsafe-input-change.ts
+++ b/examples/src/scenarios/cam-unsafe-input-change.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camInputChangeV1], async (client) => {
 	await delay(5_000);
 	cam.flags.inputChange = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("failed");
-	const passed = !result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "failed";
 	client.logger.info(`[CAM] Unsafe Input Change: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "failed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/cam-unsafe-insert.ts
+++ b/examples/src/scenarios/cam-unsafe-insert.ts
@@ -9,10 +9,10 @@ await runWithWorker([cam.camInsertV1], async (client) => {
 	await delay(5_000);
 	cam.flags.insert = true;
 	await handle.events.proceed.send();
-	const result = await handle.waitForStatus("failed");
-	const passed = !result.success;
+	const result = await handle.wait();
+	const passed = result.state.status === "failed";
 	client.logger.info(`[CAM] Unsafe Insert: ${passed ? "PASS" : "FAIL"}`, {
 		expected: "failed",
-		got: result.success ? "completed" : "failed",
+		got: result.state.status,
 	});
 });

--- a/examples/src/scenarios/concurrent-tasks.ts
+++ b/examples/src/scenarios/concurrent-tasks.ts
@@ -3,8 +3,8 @@ import { concurrentTasksV1 } from "../workflows/concurrent-tasks";
 
 await runWithWorker([concurrentTasksV1], async (client) => {
 	const handle = await concurrentTasksV1.start(client);
-	const result = await handle.waitForStatus("completed");
-	if (result.success) {
+	const result = await handle.wait();
+	if (result.state.status === "completed") {
 		client.logger.info("Concurrent tasks result", result.state.output);
 	}
 });

--- a/examples/src/scenarios/delayed-start.ts
+++ b/examples/src/scenarios/delayed-start.ts
@@ -8,9 +8,9 @@ await runWithWorker([notify], async (client) => {
 	const handle = await notify
 		.with("trigger", { type: "delayed", delay: { seconds: 5 } })
 		.start(client, "It's a good day");
-	const result = await handle.waitForStatus("completed");
+	const result = await handle.wait();
 
-	if (result.success) {
+	if (result.state.status === "completed") {
 		const elapsed = Date.now() - startedAt;
 		client.logger.info("Delayed workflow completed", { elapsedMs: elapsed, output: result.state.output });
 	}

--- a/examples/src/scenarios/echo.ts
+++ b/examples/src/scenarios/echo.ts
@@ -12,5 +12,5 @@ await runWithWorker([echoV1], async (client) => {
 	await delay(5_000);
 	await handle.events.ping.send({ message: "Another Ping" });
 
-	await handle.waitForStatus("completed");
+	await handle.wait();
 });

--- a/examples/src/scenarios/fan-out-gather.ts
+++ b/examples/src/scenarios/fan-out-gather.ts
@@ -3,8 +3,8 @@ import { childV1, fanOutGatherV1 } from "../workflows/fan-out-gather";
 
 await runWithWorker([childV1, fanOutGatherV1], async (client) => {
 	const handle = await fanOutGatherV1.start(client, { items: ["foo", "bar", "baz"] });
-	const result = await handle.waitForStatus("completed");
-	if (result.success) {
+	const result = await handle.wait();
+	if (result.state.status === "completed") {
 		client.logger.info("Fan-out results", { output: result.state.output });
 	}
 });

--- a/examples/src/scenarios/long-running-pipeline.ts
+++ b/examples/src/scenarios/long-running-pipeline.ts
@@ -8,8 +8,8 @@ await runWithWorker([longRunningPipelineV1], async (client) => {
 	// Wait for it to reach the approval stage, then approve
 	await delay(35_000);
 	await handle.events.approve.send({ approver: "admin@example.com" });
-	const result = await handle.waitForStatus("completed");
-	if (result.success) {
+	const result = await handle.wait();
+	if (result.state.status === "completed") {
 		client.logger.info("Pipeline complete", result.state.output);
 	}
 });

--- a/examples/src/scenarios/retry-until-success.ts
+++ b/examples/src/scenarios/retry-until-success.ts
@@ -3,6 +3,6 @@ import { retryUntilSuccessV1 } from "../workflows/retry-until-success";
 
 await runWithWorker([retryUntilSuccessV1], async (client) => {
 	const handle = await retryUntilSuccessV1.start(client);
-	const result = await handle.waitForStatus("completed");
-	client.logger.info("Retry workflow done", { success: result.success });
+	const result = await handle.wait();
+	client.logger.info("Retry workflow done", { status: result.state.status });
 });

--- a/examples/src/scenarios/versioning.ts
+++ b/examples/src/scenarios/versioning.ts
@@ -8,8 +8,8 @@ await runWithWorker([greeterV1, greeterV2], async (client) => {
 		greeterV2.start(client, { name: "Bob", loud: true }),
 	]);
 
-	const [r1, r2] = await Promise.all([h1.waitForStatus("completed"), h2.waitForStatus("completed")]);
+	const [r1, r2] = await Promise.all([h1.wait(), h2.wait()]);
 
-	if (r1.success) client.logger.info("v1 result", r1.state.output);
-	if (r2.success) client.logger.info("v2 result", r2.state.output);
+	if (r1.state.status === "completed") client.logger.info("v1 result", r1.state.output);
+	if (r2.state.status === "completed") client.logger.info("v2 result", r2.state.output);
 });

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -23,7 +23,7 @@ const handle = await orderWorkflowV1.start(aikiClient, {
 	orderId: "order-123",
 });
 
-const result = await handle.waitForStatus("completed");
+const result = await handle.wait();
 ```
 
 ## Documentation

--- a/sdk/client/src/client.ts
+++ b/sdk/client/src/client.ts
@@ -29,7 +29,7 @@ const EMBEDDED_BASE_URL = "aiki://embedded/api";
  * const aikiClient = client({ handler: aiki.handler });
  *
  * const handle = await myWorkflow.start(aikiClient, { email: "user@example.com" });
- * const result = await handle.waitForStatus("completed", { timeout: { seconds: 60 } });
+ * const result = await handle.wait({ timeout: { seconds: 60 } });
  * ```
  */
 export function client<Context = null>(params: RemoteClientParams<Context>): Client<Context>;

--- a/sdk/server/src/service/state-machine/workflow-run.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.test.ts
@@ -57,7 +57,7 @@ describe("assertIsValidWorkflowRunStateTransition", () => {
 		stalled: { scheduled: { reasons: ["redelivery"] }, cancelled: {} },
 		cancelled: {},
 		completed: {},
-		failed: { awaiting_retry: {} },
+		failed: {},
 	};
 
 	const possibleReasons = Array.from(new Set([...WORKFLOW_RUN_SCHEDULED_REASONS, ...WORKFLOW_RUN_QUEUED_REASON]));

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -81,9 +81,7 @@ const workflowRunStateTransitionValidator: Record<
 	},
 	cancelled: {},
 	completed: {},
-	failed: {
-		awaiting_retry: true,
-	},
+	failed: {},
 };
 
 export function assertIsValidWorkflowRunStateTransition(

--- a/sdk/workflow/src/run/handle-child.ts
+++ b/sdk/workflow/src/run/handle-child.ts
@@ -38,7 +38,7 @@ export function childWorkflowRunHandle<Input, Output, Context, TEvents extends E
 
 export type ChildWorkflowRunHandle<Input, Output, Context, TEvents extends EventsDefinition = EventsDefinition> = Omit<
 	WorkflowRunHandle<Input, Output, Context, TEvents>,
-	"waitForStatus"
+	"wait"
 > & {
 	/**
 	 * Waits for the child workflow run to reach a terminal status.

--- a/sdk/workflow/src/run/handle.test.ts
+++ b/sdk/workflow/src/run/handle.test.ts
@@ -268,8 +268,8 @@ describe("workflowRunHandle", () => {
 			}));
 	});
 
-	describe("waitForStatus", () => {
-		test("returns success with the state when the run reaches the target status", () =>
+	describe("wait", () => {
+		test("resolves with the state when the run terminates", () =>
 			withFakeClient(async (client) => {
 				const record = runningWorkflowRunRecordFactory.build({ stateTransitionId: "t0" });
 				const handle = workflowRunHandle(client, record);
@@ -284,12 +284,12 @@ describe("workflowRunHandle", () => {
 				};
 				client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: completed });
 
-				const result = await handle.waitForStatus("completed");
+				const result = await handle.wait();
 
 				expect(result).toEqual({ success: true, state: { status: "completed", output: "done" } });
 			}));
 
-		test("returns run_terminated when the run reaches a different terminal status", () =>
+		test("resolves with whatever terminal state the run reached", () =>
 			withFakeClient(async (client) => {
 				const record = runningWorkflowRunRecordFactory.build({ stateTransitionId: "t0" });
 				const handle = workflowRunHandle(client, record);
@@ -304,9 +304,12 @@ describe("workflowRunHandle", () => {
 				};
 				client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: failed });
 
-				const result = await handle.waitForStatus("completed");
+				const result = await handle.wait();
 
-				expect(result).toEqual({ success: false, cause: "run_terminated" });
+				expect(result).toEqual({
+					success: true,
+					state: { status: "failed", cause: "self", error: { name: "Error", message: "boom" } },
+				});
 			}));
 
 		test("polls until the run terminates, advancing the state-transition cursor", () =>
@@ -323,7 +326,7 @@ describe("workflowRunHandle", () => {
 				};
 				client.api.workflowRun.getByIdV1.once({ id: record.id }, { run: completed });
 
-				const result = await handle.waitForStatus("completed", { interval: { milliseconds: 1 } });
+				const result = await handle.wait({ interval: { milliseconds: 1 } });
 
 				expect(result).toEqual({ success: true, state: { status: "completed", output: 42 } });
 			}));
@@ -339,7 +342,7 @@ describe("workflowRunHandle", () => {
 
 				// timeout < interval: the sleep after the first poll is capped to the remaining
 				// budget, and exactly one more poll happens at the deadline before giving up
-				const result = await handle.waitForStatus("completed", {
+				const result = await handle.wait({
 					interval: { seconds: 2 },
 					timeout: { milliseconds: 20 },
 				});
@@ -355,7 +358,7 @@ describe("workflowRunHandle", () => {
 				const controller = new AbortController();
 				controller.abort();
 
-				const result = await handle.waitForStatus("completed", { signal: controller.signal });
+				const result = await handle.wait({ signal: controller.signal });
 
 				expect(result).toEqual({ success: false, cause: "aborted" });
 			}));

--- a/sdk/workflow/src/run/handle.ts
+++ b/sdk/workflow/src/run/handle.ts
@@ -8,7 +8,7 @@ import type { WorkflowRunStateRequest, WorkflowRunTransitionStateResponseV1 } fr
 import type { ApiClient, Client } from "@aikirun/types/client";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type {
-	TerminalWorkflowRunStatus,
+	TerminalWorkflowRunState,
 	WorkflowRunId,
 	WorkflowRunRecord,
 	WorkflowRunState,
@@ -80,65 +80,47 @@ export interface WorkflowRunHandle<Input, Output, Context, TEvents extends Event
 	/**
 	 * Waits for the workflow run to reach a terminal status by polling.
 	 *
+	 * Any terminal status (`completed`, `failed`, or `cancelled`) resolves the wait.
+	 *
 	 * Returns a result object:
-	 * - `{ success: true, state }` - workflow reached the expected status
-	 * - `{ success: false, cause }` - workflow did not reach status
+	 * - `{ success: true, state }` - the run reached a terminal status; `state.status` says which
+	 * - `{ success: false, cause: "timeout" }` - the wall-clock timeout elapsed (only when a
+	 *   timeout option is provided); a final poll happens at the deadline before the wait gives up
+	 * - `{ success: false, cause: "aborted" }` - the abort signal triggered (only when a signal
+	 *   option is provided)
 	 *
-	 * Possible failure causes:
-	 * - `"run_terminated"` - workflow reached a terminal state other than expected
-	 * - `"timeout"` - the wall-clock timeout elapsed (only when timeout option provided);
-	 *   a final poll happens at the deadline before the wait gives up
-	 * - `"aborted"` - abort signal triggered (only when signal option provided)
-	 *
-	 * @param status - The target status to wait for
 	 * @param options - Optional configuration for polling interval, timeout, and abort signal
 	 *
 	 * @example
-	 * // Wait indefinitely until completed or the workflow reaches another terminal state
-	 * const result = await handle.waitForStatus("completed");
-	 * if (result.success) {
+	 * // Wait indefinitely until the run terminates
+	 * const result = await handle.wait();
+	 * if (result.state.status === "completed") {
 	 *   console.log(result.state.output);
 	 * } else {
-	 *   console.log(`Workflow terminated: ${result.cause}`);
+	 *   console.log(`Run ended ${result.state.status}`);
 	 * }
 	 *
 	 * @example
 	 * // Wait with a timeout
-	 * const result = await handle.waitForStatus("completed", {
-	 *   timeout: { seconds: 30 }
-	 * });
-	 * if (result.success) {
+	 * const result = await handle.wait({ timeout: { seconds: 30 } });
+	 * if (!result.success) {
+	 *   console.log("Timed out waiting for the run");
+	 * } else if (result.state.status === "completed") {
 	 *   console.log(result.state.output);
-	 * } else if (result.cause === "timeout") {
-	 *   console.log("Timed out waiting for completion");
 	 * }
 	 *
 	 * @example
 	 * // Wait with an abort signal
 	 * const controller = new AbortController();
-	 * const result = await handle.waitForStatus("completed", {
-	 *   signal: controller.signal
-	 * });
+	 * const result = await handle.wait({ signal: controller.signal });
 	 * if (!result.success) {
 	 *   console.log(`Wait ended: ${result.cause}`);
 	 * }
 	 */
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options?: WorkflowRunWaitOptions<false, false>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, false>>;
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<true, false>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, false>>;
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<false, true>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, true>>;
-	waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<true, true>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, true>>;
+	wait(options?: WorkflowRunWaitOptions<false, false>): Promise<WorkflowRunWaitResult<Output, false, false>>;
+	wait(options: WorkflowRunWaitOptions<true, false>): Promise<WorkflowRunWaitResult<Output, true, false>>;
+	wait(options: WorkflowRunWaitOptions<false, true>): Promise<WorkflowRunWaitResult<Output, false, true>>;
+	wait(options: WorkflowRunWaitOptions<true, true>): Promise<WorkflowRunWaitResult<Output, true, true>>;
 
 	cancel: (explanation?: string) => Promise<void>;
 
@@ -164,25 +146,23 @@ export interface WorkflowRunWaitOptions<Timed extends boolean, Abortable extends
 	signal?: Abortable extends true ? AbortSignal : never;
 }
 
-export type WorkflowRunWaitResultSuccess<Status extends TerminalWorkflowRunStatus, Output> = Extract<
-	WorkflowRunState<Output>,
-	{ status: Status }
->;
-
-export type WorkflowRunWaitResult<
-	Status extends TerminalWorkflowRunStatus,
-	Output,
-	Timed extends boolean,
-	Abortable extends boolean,
-> =
-	| {
-			success: false;
-			cause: "run_terminated" | (Timed extends true ? "timeout" : never) | (Abortable extends true ? "aborted" : never);
-	  }
-	| {
+export type WorkflowRunWaitResult<Output, Timed extends boolean, Abortable extends boolean> = [
+	Timed,
+	Abortable,
+] extends [false, false]
+	? {
 			success: true;
-			state: WorkflowRunWaitResultSuccess<Status, Output>;
-	  };
+			state: TerminalWorkflowRunState<Output>;
+		}
+	:
+			| {
+					success: true;
+					state: TerminalWorkflowRunState<Output>;
+			  }
+			| {
+					success: false;
+					cause: (Timed extends true ? "timeout" : never) | (Abortable extends true ? "aborted" : never);
+			  };
 
 class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefinition>
 	implements WorkflowRunHandle<Input, Output, Context, TEvents>
@@ -218,37 +198,25 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 		this._run = currentRun as WorkflowRunRecord<Input, Output>;
 	}
 
-	public async waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
+	public async wait(
 		options?: WorkflowRunWaitOptions<false, false>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, false>>;
+	): Promise<WorkflowRunWaitResult<Output, false, false>>;
 
-	public async waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<true, false>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, false>>;
+	public async wait(options: WorkflowRunWaitOptions<true, false>): Promise<WorkflowRunWaitResult<Output, true, false>>;
 
-	public async waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<false, true>
-	): Promise<WorkflowRunWaitResult<Status, Output, false, true>>;
+	public async wait(options: WorkflowRunWaitOptions<false, true>): Promise<WorkflowRunWaitResult<Output, false, true>>;
 
-	public async waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
-		options: WorkflowRunWaitOptions<true, true>
-	): Promise<WorkflowRunWaitResult<Status, Output, true, true>>;
+	public async wait(options: WorkflowRunWaitOptions<true, true>): Promise<WorkflowRunWaitResult<Output, true, true>>;
 
-	public async waitForStatus<Status extends TerminalWorkflowRunStatus>(
-		status: Status,
+	public async wait(
 		options?: WorkflowRunWaitOptions<boolean, boolean>
-	): Promise<WorkflowRunWaitResult<Status, Output, boolean, boolean>> {
-		return this.waitForStatusByPolling(status, options);
+	): Promise<WorkflowRunWaitResult<Output, boolean, boolean>> {
+		return this.waitByPolling(options);
 	}
 
-	private async waitForStatusByPolling<Status extends TerminalWorkflowRunStatus>(
-		expectedStatus: Status,
+	private async waitByPolling(
 		options?: WorkflowRunWaitOptions<boolean, boolean>
-	): Promise<WorkflowRunWaitResult<Status, Output, boolean, boolean>> {
+	): Promise<WorkflowRunWaitResult<Output, boolean, boolean>> {
 		const signal = options?.signal;
 		const intervalMs = options?.interval ? toMilliseconds(options.interval) : 1_000;
 		const timeoutAt = options?.timeout ? Date.now() + toMilliseconds(options.timeout) : undefined;
@@ -271,19 +239,13 @@ class WorkflowRunHandleImpl<Input, Output, Context, TEvents extends EventsDefini
 			}
 
 			if (terminated) {
+				// Terminal states have no exits, so a run reported terminated is terminated
+				// forever: the refreshed state is a terminal state.
 				await this.refresh();
-
-				// TODO: If the run transitions from failed -> awaiting_retry between the refresh and this check,
-				// a wrong response will be sent to the caller i.e. { success: false, cause: "run_terminated" }.
-				// The correct response should be { success: true, state }
-				if (this._run.state.status === expectedStatus) {
-					return {
-						success: true,
-						state: this._run.state as WorkflowRunWaitResultSuccess<Status, Output>,
-					};
-				}
-
-				return { success: false, cause: "run_terminated" };
+				return {
+					success: true,
+					state: this._run.state as TerminalWorkflowRunState<Output>,
+				};
 			}
 
 			if (finalPoll) {


### PR DESCRIPTION
## Motivation

The handle returned by starting or looking up a workflow run waits with `waitForStatus(status)`: the caller names one terminal status, the handle polls until the run terminates, and any other terminal outcome comes back as `{ success: false, cause: "run_terminated" }` — a result that says the run ended but not how, so the caller re-reads the run to find out. Child run handles already wait the other way: their `wait()` resolves on any terminal status and hands back the reached state. The two wait APIs disagree for no reason.

The transition table has a related wart: it allows `failed → awaiting_retry`, reserved for a run-replay feature that was never built. No caller exists, but the entry alone makes "terminal" untrustworthy. The polling wait carried a TODO for exactly that: a run can be reported terminated and then leave `failed` before the follow-up read, and the old code would answer `run_terminated` for a run that is about to retry.

## Solution

**`wait()` resolves on whatever terminal status the run reaches.**

```typescript
// before
const result = await handle.waitForStatus("completed");
if (result.success) {
	console.log(result.state.output);
} else {
	// cause is "run_terminated" — which status? re-read the run to learn
}

// after
const result = await handle.wait();
if (result.state.status === "completed") {
	console.log(result.state.output);
} else {
	console.log(`Run ended ${result.state.status}`);
}
```

The failure causes shrink to the two things that can actually interrupt the wait, and each exists in the result type only when the caller opts into it:

| call | possible results |
|---|---|
| `wait()` | `{ success: true, state }` — nothing can interrupt it, so the type has no failure arm | | `wait({ timeout })` | adds `{ success: false, cause: "timeout" }` | | `wait({ signal })` | adds `{ success: false, cause: "aborted" }` |

**`failed` has no exits.** The transition table entry becomes `failed: {}`, matching `cancelled` and `completed` — and matching the task table, where `failed` never had an exit. A terminal run is terminal forever.

That property is what lets the wait resolve without re-checking: once the server reports a run terminated, the follow-up read can only observe a terminal state, so the `run_terminated`-for-a-retrying-run race is gone along with its TODO. It also makes the one-terminal-row-per-child invariant from the child wait design unconditional — a child passes through terminal exactly once — which closes that design's only open question.

Retrying a failed run, if it ever ships, means starting a new run: a failed run has already told everyone it failed — its parent consumed the outcome, events sent to it were rejected — and none of that can be unsaid in place.

## Breaking changes

- `waitForStatus(status)` is removed from the run handle; use `wait()` and read `result.state.status`. The `run_terminated` failure cause no longer exists.
- The server rejects `failed → awaiting_retry` run transitions. Nothing sent them.