### PR TITLE
Sequence-stamped child wait rows

### DIFF
--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
@@ -112,6 +112,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 					childWorkflowRunStatus: null,
 					childWorkflowRunStateTransitionId: null,
 					childWorkflowRunState: null,
+					signalSequence: null,
 				}),
 			]);
 		}));

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -231,10 +231,10 @@ async function transitionToQueuedInTx(
 			}))
 		)
 	);
-	const incrementedRunsByRunId = new Map(incrementedRuns.map((run) => [run.id, run]));
+	const incrementedRunsById = new Map(incrementedRuns.map((run) => [run.id, run]));
 	const sequenceStampedEventWaitEntries = eventWaitEntriesToInsert.map((entry) => {
-		const incrementedRun = incrementedRunsByRunId.get(entry.workflowRunId);
-		if (incrementedRun === undefined) {
+		const incrementedRun = incrementedRunsById.get(entry.workflowRunId);
+		if (!incrementedRun) {
 			throw new Error(`Run not found: ${entry.workflowRunId}`);
 		}
 		return { ...entry, signalSequence: incrementedRun.signalSequence };

--- a/sdk/server/src/infra/db/pg/migration/0028_windy_ghost_rider.sql
+++ b/sdk/server/src/infra/db/pg/migration/0028_windy_ghost_rider.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "child_workflow_run_wait" DROP CONSTRAINT "chk_child_workflow_run_wait_completed_invariants";--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" DROP CONSTRAINT "chk_child_workflow_run_wait_timeout_invariants";--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" ADD COLUMN "signal_sequence" integer;--> statement-breakpoint
+
+-- Backfill: rows delivered before stamps existed carry stamp 0 — below every worker's
+-- cursor, so no delta read ever returns them, and every record load includes them.
+-- Timeout rows stay null. Child rows are not ordered by the stamp, so nothing renumbers.
+UPDATE "child_workflow_run_wait" SET "signal_sequence" = 0 WHERE "status" = 'completed';--> statement-breakpoint
+
+ALTER TABLE "child_workflow_run_wait" ADD CONSTRAINT "chk_child_workflow_run_wait_completed_invariants" CHECK ("child_workflow_run_wait"."status" != 'completed' OR ("child_workflow_run_wait"."completed_at" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_state_transition_id" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_status" IS NOT NULL AND "child_workflow_run_wait"."signal_sequence" IS NOT NULL));--> statement-breakpoint
+ALTER TABLE "child_workflow_run_wait" ADD CONSTRAINT "chk_child_workflow_run_wait_timeout_invariants" CHECK ("child_workflow_run_wait"."status" != 'timeout' OR ("child_workflow_run_wait"."timed_out_at" IS NOT NULL AND "child_workflow_run_wait"."child_workflow_run_status" IS NULL AND "child_workflow_run_wait"."child_workflow_run_state_transition_id" IS NULL AND "child_workflow_run_wait"."signal_sequence" IS NULL));

--- a/sdk/server/src/infra/db/pg/migration/meta/0028_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0028_snapshot.json
@@ -1,0 +1,1793 @@
+{
+	"id": "236c2b16-3d12-4747-986b-0abd006fb02c",
+	"prevId": "192a047b-690e-4254-b3a8-7a69091f1197",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_signal_sequence_id": {
+					"name": "idx_event_wait_workflow_run_signal_sequence_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "signal_sequence",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_status_next_run_at_id": {
+					"name": "idx_schedule_status_next_run_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_status_next_attempt_at_workflow_run": {
+					"name": "idx_task_status_next_attempt_at_workflow_run",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_scheduled_at_id": {
+					"name": "idx_workflow_run_status_scheduled_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_wakeup_at_id": {
+					"name": "idx_workflow_run_status_wakeup_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_timeout_at_id": {
+					"name": "idx_workflow_run_status_timeout_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_status_next_attempt_at_id": {
+					"name": "idx_workflow_run_status_next_attempt_at_id",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -190,6 +190,13 @@
 			"when": 1787733229831,
 			"tag": "0027_cultured_ghost_rider",
 			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1787738519135,
+			"tag": "0028_windy_ghost_rider",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -294,6 +294,13 @@ export const eventWait = pgTable(
 		status: eventWaitStatusEnum("status").notNull(),
 		referenceId: text("reference_id"),
 
+		// The run's signal_sequence at the moment this row was written. Rows are handed to
+		// the workflow's waits in this order: the value is assigned under the run's row
+		// lock, so it is exactly the order the server accepted the sends — ids order only
+		// down to the millisecond and can invert two sends that land close together on
+		// different server replicas. Timeout rows sit in the same ordered queue as received
+		// rows, so they carry it too. It also lets a worker fetch just the rows written
+		// after the copy it loaded, the same catch-up the child wait column below serves.
 		signalSequence: integer("signal_sequence").notNull(),
 
 		data: jsonb("data"),
@@ -331,6 +338,14 @@ export const childWorkflowRunWait = pgTable(
 
 		childWorkflowRunStateTransitionId: text("child_workflow_run_state_transition_id"),
 
+		// The parent run's signal_sequence at the moment this row was written. A child can
+		// finish while its parent is executing, so a row can land that the parent's loaded
+		// copy of this table lacks; the value lets the parent fetch just the rows written
+		// after its copy, instead of re-reading everything. A timeout row cannot land that
+		// way — it is written only while the parent is parked, and the parent re-reads
+		// everything when it wakes — so there is nothing to catch up on, and it stays null.
+		signalSequence: integer("signal_sequence"),
+
 		createdAt: timestampMs("created_at").notNull().default(sql`now()`),
 	},
 	(table) => [
@@ -352,11 +367,11 @@ export const childWorkflowRunWait = pgTable(
 		index("idx_child_workflow_run_wait_parent_id").on(table.parentWorkflowRunId, table.id),
 		check(
 			"chk_child_workflow_run_wait_completed_invariants",
-			sql`${table.status} != 'completed' OR (${table.completedAt} IS NOT NULL AND ${table.childWorkflowRunStateTransitionId} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NOT NULL)`
+			sql`${table.status} != 'completed' OR (${table.completedAt} IS NOT NULL AND ${table.childWorkflowRunStateTransitionId} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NOT NULL AND ${table.signalSequence} IS NOT NULL)`
 		),
 		check(
 			"chk_child_workflow_run_wait_timeout_invariants",
-			sql`${table.status} != 'timeout' OR (${table.timedOutAt} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NULL AND ${table.childWorkflowRunStateTransitionId} IS NULL)`
+			sql`${table.status} != 'timeout' OR (${table.timedOutAt} IS NOT NULL AND ${table.childWorkflowRunStatus} IS NULL AND ${table.childWorkflowRunStateTransitionId} IS NULL AND ${table.signalSequence} IS NULL)`
 		),
 	]
 );

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -35,18 +35,6 @@ export async function deliverTerminatedSignalToParentRun(
 	logger: Logger,
 	imminentRunTimerQueue: ImminentRunTimerQueue | undefined
 ): Promise<void> {
-	await txRepos.childWorkflowRunWait.insert(
-		runs.map((run) => ({
-			id: ulid(),
-			parentWorkflowRunId: run.parentWorkflowRunId,
-			childWorkflowRunId: run.id,
-			childWorkflowRunStatus: run.status,
-			status: "completed",
-			completedAt: now,
-			childWorkflowRunStateTransitionId: run.latestStateTransitionId,
-		}))
-	);
-
 	const parentsRunsById = new Map<WorkflowRunId, { namespaceId: NamespaceId; id: WorkflowRunId }>();
 	for (const run of runs) {
 		const parentRunId = run.parentWorkflowRunId as WorkflowRunId;
@@ -58,6 +46,28 @@ export async function deliverTerminatedSignalToParentRun(
 	// is running but there is a concurrent state transition moving it to awaiting_child_workflow
 	const incrementedParentsRuns = await txRepos.workflowRun.bulkIncrementSignalSequence(
 		asNonEmptyArray(Array.from(parentsRunsById.values()))
+	);
+
+	// The bump comes first so its returned value can stamp the rows: siblings in one
+	// batch share their parent's stamp.
+	const incrementedParentRunsById = new Map(incrementedParentsRuns.map((run) => [run.id, run]));
+	await txRepos.childWorkflowRunWait.insert(
+		runs.map((run) => {
+			const incrementedParentRun = incrementedParentRunsById.get(run.parentWorkflowRunId);
+			if (!incrementedParentRun) {
+				throw new Error(`Parent run not found: ${run.parentWorkflowRunId}`);
+			}
+			return {
+				id: ulid(),
+				parentWorkflowRunId: run.parentWorkflowRunId,
+				childWorkflowRunId: run.id,
+				childWorkflowRunStatus: run.status,
+				status: "completed",
+				completedAt: now,
+				childWorkflowRunStateTransitionId: run.latestStateTransitionId,
+				signalSequence: incrementedParentRun.signalSequence,
+			};
+		})
 	);
 
 	const parkedParentsRuns = incrementedParentsRuns.filter((parent) => parent.status === "awaiting_child_workflow");

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -939,6 +939,7 @@ describe("WorkflowRunStateMachine child terminal signals", () => {
 						childWorkflowRunStatus: status,
 						status: "completed",
 						childWorkflowRunState: expectedChildState,
+						signalSequence: 1,
 					}),
 				]);
 			}));

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -298,6 +298,24 @@ describe("WorkflowRunService cancelByIds", () => {
 					state: { status: "running" },
 				})
 			);
+			// Both siblings were delivered by the one bump, so their rows share its stamp.
+			// The bulk cancellation decides which child's row is written first, so the set
+			// is compared sorted rather than in listing order.
+			const waitRows = await repos.childWorkflowRunWait.listByParentRunIdWithChildState(parent.runId);
+			expect(
+				waitRows
+					.map((row) => ({
+						childWorkflowRunId: row.childWorkflowRunId,
+						status: row.status,
+						signalSequence: row.signalSequence,
+					}))
+					.sort((a, b) => (a.childWorkflowRunId < b.childWorkflowRunId ? -1 : 1))
+			).toEqual(
+				[
+					{ childWorkflowRunId: firstChild.runId, status: "completed" as const, signalSequence: 1 },
+					{ childWorkflowRunId: secondChild.runId, status: "completed" as const, signalSequence: 1 },
+				].sort((a, b) => (a.childWorkflowRunId < b.childWorkflowRunId ? -1 : 1))
+			);
 		}));
 
 	test("cancelling a child adds the woken parent's timer to the priority queue", () =>


### PR DESCRIPTION
## Motivation

When a child run reaches a terminal status, delivery writes a `child_workflow_run_wait` row recording the outcome for its parent, bumps the parent's `signal_sequence` — the counter on the run row that counts signals delivered to it — and wakes the parent if it is parked on that child. The bump happens after the rows are inserted, and the rows do not record the counter's value.

That leaves child wait rows as the one signal stream whose rows cannot be addressed by the sequence. Event rows carry the value each send's bump returned; a child terminal row carries nothing. The consumer this matters for is a planned refresh read — not in this PR — that fetches only the rows written after the sequence a worker last saw, instead of re-reading the whole record: a child can finish while its parent is executing, so a row can exist that the parent's loaded copy lacks, and without a value on the row there is no way to ask for "just what I missed".

## Solution

Delivery bumps first, then inserts the rows stamped with the value each parent's bump returned. A batch that delivers several children of one parent still bumps that parent once, so sibling rows share a stamp — they were written in one transaction and there is no order between them to record.

Unlike the event column, this one does no ordering work. Event rows form one queue per name where received and timeout rows interleave, so every row needs a position. Child rows are split by the record into per-child timeouts and one terminal outcome, and the timeouts are interchangeable — consuming one yields only "timed out" — so nothing sorts child rows by the stamp. The column serves the catch-up read alone, which decides the null rule:

| row | `signal_sequence` |
|---|---|
| terminal outcome | the delivering bump's value — required | | timeout | null — forbidden |

A timeout row is written only while the parent is parked, and a parked parent re-reads everything when it wakes, so a timeout row can never be one a worker missed. The table's check constraints encode the split the same way they already encode the other per-kind columns.

The migration adds the column between dropping and re-adding the tightened constraints, backfilling existing terminal rows to `0`: below every worker's sequence, so a catch-up read never returns them, while every full record load still includes them. Nothing is renumbered and the run counters are untouched.

## DB Migration

- Schema migration on `child_workflow_run_wait`: adds `signal_sequence`, backfills terminal rows to `0`, and tightens both check constraints (required on `completed` rows, forbidden on `timeout` rows).