### PR TITLE
Sequence-stamped event waits

### DIFF
--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.integration.test.ts
@@ -1,0 +1,403 @@
+import { noopLogger } from "@aikirun/lib/logger";
+import type { TimestampMs } from "@aikirun/lib/timestamp";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+import { processImminentEventWaitTimedOutRuns, queueEventWaitTimedOutRuns } from "./imminent-event-wait-timed-out-runs";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { computeRank } from "../lib/rank";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness } from "../testing/harness";
+import { seedAwaitingEventRun } from "../testing/seed/run";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build();
+
+const EPOCH_MS = 1 as TimestampMs;
+const ONE_HOUR_MS = 1 * 60 * 60 * 1000;
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+describe("processImminentEventWaitTimedOutRuns", () => {
+	test("queues a run whose event wait timed out", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			// Parked at the epoch with a 1ms timeout: the deadline is overdue for any daemon
+			// pass under the real clock.
+			const { runId, revisionWhenParked } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "queued", revision: revisionWhenParked + 1 }),
+					state: { status: "queued", reason: "event_wait_timeout" },
+				})
+			);
+		}));
+
+	test("stamps the timeout row with the run's bumped sequence", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { runId } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			const timedOutAt = Date.now() as TimestampMs;
+			await withFakeClock(timedOutAt, () =>
+				processImminentEventWaitTimedOutRuns(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff })
+			);
+
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({
+					workflowRunId: runId,
+					name: "orderShipped",
+					status: "timeout",
+					timedOutAt,
+					data: null,
+					referenceId: null,
+					signalSequence: 1,
+				}),
+			]);
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "queued", signalSequence: 1 }),
+					state: { status: "queued", reason: "event_wait_timeout" },
+				})
+			);
+		}));
+
+	test("mints a fresh pending outbox row ranked at the wait's deadline", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { runId, workflowSource, workflowName, workflowVersionId } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toBeNull();
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toEqual(
+				expect.objectContaining({
+					workflowRunId: runId,
+					status: "pending",
+					workflowSource,
+					workflowName,
+					workflowVersionId,
+					// computeRank(timeoutAt = EPOCH_MS + 1, default priority 9) = 2 * 10 + 9.
+					rank: 29,
+					nextPublishAttemptRank: 29,
+				})
+			);
+		}));
+
+	test("charges no execution attempt for the timed-out wait", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { runId, attemptsWhenClaimed } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "queued", attempts: attemptsWhenClaimed }),
+				})
+			);
+		}));
+
+	test("publishes the fresh outbox row when a publisher is wired", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { runId } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos, publisher },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toEqual(expect.objectContaining({ workflowRunId: runId, status: "published" }));
+		}));
+
+	test("leaves a run whose deadline has not passed parked", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const { runId, revisionWhenParked } = await seedAwaitingEventRun(
+				{ daemonContext: context, namespaceRequestContext, repos, publisher },
+				{ eventName: "orderShipped", timeoutInMs: ONE_HOUR_MS }
+			);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "awaiting_event", revision: revisionWhenParked }),
+				})
+			);
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([]);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toBeNull();
+		}));
+
+	test("never times out a wait parked without a deadline", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			// Parked at the epoch: any deadline this old would be overdue — only the absent
+			// timeout spares the run.
+			const { runId, revisionWhenParked } = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped" }
+				)
+			);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "awaiting_event", revision: revisionWhenParked }),
+				})
+			);
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([]);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toBeNull();
+		}));
+
+	test("queues the due wait and hands the imminent one to the timer priority queue", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const due = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			const parkedAt = Date.now() as TimestampMs;
+			const imminent = await withFakeClock(parkedAt, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: ONE_HOUR_MS }
+				)
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// Frozen at the park instant: the due wait's deadline is behind now, the imminent
+			// one an hour ahead but inside the two-hour lookahead window.
+			await withFakeClock(parkedAt, () =>
+				processImminentEventWaitTimedOutRuns(
+					context,
+					{ repos, timerPriorityQueue },
+					{ limit: 100, lookaheadWindowMs: 2 * ONE_HOUR_MS, republishBackoff }
+				)
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{
+					type: "event_wait_timeout",
+					id: imminent.runId,
+					rank: computeRank({ dueAt: parkedAt + ONE_HOUR_MS }),
+				},
+			]);
+
+			const dueRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: due.runId,
+			});
+			expect(dueRun).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: due.runId, status: "queued" }),
+					state: { status: "queued", reason: "event_wait_timeout" },
+				})
+			);
+
+			const imminentRun = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: imminent.runId,
+			});
+			expect(imminentRun).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: imminent.runId,
+						status: "awaiting_event",
+						revision: imminent.revisionWhenParked,
+					}),
+				})
+			);
+		}));
+
+	test("drains every due wait when they outnumber the limit", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const seedDeps = { daemonContext: context, namespaceRequestContext, repos, publisher };
+			const parked = await withFakeClock(EPOCH_MS, async () => [
+				await seedAwaitingEventRun(seedDeps, { eventName: "orderShipped", timeoutInMs: 1 }),
+				await seedAwaitingEventRun(seedDeps, { eventName: "orderShipped", timeoutInMs: 1 }),
+				await seedAwaitingEventRun(seedDeps, { eventName: "orderShipped", timeoutInMs: 1 }),
+			]);
+
+			await processImminentEventWaitTimedOutRuns(
+				context,
+				{ repos },
+				{ limit: 2, lookaheadWindowMs: 0, republishBackoff }
+			);
+
+			for (const { runId } of parked) {
+				const run = await repos.workflowRun.getByIdWithState({
+					namespaceId: namespaceRequestContext.namespaceId,
+					id: runId,
+				});
+				expect(run).toEqual(expect.objectContaining({ run: expect.objectContaining({ id: runId, status: "queued" }) }));
+			}
+		}));
+});
+
+describe("queueEventWaitTimedOutRuns", () => {
+	test("skips a run that moved after the listing without bumping or stamping it twice", () =>
+		withHarness(async (deps) => {
+			const { context, repos, publisher } = deps;
+			const runA = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+			const runB = await withFakeClock(EPOCH_MS, () =>
+				seedAwaitingEventRun(
+					{ daemonContext: context, namespaceRequestContext, repos, publisher },
+					{ eventName: "orderShipped", timeoutInMs: 1 }
+				)
+			);
+
+			const listedRuns = await repos.workflowRun.listEventWaitTimedOutRuns(context, Date.now() as TimestampMs, 100);
+			expect(listedRuns.map((run) => run.id).sort()).toEqual([runA.runId, runB.runId].sort());
+
+			const rankedRuns = listedRuns.map((run) => ({ ...run, rank: computeRank({ dueAt: run.dueAt }) }));
+			const listedA = rankedRuns.find((run) => run.id === runA.runId);
+			const listedB = rankedRuns.find((run) => run.id === runB.runId);
+			if (!listedA || !listedB) {
+				throw new Error("Both parked runs must be listed as due");
+			}
+
+			// The first pass queues A, moving it past the listing's revision snapshot.
+			await queueEventWaitTimedOutRuns(context, repos, undefined, republishBackoff, [listedA]);
+
+			// The replayed batch still carries A at its parked revision — the race the
+			// revision guard settles. A must not get a second row, stamp, or bump.
+			await queueEventWaitTimedOutRuns(context, repos, undefined, republishBackoff, [listedA, listedB]);
+
+			expect(await repos.eventWait.listByWorkflowRunId(runA.runId)).toEqual([
+				expect.objectContaining({ workflowRunId: runA.runId, status: "timeout", signalSequence: 1 }),
+			]);
+			const rowA = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runA.runId,
+			});
+			expect(rowA).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runA.runId, status: "queued", signalSequence: 1 }),
+				})
+			);
+
+			expect(await repos.eventWait.listByWorkflowRunId(runB.runId)).toEqual([
+				expect.objectContaining({ workflowRunId: runB.runId, status: "timeout", signalSequence: 1 }),
+			]);
+			const rowB = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runB.runId,
+			});
+			expect(rowB).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runB.runId, status: "queued", signalSequence: 1 }),
+					state: { status: "queued", reason: "event_wait_timeout" },
+				})
+			);
+		}));
+});

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -1,9 +1,10 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/collection/array";
+import { asNonEmptyArray, chunkLazy, isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
-import type { WorkflowRunState, WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { WorkflowRunId, WorkflowRunState, WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
@@ -99,7 +100,7 @@ async function processChunk(
 ): Promise<void> {
 	const timedOutAt = Date.now() as TimestampMs;
 
-	const eventWaitEntries: EventWaitRowInsert[] = [];
+	const eventWaitEntries: Omit<EventWaitRowInsert, "signalSequence">[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
@@ -186,7 +187,7 @@ async function transitionToQueuedInTx(
 			filter: { id: string; revision: number };
 			update: { stateTransitionId: string };
 		}>;
-		eventWaitEntries: EventWaitRowInsert[];
+		eventWaitEntries: Omit<EventWaitRowInsert, "signalSequence">[];
 		stateTransitionEntries: StateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
@@ -222,7 +223,24 @@ async function transitionToQueuedInTx(
 		return [];
 	}
 
-	await txRepos.eventWait.insert(eventWaitEntriesToInsert);
+	const incrementedRuns = await txRepos.workflowRun.bulkIncrementSignalSequence(
+		asNonEmptyArray(
+			outboxEntriesToInsert.map((entry) => ({
+				namespaceId: entry.namespaceId as NamespaceId,
+				id: entry.workflowRunId as WorkflowRunId,
+			}))
+		)
+	);
+	const incrementedRunsByRunId = new Map(incrementedRuns.map((run) => [run.id, run]));
+	const sequenceStampedEventWaitEntries = eventWaitEntriesToInsert.map((entry) => {
+		const incrementedRun = incrementedRunsByRunId.get(entry.workflowRunId);
+		if (incrementedRun === undefined) {
+			throw new Error(`Run not found: ${entry.workflowRunId}`);
+		}
+		return { ...entry, signalSequence: incrementedRun.signalSequence };
+	});
+
+	await txRepos.eventWait.insert(sequenceStampedEventWaitEntries);
 	await txRepos.stateTransition.appendBatch(stateTransitionEntriesToInsert);
 	await txRepos.workflowRunOutbox.createBatch(outboxEntriesToInsert);
 	return outboxEntriesToInsert;

--- a/sdk/server/src/infra/db/event-wait.integration.test.ts
+++ b/sdk/server/src/infra/db/event-wait.integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { createServiceHarness } from "../../testing/harness";
+import { seedClaimedRun } from "../../testing/seed/run";
+
+const withHarness = createServiceHarness();
+
+describe("event wait repository", () => {
+	test("lists a run's waits in stamp order, not id order", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+
+			// Ids and stamps deliberately disagree: the second-accepted signal carries the
+			// smaller id, as two server replicas landing in the same millisecond can produce.
+			await repos.eventWait.insert([
+				{
+					id: "01-smaller-id",
+					workflowRunId: runId,
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-2" },
+					signalSequence: 2,
+				},
+				{
+					id: "02-larger-id",
+					workflowRunId: runId,
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-1" },
+					signalSequence: 1,
+				},
+			]);
+
+			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
+				expect.objectContaining({ signalSequence: 1, data: { trackingId: "TRK-1" } }),
+				expect.objectContaining({ signalSequence: 2, data: { trackingId: "TRK-2" } }),
+			]);
+		}));
+});

--- a/sdk/server/src/infra/db/pg/migration/0027_cultured_ghost_rider.sql
+++ b/sdk/server/src/infra/db/pg/migration/0027_cultured_ghost_rider.sql
@@ -1,0 +1,27 @@
+DROP INDEX "idx_event_wait_workflow_run_id";--> statement-breakpoint
+ALTER TABLE "event_wait" ADD COLUMN "signal_sequence" integer;--> statement-breakpoint
+
+-- Backfill: number each run's existing rows in id order — the only order recorded so
+-- far — so in-flight runs replay their waits in the order they always have.
+UPDATE "event_wait"
+   SET "signal_sequence" = "numbered"."rn"
+  FROM (
+    SELECT "id", ROW_NUMBER() OVER (PARTITION BY "workflow_run_id" ORDER BY "id") AS "rn"
+      FROM "event_wait"
+  ) AS "numbered"
+ WHERE "event_wait"."id" = "numbered"."id";--> statement-breakpoint
+
+-- Raise each run's sequence to at least its row count, so the next delivery stamps
+-- above every backfilled row. Never lowered: child terminal deliveries also bump this
+-- counter, and lowering it could make a stale park's expected sequence match again.
+UPDATE "workflow_run"
+   SET "signal_sequence" = GREATEST("workflow_run"."signal_sequence", "counts"."n")
+  FROM (
+    SELECT "workflow_run_id", COUNT(*)::integer AS "n"
+      FROM "event_wait"
+     GROUP BY "workflow_run_id"
+  ) AS "counts"
+ WHERE "workflow_run"."id" = "counts"."workflow_run_id";--> statement-breakpoint
+
+ALTER TABLE "event_wait" ALTER COLUMN "signal_sequence" SET NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_event_wait_workflow_run_signal_sequence_id" ON "event_wait" USING btree ("workflow_run_id","signal_sequence","id");

--- a/sdk/server/src/infra/db/pg/migration/meta/0027_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0027_snapshot.json
@@ -1,0 +1,1787 @@
+{
+	"id": "192a047b-690e-4254-b3a8-7a69091f1197",
+	"prevId": "78c8cdd0-7c1e-46c0-b761-76d40afffbf9",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_signal_sequence_id": {
+					"name": "idx_event_wait_workflow_run_signal_sequence_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "signal_sequence",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -183,6 +183,13 @@
 			"when": 1787581975349,
 			"tag": "0026_blue_stone_men",
 			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1787733229831,
+			"tag": "0027_cultured_ghost_rider",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/event-wait.ts
+++ b/sdk/server/src/infra/db/pg/repository/event-wait.ts
@@ -28,7 +28,7 @@ export const createEventWaitRepository = (db: PgDb) => ({
 			.select()
 			.from(eventWait)
 			.where(eq(eventWait.workflowRunId, workflowRunId))
-			.orderBy(eventWait.id)
+			.orderBy(eventWait.signalSequence, eventWait.id)
 			.limit(10_000);
 	},
 });

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -294,6 +294,8 @@ export const eventWait = pgTable(
 		status: eventWaitStatusEnum("status").notNull(),
 		referenceId: text("reference_id"),
 
+		signalSequence: integer("signal_sequence").notNull(),
+
 		data: jsonb("data"),
 
 		timedOutAt: timestampMs("timed_out_at"),
@@ -307,7 +309,7 @@ export const eventWait = pgTable(
 			foreignColumns: [workflowRun.id],
 		}),
 		uniqueIndex("uqidx_event_wait_workflow_run_name_reference").on(table.workflowRunId, table.name, table.referenceId),
-		index("idx_event_wait_workflow_run_id").on(table.workflowRunId, table.id),
+		index("idx_event_wait_workflow_run_signal_sequence_id").on(table.workflowRunId, table.signalSequence, table.id),
 		check(
 			"chk_event_wait_timeout_requires_timed_out_at",
 			sql`${table.status} != 'timeout' OR ${table.timedOutAt} IS NOT NULL`

--- a/sdk/server/src/service/event.integration.test.ts
+++ b/sdk/server/src/service/event.integration.test.ts
@@ -43,6 +43,7 @@ describe("EventService sendEventToWorkflowRun", () => {
 					status: "received",
 					data: { trackingId: "TRK-1" },
 					referenceId: null,
+					signalSequence: 1,
 				}),
 			]);
 		}));
@@ -70,8 +71,15 @@ describe("EventService sendEventToWorkflowRun", () => {
 					status: "received",
 					data: { trackingId: "TRK-1" },
 					referenceId: "carrier-callback-1",
+					// The deduplicated repeat send bumped the sequence but wrote no row; the
+					// first send's stamp survives.
+					signalSequence: 1,
 				}),
 			]);
+			// The bump is unconditional — it happens before the send can know it is a
+			// duplicate. The run's counter shows both sends; only the row shows one.
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(expect.objectContaining({ run: expect.objectContaining({ id: runId, signalSequence: 2 }) }));
 		}));
 
 	test("two sends without a reference record two waits", () =>
@@ -91,8 +99,18 @@ describe("EventService sendEventToWorkflowRun", () => {
 			await send("TRK-2");
 
 			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
-				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-1" } }),
-				expect.objectContaining({ name: "orderShipped", status: "received", data: { trackingId: "TRK-2" } }),
+				expect.objectContaining({
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-1" },
+					signalSequence: 1,
+				}),
+				expect.objectContaining({
+					name: "orderShipped",
+					status: "received",
+					data: { trackingId: "TRK-2" },
+					signalSequence: 2,
+				}),
 			]);
 		}));
 

--- a/sdk/server/src/service/event.ts
+++ b/sdk/server/src/service/event.ts
@@ -98,6 +98,7 @@ async function sendEventToWorkflowRunInTx(
 		name: eventName,
 		status: "received",
 		referenceId: reference?.id,
+		signalSequence: run.signalSequence,
 		data,
 	};
 	if (propsRequiredNonNull(eventWaitEntry, "referenceId")) {

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -186,7 +186,7 @@ export async function seedPublishedRun(deps: SeedRunDeps & { publisher: FakePubl
 
 export async function seedAwaitingEventRun(
 	deps: SeedRunDeps & { publisher: FakePublisher },
-	params: { eventName: string }
+	params: { eventName: string; timeoutInMs?: number }
 ) {
 	const { repos } = deps;
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
@@ -196,7 +196,7 @@ export async function seedAwaitingEventRun(
 	const parked = await services.workflowRunStateMachine.transitionState(namespaceRequestContext, {
 		type: "optimistic",
 		id: seeded.runId,
-		state: { status: "awaiting_event", eventName: params.eventName },
+		state: { status: "awaiting_event", eventName: params.eventName, timeoutInMs: params.timeoutInMs },
 		expectedRevision: seeded.revisionWhenClaimed,
 		expectedSignalSequence: 0,
 	});


### PR DESCRIPTION
## Motivation

`event_wait` rows are the durable record of every event a run has received or timed out on. Replay hands them out by position: the first `wait()` on a name gets the first stored row for that name, the second gets the second. Position comes from sort order, and today that is the row's id — a ULID, ordered by time only down to the millisecond, with a random tiebreak inside it.

The run row already carries `signal_sequence`, a counter every event send increments before it does anything else, while holding the run's row lock. The bump order is the only value in the system that records the order the server accepted the sends — across replicas, inside a millisecond — but it is thrown away: nothing writes it to the row it delivered.

So two sends with a real order can be stored inverted:

```
sender A (replica 1)                 sender B (replica 2, after A returned)
bump → 1
insert row, id 01H…X
                                     bump → 2
                                     insert row, id 01H…W   ← same millisecond,
                                                              smaller random tiebreak
```

Stored in id order, B's row comes first, and the first `wait()` on that name gets B's event. Nothing detects it — both rows are valid, only their order is wrong.

The timeout daemon writes to the same stream: when a parked run's deadline passes, it inserts a `timeout` row that a later `wait()` consumes by position. Those rows have the same ordering problem and today do not touch the sequence at all.

## Solution

`event_wait` gains a `signal_sequence` column, stamped at insert with the value the sender's bump returned. Replay orders by stamp, with the id as a stable tiebreak. The sender already bumps first and holds the run's lock, so the value is free; the interleaving above stores A at 1 and B at 2 regardless of ids.

**The timeout daemon becomes a bumping sender.** In the transaction that moves timed-out runs to `queued`, the runs whose revision-guarded transition won are bumped in bulk and each timeout row is stamped with its run's returned value. A run that moved after the listing gets no row, no stamp, and no bump.

**A deduplicated repeat send keeps the first stamp.** Sends carrying a reference id are idempotent: the repeat's insert conflicts and writes nothing. The repeat still bumps — the bump comes first, before the send can know it is a duplicate — so the sequence gains a gap and the surviving row keeps the first send's stamp. That is deliberate: the stamp is the row's position in replay order, and positions never move once written.

**Migration and backfill.** The column arrives nullable; existing rows are numbered 1..N per run in id order — the only order recorded so far, so in-flight runs replay exactly as before — and then the column becomes `NOT NULL`. Each run's counter is raised to `GREATEST(current, N)` so the next delivery stamps above every backfilled row. It is raised, never set: child runs reaching a terminal status bump the same counter, so a run's sequence can already sit above its event-row count, and lowering it could make a parked worker's stale expected sequence match again.

**Index.** `idx_event_wait_workflow_run_id` on `(workflow_run_id, id)` existed so the per-run listing came back index-ordered. The listing's order changed, so the index follows: it is replaced by `(workflow_run_id, signal_sequence, id)`, keeping the read sort-free and the index count flat.