### PR TITLE
Completion-only manual task writes

### DIFF
--- a/sdk/server/src/contract/schema/task.ts
+++ b/sdk/server/src/contract/schema/task.ts
@@ -59,14 +59,6 @@ export const taskRecordSchema = type({
 });
 
 export const taskSetStateRequestSchema = type({
-	type: "'new'",
-	workflowRunId: "string > 0",
-	taskName: "string > 0",
-	"input?": "unknown",
-	inputHash: "string > 0",
-	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),
-}).or({
-	type: "'existing'",
 	id: "string > 0",
 	workflowRunId: "string > 0",
 	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -7,7 +7,7 @@ import { InvalidTaskStateTransitionError, WorkflowRunTerminatedError } from "../
 import { createTaskService } from "../service/task";
 import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
 import { createServiceHarness } from "../testing/harness";
-import { completeRun, seedClaimedRun, seedCompletedRun } from "../testing/seed/run";
+import { completeRun, seedClaimedRun } from "../testing/seed/run";
 import { seedCompletedTask, seedRunningTask } from "../testing/seed/task";
 
 const withHarness = createServiceHarness();
@@ -71,33 +71,50 @@ describe("TaskService getTaskById", () => {
 });
 
 describe("TaskService setTaskState", () => {
-	test("creates a new task with the request's input hash and terminal state", () =>
+	test("completes a running task with the request's output", () =>
 		withHarness(async ({ context, repos, publisher }) => {
-			const { runId } = await seedClaimedRun({
+			const { runId, taskInfo } = await seedRunningTask({
 				namespaceRequestContext: context,
 				repos,
 				publisher,
 			});
 
-			const input = { sku: "SKU-42", quantity: 3 };
-			const inputHash = "request-input-hash";
 			const output = { reservationId: "rsv-1" };
-
 			const taskService = createTaskService({ repos });
 			await taskService.setTaskState(context, {
-				type: "new",
+				id: taskInfo.id,
 				workflowRunId: runId,
-				taskName: "reserve-inventory",
-				input,
-				inputHash,
 				state: { status: "completed", output },
 			});
 
 			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([
 				expect.objectContaining({
-					name: "reserve-inventory",
-					inputHash,
-					state: { status: "completed", attempts: 1, output },
+					id: taskInfo.id,
+					state: { status: "completed", attempts: 2, output },
+				}),
+			]);
+		}));
+
+	test("fails a running task with the request's error", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, taskInfo } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const error = { name: "Error", message: "inventory system unreachable" };
+			const taskService = createTaskService({ repos });
+			await taskService.setTaskState(context, {
+				id: taskInfo.id,
+				workflowRunId: runId,
+				state: { status: "failed", error },
+			});
+
+			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([
+				expect.objectContaining({
+					id: taskInfo.id,
+					state: { status: "failed", attempts: 2, error },
 				}),
 			]);
 		}));
@@ -125,7 +142,6 @@ describe("TaskService setTaskState", () => {
 			const taskService = createTaskService({ repos });
 			expect(
 				taskService.setTaskState(context, {
-					type: "existing",
 					id: victimTaskSeed.taskInfo.id,
 					workflowRunId: attackerRunSeed.runId,
 					state: { status: "completed", output: "hijacked" },
@@ -135,29 +151,6 @@ describe("TaskService setTaskState", () => {
 			expect(await repos.task.getById({ id: victimTaskSeed.taskInfo.id, workflowRunId: victimTaskSeed.runId })).toEqual(
 				victimRowBefore
 			);
-		}));
-
-	test("does not create a task on a run that has already finished", () =>
-		withHarness(async ({ context, repos, publisher }) => {
-			const { runId } = await seedCompletedRun({
-				namespaceRequestContext: context,
-				repos,
-				publisher,
-			});
-
-			const taskService = createTaskService({ repos });
-			expect(
-				taskService.setTaskState(context, {
-					type: "new",
-					workflowRunId: runId,
-					taskName: "reserve-inventory",
-					input: { sku: "SKU-42", quantity: 3 },
-					inputHash: "request-input-hash",
-					state: { status: "completed", output: { reservationId: "rsv-1" } },
-				})
-			).rejects.toBeInstanceOf(WorkflowRunTerminatedError);
-
-			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([]);
 		}));
 
 	test("does not set an existing task's state on a run that has already finished", () =>
@@ -174,7 +167,6 @@ describe("TaskService setTaskState", () => {
 			const taskService = createTaskService({ repos });
 			expect(
 				taskService.setTaskState(context, {
-					type: "existing",
 					id: taskInfo.id,
 					workflowRunId: runId,
 					state: { status: "completed", output: { reservationId: "rsv-1" } },
@@ -197,7 +189,6 @@ describe("TaskService setTaskState", () => {
 			const taskService = createTaskService({ repos });
 			expect(
 				taskService.setTaskState(context, {
-					type: "existing",
 					id: taskInfo.id,
 					workflowRunId: runId,
 					state: { status: "failed", error: { name: "Error", message: "boom" } },
@@ -233,7 +224,6 @@ describe("TaskService setTaskState", () => {
 			const taskService = createTaskService({ repos });
 			expect(
 				taskService.setTaskState(context, {
-					type: "existing",
 					id: taskInfo.id,
 					workflowRunId: runId,
 					state: { status: "failed", error: { name: "Error", message: "boom" } },

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -1,12 +1,8 @@
 import { NotFoundError } from "@aikirun/lib/error";
-import type {
-	TaskSetStateRequestExisting,
-	TaskSetStateRequestNew,
-	TaskSetStateRequestV1,
-} from "@aikirun/types/api/task";
+import type { TaskSetStateRequestV1 } from "@aikirun/types/api/task";
 import { isTerminalWorkflowRunStatus, type WorkflowRunId } from "@aikirun/types/workflow/run";
-import type { TaskId, TaskName, TaskRecord, TaskState, TaskStateRunning } from "@aikirun/types/workflow/task";
-import { monotonicFactory, ulid } from "ulidx";
+import type { TaskId, TaskName, TaskRecord, TaskState } from "@aikirun/types/workflow/task";
+import { ulid } from "ulidx";
 
 import { assertIsValidTaskStateTransition } from "./state-machine/task";
 import { TaskStateConflictError, WorkflowRunTerminatedError } from "../errors";
@@ -16,8 +12,6 @@ import type { NamespaceRequestContext } from "../middleware/context";
 export interface TaskServiceDeps {
 	repos: Repositories;
 }
-
-const monotonicUlid = monotonicFactory();
 
 export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 	async getTaskById(context: NamespaceRequestContext, taskId: string): Promise<TaskRecord> {
@@ -38,16 +32,9 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 	},
 
 	async setTaskState(context: NamespaceRequestContext, request: TaskSetStateRequestV1): Promise<void> {
-		if (request.type === "new") {
-			const taskId = await repos.transaction(async (txRepos) => setNewTaskStateInTx(context, request, txRepos));
-			context.logger.info("New task state set", {
-				"aiki.taskId": taskId,
-				"aiki.state": request.state,
-			});
-			return;
-		}
-		await repos.transaction(async (txRepos) => setExistingTaskStateInTx(context, request, txRepos));
-		context.logger.info("Existing task state set", {
+		await repos.transaction(async (txRepos) => setTaskStateInTx(context, request, txRepos));
+		context.logger.info("Task state set", {
+			"aiki.workflowRunId": request.workflowRunId,
 			"aiki.taskId": request.id,
 			"aiki.state": request.state,
 		});
@@ -56,72 +43,9 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 
 export type TaskService = ReturnType<typeof createTaskService>;
 
-async function setNewTaskStateInTx(
+async function setTaskStateInTx(
 	{ namespaceId }: NamespaceRequestContext,
-	request: TaskSetStateRequestNew,
-	txRepos: TxRepositories
-): Promise<TaskId> {
-	const runId = request.workflowRunId as WorkflowRunId;
-	const run = await txRepos.workflowRun.getById({ namespaceId, id: runId }, { lock: "share" });
-	if (!run) {
-		throw new NotFoundError(`Workflow run not found: ${runId}`);
-	}
-	if (isTerminalWorkflowRunStatus(run.status)) {
-		throw new WorkflowRunTerminatedError(runId, run.status);
-	}
-
-	const taskId = ulid() as TaskId;
-	const runningStateTransitionId = monotonicUlid();
-	const targetStateTransitionId = monotonicUlid();
-
-	const runningState: TaskStateRunning = {
-		status: "running",
-		attempts: 1,
-	};
-
-	const targetState: TaskState =
-		request.state.status === "completed"
-			? { status: "completed", attempts: 1, output: request.state.output }
-			: { status: request.state.status satisfies "failed", attempts: 1, error: request.state.error };
-
-	await txRepos.task.create({
-		id: taskId,
-		name: request.taskName,
-		workflowRunId: runId,
-		status: targetState.status,
-		attempts: 1,
-		input: request.input,
-		inputHash: request.inputHash,
-		options: null,
-		latestStateTransitionId: targetStateTransitionId,
-	});
-	await txRepos.stateTransition.appendBatch([
-		{
-			id: runningStateTransitionId,
-			workflowRunId: runId,
-			type: "task",
-			taskId,
-			status: runningState.status,
-			attempt: runningState.attempts,
-			state: runningState,
-		},
-		{
-			id: targetStateTransitionId,
-			workflowRunId: runId,
-			type: "task",
-			taskId,
-			status: targetState.status,
-			attempt: targetState.attempts,
-			state: targetState,
-		},
-	]);
-
-	return taskId;
-}
-
-async function setExistingTaskStateInTx(
-	{ namespaceId }: NamespaceRequestContext,
-	request: TaskSetStateRequestExisting,
+	request: TaskSetStateRequestV1,
 	txRepos: TxRepositories
 ): Promise<void> {
 	const runId = request.workflowRunId as WorkflowRunId;

--- a/types/src/api/task.ts
+++ b/types/src/api/task.ts
@@ -77,20 +77,8 @@ export interface TaskTransitionStateResponseV1 {
 	taskInfo: TaskInfo;
 }
 
-export interface TaskSetStateRequestNew {
-	type: "new";
-	workflowRunId: string;
-	taskName: string;
-	input?: unknown;
-	inputHash: string;
-	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
-}
-
-export interface TaskSetStateRequestExisting {
-	type: "existing";
+export interface TaskSetStateRequestV1 {
 	id: string;
 	workflowRunId: string;
 	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
 }
-
-export type TaskSetStateRequestV1 = TaskSetStateRequestNew | TaskSetStateRequestExisting;


### PR DESCRIPTION
## Motivation

The manual task-write endpoint records a task outcome from outside the workflow: it can complete or fail a task that is `running`, or create a completed task the workflow never ran, so the next replay picks the result up as if the task had executed.

Creation breaks replay. The workflow replays against a manifest of its stored task rows: while any row is unconsumed, a call that finds no row of its own fails the run with a divergence error. A row created at a step the workflow has not reached is exactly that — on the next replay, the first call short of that step finds the injected row unconsumed and none of its own, and the run fails. A live worker cannot even see the row (nothing refreshes its record mid-run), so it does the work and writes its own, leaving two rows at one step: replay reads the wrong one and the leftover fails any later call the same way. Creation is also the one outside write that inserts rows into the task table rather than filling in a row the workflow's own execution created.

## Solution

The endpoint only writes existing rows: it completes or fails a task that is `running`. An in-place write cannot break replay — the row's place in the replay order was fixed when the execution created it — and a race with the execution finishing the same task is settled by the task's status-and-attempts guard: one write wins, the other gets a task-state conflict.

With one variant left, the request drops the create arm and its discriminant:

```ts
// before
type TaskSetStateRequestV1 =
	| { type: "new"; workflowRunId: string; taskName: string; input?: unknown; inputHash: string; state: State }
	| { type: "existing"; id: string; workflowRunId: string; state: State };

// after
interface TaskSetStateRequestV1 {
	id: string;
	workflowRunId: string;
	state: State; // completed or failed, without attempts
}
```

The capability creation served — recording work done outside the system so a step never executes — is modeled as an event wait instead: the workflow waits for an event at that step, and the operator sends the event carrying the result. Events are the channel built for data that arrives from outside, with ordering and delivery already defined.

## Breaking changes

The set-state endpoint's wire contract changed: the create variant is removed, and the surviving request no longer carries a `type` discriminant. No database change — rows created manually before this change replay as before.