### PR TITLE
Priority as a run option

### DIFF
--- a/app/website/content/docs/core-concepts/schedules.md
+++ b/app/website/content/docs/core-concepts/schedules.md
@@ -96,8 +96,8 @@ const syncSchedule = schedule({
 
 | Policy | Behavior |
 |--------|----------|
-| `"allow"` (default) | Start a new run regardless of active runs |
-| `"skip"` | Skip this occurrence if a run is still active |
+| `"allow"` | Start a new run regardless of active runs |
+| `"skip"` (default) | Skip this occurrence if a run is still active |
 | `"cancel_previous"` | Cancel the active run and start a new one |
 
 Overlap policies are evaluated per schedule instance, not globally. If you activate the same schedule for multiple tenants with different inputs, each tenant has independent overlap handling.
@@ -120,7 +120,7 @@ await hourlySync.activate(
 );
 ```
 
-Only `retry` and `pool` travel this way. `reference` or `trigger` answers something about one particular run — which run it is, when execution begins — and a schedule fires a fresh run every tick, so passing a workflow that carries either will not compile. See [Workflow Options](./workflows.md#workflow-options).
+Only `retry`, `pool`, and `priority` travel this way. `reference` or `trigger` answers something about one particular run — which run it is, when execution begins — and a schedule fires a fresh run every tick, so passing a workflow that carries either will not compile. See [Workflow Options](./workflows.md#workflow-options).
 
 Run options are part of a schedule's identity, so changing them is a different schedule — or, with a [reference ID](#reference-ids), a conflict.
 

--- a/app/website/content/docs/core-concepts/workflows.md
+++ b/app/website/content/docs/core-concepts/workflows.md
@@ -156,7 +156,7 @@ orderWorkflowV1.with("reference.id", 123);           // ❌ reference.id is a st
 
 Look at what each option answers and they fall into two groups.
 
-`retry` answers "if this fails, try three more times". `pool` answers "run on this kind of workers". Answers like those fit any run — the one you start now, or one that goes next Tuesday. Set one and you get back something you can go on starting as often as you like.
+`retry` answers "if this fails, try three more times". `pool` answers "run on this kind of workers". `priority` answers "when several runs are due at the same instant, this one goes first". Answers like those fit any run — the one you start now, or one that goes next Tuesday. Set one and you get back something you can go on starting as often as you like.
 
 `reference` answers "this particular run is order-123" - a second run cannot be referenced as order-123. `trigger` answers "execute this particular run five minutes from now" - scheduled runs are triggered on a pre-configured cadence. Both are about one particular run — which one it is, when it goes. Set one and you get back a single start — you can `start()` it, and that is all.
 
@@ -181,6 +181,20 @@ const handle = await orderWorkflowV1
 ```
 
 Workers must be configured to serve the same pool. A workflow routed to `"tenant-acme"` will only be picked up by workers with `pools: ["tenant-acme"]` in their configuration. See **[Workers](./workers.md)** for worker-side setup.
+
+## Priority
+
+When many runs become due at the same instant — a burst of starts, schedules firing on the same tick — priority decides who dispatches first:
+
+```typescript
+const handle = await orderWorkflowV1
+	.with("priority", 2)
+	.start(client, { orderId: "123" });
+```
+
+Priority is an integer from 0 (highest) to 9 (lowest), defaulting to 5. It follows the run through its whole life: a wakeup after a sleep, a retry, or an event resumption dispatches with the same priority as the original start. Child workflows inherit their parent's priority unless they set their own.
+
+Priority never moves a run ahead of its due time. A run due earlier always dispatches first, whatever the priorities — `trigger` decides *when* a run becomes due, priority only breaks the tie among runs due at the same millisecond.
 
 ## Starting Workflows
 

--- a/sdk/server/src/contract/schema/workflow-run.ts
+++ b/sdk/server/src/contract/schema/workflow-run.ts
@@ -22,6 +22,7 @@ const workflowReferenceSchema = type({
 export const workflowRunOptionsSchema = type({
 	"pool?": "string | undefined",
 	"retry?": retryStrategySchema,
+	"priority?": "0 <= number.integer <= 9 | undefined",
 });
 
 export const workflowStartOptionsSchema = workflowRunOptionsSchema.and({

--- a/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
@@ -1,0 +1,55 @@
+import { asConfigProvider } from "@aikirun/lib/config";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+import { processDueTimers } from "./due-timers-consumer";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { computeRank } from "../lib/rank";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness } from "../testing/harness";
+import { seedScheduledRun } from "../testing/seed/run";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build();
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+describe("processDueTimers", () => {
+	test("the timer's rank flows to the outbox entry unchanged", () =>
+		withHarness(async ({ context, repos }) => {
+			const now = 1_000_000;
+			await withFakeClock(now, async () => {
+				const { runId } = await seedScheduledRun({ repos, namespaceRequestContext }, { options: { priority: 2 } });
+
+				await processDueTimers(
+					context,
+					{
+						repos,
+						signal: new AbortController().signal,
+						timerPriorityQueue: inMemoryTimerPriorityQueue()({ logger: noopLogger }),
+						childRunCanceller: createChildRunCanceller(),
+						configProvider: asConfigProvider(() => ({ limit: 100, overshootMs: 0, republishBackoff })),
+					},
+					[{ type: "scheduled", id: runId, rank: computeRank({ dueAt: now, priority: 2 }) }]
+				);
+
+				const row = await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				});
+				// computeRank(scheduledAt = now, priority 2) = 1_000_000 * 10 + 2.
+				expect(row).toEqual(
+					expect.objectContaining({
+						workflowRunId: runId,
+						status: "pending",
+						rank: 10_000_002,
+						nextPublishAttemptRank: 10_000_002,
+					})
+				);
+			});
+		}));
+});

--- a/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
@@ -1,0 +1,53 @@
+import { hashInput } from "@aikirun/lib/crypto";
+
+import { processImminentRecurringRuns } from "./imminent-recurring-runs";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createScheduleService } from "../service/schedule";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness } from "../testing/harness";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build();
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+describe("processImminentRecurringRuns", () => {
+	test("the occurrence's outbox rank carries the schedule's run priority", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput,
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
+				workflowRunOptions: { priority: 2 },
+			});
+			const { createdAt } = schedule;
+			expect(createdAt).toBeGreaterThan(0);
+
+			await withFakeClock(createdAt + 120_000, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller() },
+					{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				)
+			);
+
+			// computeRank(occurrence, priority 2) = occurrence * 10 + 2.
+			expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
+				expect.objectContaining({
+					workflowName: "send-invoices",
+					status: "pending",
+					rank: (createdAt + 120_000) * 10 + 2,
+					nextPublishAttemptRank: (createdAt + 120_000) * 10 + 2,
+				}),
+			]);
+		}));
+});

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -83,7 +83,7 @@ export async function processImminentRecurringRuns(
 			const timers: TimerEntry[] = schedulesDueSoon.map((schedule) => ({
 				type: "recurring",
 				id: schedule.id,
-				rank: computeRank({ dueAt: schedule.nextRunAt }),
+				rank: computeRank({ dueAt: schedule.nextRunAt, priority: schedule.workflowRunOptions?.priority }),
 			}));
 			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
 			if (result.status === "failed") {
@@ -180,7 +180,7 @@ async function processOverlapAllowSchedules(
 				attempt: 1,
 				state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 			});
-			const rank = computeRank({ dueAt: occurrence });
+			const rank = computeRank({ dueAt: occurrence, priority: schedule.workflowRunOptions?.priority });
 			outboxEntries.push({
 				id: ulid(),
 				namespaceId: schedule.namespaceId,
@@ -293,7 +293,7 @@ async function processOverlapSkipSchedules(
 			attempt: 1,
 			state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 		});
-		const rank = computeRank({ dueAt: occurrence });
+		const rank = computeRank({ dueAt: occurrence, priority: schedule.workflowRunOptions?.priority });
 		outboxEntries.push({
 			id: ulid(),
 			namespaceId: schedule.namespaceId,
@@ -363,7 +363,13 @@ async function processOverlapCancelPreviousSchedules(
 	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(deps.repos, schedules);
 
 	const runIdsToCancel: string[] = [];
-	const runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string }> = [];
+	const runsToCancel: Array<{
+		id: string;
+		attempts: number;
+		namespaceId: NamespaceId;
+		pool?: string;
+		priority?: number;
+	}> = [];
 
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
 	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
@@ -410,7 +416,7 @@ async function processOverlapCancelPreviousSchedules(
 			attempt: 1,
 			state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 		});
-		const rank = computeRank({ dueAt: occurrence });
+		const rank = computeRank({ dueAt: occurrence, priority: schedule.workflowRunOptions?.priority });
 		newOutboxEntries.push({
 			id: ulid(),
 			namespaceId: schedule.namespaceId,
@@ -468,7 +474,7 @@ async function cancelPreviousAndInsertRunsInTx(
 	now: TimestampMs,
 	entries: {
 		runIdsToCancel: string[];
-		runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string }>;
+		runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string; priority?: number }>;
 		newWorkflowRunEntries: NonEmptyArray<WorkflowRunRowInsert>;
 		newRunStateTransitionEntries: NonEmptyArray<StateTransitionRowInsert>;
 		scheduleUpdates: NonEmptyArray<ScheduleOccurrenceUpdate>;
@@ -528,7 +534,7 @@ async function cancelPreviousAndInsertRunsInTx(
 				filter: { namespaceId: run.namespaceId, id: run.id },
 				update: { stateTransitionId },
 			});
-			cancelledRunsMeta.push({ namespaceId: run.namespaceId, id: run.id, pool: run.pool });
+			cancelledRunsMeta.push({ namespaceId: run.namespaceId, id: run.id, pool: run.pool, priority: run.priority });
 
 			if (cancelledRun.parentWorkflowRunId !== null) {
 				cancelledRunsHavingParent.push({
@@ -589,7 +595,7 @@ async function fetchActiveRunsBySchedule(repos: Repositories, schedules: NonEmpt
 		schedulesByReferenceId.set(referenceId, schedule);
 	}
 
-	const activeRunsByScheduleId = new Map<string, { id: string; attempts: number; pool?: string }>();
+	const activeRunsByScheduleId = new Map<string, { id: string; attempts: number; pool?: string; priority?: number }>();
 
 	if (isNonEmptyArray(workflowAndReferenceIdPairs) && isNonEmptyArray(NON_TERMINAL_WORKFLOW_RUN_STATUSES)) {
 		const activeRuns = await repos.workflowRun.listByWorkflowAndReferenceIdPairs({
@@ -601,8 +607,12 @@ async function fetchActiveRunsBySchedule(repos: Repositories, schedules: NonEmpt
 			if (run.referenceId) {
 				const schedule = schedulesByWorkflowAndReferenceId.get(run.workflowId)?.get(run.referenceId);
 				if (schedule) {
-					const pool = run.options?.pool;
-					activeRunsByScheduleId.set(schedule.id, { id: run.id, attempts: run.attempts, pool });
+					activeRunsByScheduleId.set(schedule.id, {
+						id: run.id,
+						attempts: run.attempts,
+						pool: run.options?.pool,
+						priority: run.options?.priority,
+					});
 				}
 			}
 		}

--- a/sdk/server/src/daemon/imminent-retryable-tasks.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-retryable-tasks.integration.test.ts
@@ -1,0 +1,117 @@
+import { createConsoleLogger, noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+import { processImminentRetryableTasks } from "./imminent-retryable-tasks";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { computeRank } from "../lib/rank";
+import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createWorkflowRunStateMachine } from "../service/state-machine/workflow-run";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness } from "../testing/harness";
+import { seedAwaitingRetryTask } from "../testing/seed/task";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build({ logger: createConsoleLogger() });
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+describe("processImminentRetryableTasks", () => {
+	test("a due retryable task promotes its run to queued with the rank carrying the run's priority", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedAwaitingRetryTask(
+				{ namespaceRequestContext, repos, publisher },
+				{ nextAttemptAt: 1 },
+				{ options: { priority: 2 } }
+			);
+
+			await processImminentRetryableTasks(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "queued" }),
+					state: { status: "queued", reason: "task_retry" },
+				})
+			);
+
+			const row = await repos.workflowRunOutbox.getByWorkflowRunId({
+				namespaceId: namespaceRequestContext.namespaceId,
+				workflowRunId: runId,
+			});
+			// computeRank(nextAttemptAt = 1, priority 2) = 1 * 10 + 2.
+			expect(row).toEqual(
+				expect.objectContaining({ workflowRunId: runId, status: "pending", rank: 12, nextPublishAttemptRank: 12 })
+			);
+		}));
+
+	test("a task due within the lookahead window mints a timer carrying the run's priority", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId } = await seedAwaitingRetryTask(
+				{ namespaceRequestContext, repos, publisher },
+				{ nextAttemptAt: 1_030_000 },
+				{ options: { priority: 2 } }
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// At now = 1_000_000 the task is not yet due, but its due time sits inside the
+			// 60_000ms lookahead window.
+			await withFakeClock(1_000_000, () =>
+				processImminentRetryableTasks(
+					context,
+					{ repos, timerPriorityQueue },
+					{ limit: 100, lookaheadWindowMs: 60_000, republishBackoff }
+				)
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "task_retry", id: runId, rank: computeRank({ dueAt: 1_030_000, priority: 2 }) },
+			]);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toBeNull();
+		}));
+
+	test("a task whose run is no longer running promotes nothing", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			// The same seed a promotion test uses; only the pause below stops it.
+			const { runId } = await seedAwaitingRetryTask(
+				{ namespaceRequestContext, repos, publisher },
+				{ nextAttemptAt: 1 },
+				{ options: { priority: 2 } }
+			);
+
+			const stateMachine = createWorkflowRunStateMachine({ repos, childRunCanceller: createChildRunCanceller() });
+			await stateMachine.transitionState(namespaceRequestContext, {
+				type: "pessimistic",
+				id: runId,
+				state: { status: "paused" },
+			});
+
+			await processImminentRetryableTasks(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });
+
+			const run = await repos.workflowRun.getByIdWithState({
+				namespaceId: namespaceRequestContext.namespaceId,
+				id: runId,
+			});
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "paused" }),
+				})
+			);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				})
+			).toBeNull();
+		}));
+});

--- a/sdk/server/src/daemon/imminent-retryable-tasks.ts
+++ b/sdk/server/src/daemon/imminent-retryable-tasks.ts
@@ -1,6 +1,6 @@
 import { streamChunks } from "@aikirun/lib/async";
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
-import { chunkLazy, isNonEmptyArray } from "@aikirun/lib/collection/array";
+import { asNonEmptyArray, chunkLazy, isNonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { Publisher } from "@aikirun/types/infra/queue";
 import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
@@ -24,7 +24,12 @@ export interface ProcessImminentRetryableTasksDeps {
 	timerPriorityQueue?: TimerPriorityQueue;
 }
 
-const advanceTaskCursor = createKeysetStreamCursorAdvancer<{ workflowRunId: string; dueAt: TimestampMs }>({
+interface RetryableTask {
+	workflowRunId: string;
+	dueAt: TimestampMs;
+}
+
+const advanceTaskCursor = createKeysetStreamCursorAdvancer<RetryableTask>({
 	getOrder: (entry) => entry.dueAt,
 	getId: (entry) => entry.workflowRunId,
 });
@@ -38,45 +43,35 @@ export async function processImminentRetryableTasks(
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	let now = Date.now();
-	for await (const { whenTrue: tasksDueNow, whenFalse: tasksDueSoon } of streamChunks(
-		(cursor) => repos.task.listRetryableTasks(context, dueBefore, limit, cursor),
-		{
-			advanceCursor: advanceTaskCursor,
-			until: (chunk) => chunk.length < limit,
-			partition: (task: { workflowRunId: string; dueAt: TimestampMs }) => ({
-				meetsCondition: task.dueAt <= now,
-				item: task,
-			}),
-		}
-	)) {
-		if (isNonEmptyArray(tasksDueNow)) {
-			const runIds: string[] = [];
-			const rankByRunId = new Map<string, number>();
-			for (const { workflowRunId, dueAt } of tasksDueNow) {
-				runIds.push(workflowRunId);
-				rankByRunId.set(workflowRunId, computeRank({ dueAt }));
-			}
+	for await (const tasks of streamChunks((cursor) => repos.task.listRetryableTasks(context, dueBefore, limit, cursor), {
+		advanceCursor: advanceTaskCursor,
+		until: (chunk) => chunk.length < limit,
+	})) {
+		const runIds = asNonEmptyArray(tasks.map((task) => task.workflowRunId));
+		const runs = await repos.workflowRun.listByIdsAndStatus(context, runIds, "running");
+		const runsById = new Map(runs.map((run) => [run.id, run]));
 
-			const runs = await repos.workflowRun.listByIdsAndStatus(context, runIds as NonEmptyArray<string>, "running");
-			const rankedRuns: Ranked<WorkflowRunMeta>[] = [];
-			for (const run of runs) {
-				const rank = rankByRunId.get(run.id);
-				if (rank !== undefined) {
-					rankedRuns.push({ ...run, rank });
-				}
+		const rankedRuns: Ranked<WorkflowRunMeta>[] = [];
+		const timers: TimerEntry[] = [];
+		for (const { workflowRunId, dueAt } of tasks) {
+			const run = runsById.get(workflowRunId);
+			if (!run) {
+				continue;
 			}
-			if (isNonEmptyArray(rankedRuns)) {
-				await queueRetryableTasks(context, repos, publisher, republishBackoff, rankedRuns);
+			const rank = computeRank({ dueAt, priority: run.options?.priority });
+			if (dueAt <= now) {
+				rankedRuns.push({ ...run, rank });
+			} else {
+				timers.push({ type: "task_retry", id: workflowRunId, rank });
 			}
 		}
 
-		if (timerPriorityQueue && isNonEmptyArray(tasksDueSoon)) {
-			const timers: TimerEntry[] = tasksDueSoon.map((task) => ({
-				type: "task_retry",
-				id: task.workflowRunId,
-				rank: computeRank({ dueAt: task.dueAt }),
-			}));
-			const result = await timerPriorityQueue.add(timers as NonEmptyArray<TimerEntry>);
+		if (isNonEmptyArray(rankedRuns)) {
+			await queueRetryableTasks(context, repos, publisher, republishBackoff, rankedRuns);
+		}
+
+		if (timerPriorityQueue && isNonEmptyArray(timers)) {
+			const result = await timerPriorityQueue.add(timers);
 			if (result.status === "failed") {
 				context.logger.debug("Failed to add timers to priority queue", { "aiki.count": timers.length });
 			}

--- a/sdk/server/src/daemon/imminent-scheduled-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.integration.test.ts
@@ -1,0 +1,39 @@
+import { processImminentScheduledRuns } from "./imminent-scheduled-runs";
+import { describe, expect, test } from "bun:test";
+import { defaultServerRuntimeConfig } from "../config/runtime";
+import { withFakeClock } from "../testing/clock";
+import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
+import { createDaemonHarness } from "../testing/harness";
+import { seedScheduledRun } from "../testing/seed/run";
+
+const withHarness = createDaemonHarness();
+
+const namespaceRequestContext = namespaceRequestContextFactory.build();
+
+const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
+
+describe("processImminentScheduledRuns", () => {
+	test("the outbox entry's rank carries the run's priority", () =>
+		withHarness(async ({ context, repos }) => {
+			const now = 1_000_000;
+			await withFakeClock(now, async () => {
+				const { runId } = await seedScheduledRun({ repos, namespaceRequestContext }, { options: { priority: 2 } });
+
+				await processImminentScheduledRuns(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });
+
+				const row = await repos.workflowRunOutbox.getByWorkflowRunId({
+					namespaceId: namespaceRequestContext.namespaceId,
+					workflowRunId: runId,
+				});
+				// computeRank(scheduledAt = now, priority 2) = 1_000_000 * 10 + 2.
+				expect(row).toEqual(
+					expect.objectContaining({
+						workflowRunId: runId,
+						status: "pending",
+						rank: 10_000_002,
+						nextPublishAttemptRank: 10_000_002,
+					})
+				);
+			});
+		}));
+});

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -208,6 +208,7 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 				signalSequence: workflowRun.signalSequence,
 				attempts: workflowRun.attempts,
 				latestStateTransitionId: workflowRun.latestStateTransitionId,
+				options: workflowRun.options,
 			});
 	},
 

--- a/sdk/server/src/infra/db/workflow-run.integration.test.ts
+++ b/sdk/server/src/infra/db/workflow-run.integration.test.ts
@@ -458,6 +458,40 @@ describe("incrementSignalSequence", () => {
 		}));
 });
 
+describe("bulkIncrementSignalSequence", () => {
+	test("bumps the sequence of each listed run and returns each run's options", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const prioritized = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ options: { priority: 2 } }
+			);
+			const plain = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+
+			const rows = await repos.workflowRun.bulkIncrementSignalSequence([
+				{ namespaceId: context.namespaceId, id: prioritized.runId as WorkflowRunId },
+				{ namespaceId: context.namespaceId, id: plain.runId as WorkflowRunId },
+			]);
+
+			rows.sort((a, b) => (a.id < b.id ? -1 : 1));
+			expect(rows).toEqual([
+				expect.objectContaining({
+					id: prioritized.runId,
+					status: "running",
+					revision: prioritized.revisionWhenClaimed,
+					signalSequence: 1,
+					options: { priority: 2 },
+				}),
+				expect.objectContaining({
+					id: plain.runId,
+					status: "running",
+					revision: plain.revisionWhenClaimed,
+					signalSequence: 1,
+					options: null,
+				}),
+			]);
+		}));
+});
+
 // Seeds a claimed run with its ulid minted at the frozen `mintedAtMs` — later instants mint
 // larger ids, pinning the id order the cursor walk depends on — then parks it on a child wait
 // due at `timeoutAt`.

--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
@@ -22,10 +22,20 @@ describe("ImminentRunTimerQueue", () => {
 	test("adds a scheduled timer for a run due within the window", async () => {
 		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
 
-		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0 }]);
+		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0, priority: undefined }]);
 
 		expect(await timerPriorityQueue.popDue({ maxRank: computeRank({ dueAt: 0 }), limit: 10 })).toEqual([
 			{ type: "scheduled", id: "run-1", rank: computeRank({ dueAt: 0 }) },
+		]);
+	});
+
+	test("mints the timer's rank with the run's priority", async () => {
+		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
+
+		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0, priority: 2 }]);
+
+		expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+			{ type: "scheduled", id: "run-1", rank: computeRank({ dueAt: 0, priority: 2 }) },
 		]);
 	});
 
@@ -33,8 +43,8 @@ describe("ImminentRunTimerQueue", () => {
 		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
 
 		imminentRunTimerQueue.add([
-			{ id: "run-due", scheduledAt: 0 },
-			{ id: "run-far", scheduledAt: Number.MAX_SAFE_INTEGER },
+			{ id: "run-due", scheduledAt: 0, priority: undefined },
+			{ id: "run-far", scheduledAt: Number.MAX_SAFE_INTEGER, priority: undefined },
 		]);
 
 		expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([

--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
@@ -23,12 +23,12 @@ export const createImminentRunTimerQueue = ({
 	 * promoter poll. Failures are logged and dropped: the poll is the backstop,
 	 * so a missed timer costs latency, never the run.
 	 */
-	add(runs: NonEmptyArray<{ id: string; scheduledAt: number }>): void {
+	add(runs: NonEmptyArray<{ id: string; scheduledAt: number; priority: number | undefined }>): void {
 		const dueBefore = Date.now() + configProvider.config.lookaheadWindowMs;
 		const timers: TimerEntry[] = [];
-		for (const { id, scheduledAt } of runs) {
+		for (const { id, scheduledAt, priority } of runs) {
 			if (scheduledAt <= dueBefore) {
-				timers.push({ type: "scheduled", id, rank: computeRank({ dueAt: scheduledAt }) });
+				timers.push({ type: "scheduled", id, rank: computeRank({ dueAt: scheduledAt, priority }) });
 			}
 		}
 		if (!isNonEmptyArray(timers)) {

--- a/sdk/server/src/lib/timer-stream.ts
+++ b/sdk/server/src/lib/timer-stream.ts
@@ -8,6 +8,7 @@ import { computeRank, type Ranked } from "../lib/rank";
 interface Timer {
 	dueAt: TimestampMs;
 	id: string;
+	options?: { priority?: number } | null;
 }
 
 const advanceTimerStreamCursor = createKeysetStreamCursorAdvancer<Timer>({
@@ -28,7 +29,10 @@ export async function* streamTimers<Item extends Timer>(
 		until: options?.until,
 		partition: (timer) => {
 			const dueAt = timer.dueAt;
-			return { meetsCondition: dueAt <= now, item: { ...timer, rank: computeRank({ dueAt }) } };
+			return {
+				meetsCondition: dueAt <= now,
+				item: { ...timer, rank: computeRank({ dueAt, priority: timer.options?.priority }) },
+			};
 		},
 	})) {
 		yield { dueNow: whenTrue, dueSoon: whenFalse };

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -22,6 +22,7 @@ export interface CancelledRunMeta {
 	namespaceId: NamespaceId;
 	id: string;
 	pool: string | undefined;
+	priority: number | undefined;
 }
 
 export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimerQueue) => ({
@@ -90,6 +91,7 @@ export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimer
 				inputHash,
 				options: {
 					pool: parentRun.pool,
+					priority: parentRun.priority,
 					retry: {
 						type: "exponential",
 						maxAttempts: Number.MAX_SAFE_INTEGER,
@@ -120,7 +122,11 @@ export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimer
 			await txRepos.stateTransition.appendBatch(stateTransitionEntries);
 
 			if (imminentRunTimerQueue) {
-				const imminentRuns = workflowRunEntries.map((entry) => ({ id: entry.id, scheduledAt: now }));
+				const imminentRuns = workflowRunEntries.map((entry) => ({
+					id: entry.id,
+					scheduledAt: now,
+					priority: entry.options?.priority,
+				}));
 				txRepos.onCommit(() => imminentRunTimerQueue.add(asNonEmptyArray(imminentRuns)));
 			}
 		}

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -144,7 +144,15 @@ export async function deliverTerminatedSignalToParentRun(
 
 	if (imminentRunTimerQueue) {
 		txRepos.onCommit(() =>
-			imminentRunTimerQueue.add(asNonEmptyArray(scheduledParentRunIds.map((id) => ({ id, scheduledAt: now }))))
+			imminentRunTimerQueue.add(
+				asNonEmptyArray(
+					scheduledParentRunIds.map((id) => ({
+						id,
+						scheduledAt: now,
+						priority: incrementedParentRunsById.get(id)?.options?.priority,
+					}))
+				)
+			)
 		);
 	}
 

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -1049,4 +1049,75 @@ describe("WorkflowRunStateMachine imminent run timers", () => {
 				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: redeliveredAtMs }) },
 			]);
 		}));
+
+	test("a scheduled transition mints the run's timer with its priority", () =>
+		withHarness(async ({ context, repos }) => {
+			const { runId } = await seedStalledRun({ namespaceRequestContext: context, repos }, { options: { priority: 2 } });
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const redeliveredAtMs = Date.now();
+			await withFakeClock(redeliveredAtMs, () =>
+				stateMachine.transitionState(context, {
+					type: "pessimistic",
+					id: runId,
+					state: { status: "scheduled", scheduledInMs: 0, reason: "redelivery" },
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: redeliveredAtMs, priority: 2 }) },
+			]);
+		}));
+
+	test("a parent's wakeup timer carries the parent's priority", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ options: { priority: 2 } }
+			);
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: parent.runId,
+				state: { status: "awaiting_child_workflow", childWorkflowRunId: child.runId },
+				expectedRevision: parent.revisionWhenClaimed,
+				expectedSignalSequence: 0,
+			});
+
+			const childTerminatedAt = Date.now();
+			await withFakeClock(childTerminatedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: child.runId,
+					state: { status: "completed", output: { receiptId: "rcp-7" } },
+					expectedRevision: child.revisionWhenClaimed,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: parent.runId, rank: computeRank({ dueAt: childTerminatedAt, priority: 2 }) },
+			]);
+		}));
 });

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -240,12 +240,18 @@ async function transitionStateInTx(
 	});
 
 	if (imminentRunTimerQueue && toState.status === "scheduled") {
-		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt: toState.scheduledAt }]));
+		txRepos.onCommit(() =>
+			imminentRunTimerQueue.add([{ id: runId, scheduledAt: toState.scheduledAt, priority: run.options?.priority }])
+		);
 	}
 
 	if (toState.status === "cancelled") {
 		await discardStaleTasks(runId, ["running", "awaiting_retry"], txRepos);
-		await childRunCanceller.cancel([{ namespaceId, id: runId, pool: run.options?.pool }], txRepos, context.logger);
+		await childRunCanceller.cancel(
+			[{ namespaceId, id: runId, pool: run.options?.pool, priority: run.options?.priority }],
+			txRepos,
+			context.logger
+		);
 	}
 
 	if (isTerminalWorkflowRunStatus(toState.status) && propsRequiredNonNull(run, "parentWorkflowRunId")) {

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -716,6 +716,32 @@ describe("WorkflowRunService imminent run timers", () => {
 			]);
 		}));
 
+	test("the created run's timer carries its priority", () =>
+		withHarness(async ({ context, repos }) => {
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			const input = { orderId: "order-1" };
+			const inputHash = await hashInput(input);
+			const createdAtMs = Date.now();
+			const runId = await withFakeClock(createdAtMs, () =>
+				service.createWorkflowRun(context, {
+					name: "checkout",
+					versionId: "v1",
+					input,
+					inputHash: { value: inputHash },
+					options: { priority: 2 },
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: runId, rank: computeRank({ dueAt: createdAtMs, priority: 2 }) },
+			]);
+		}));
+
 	test("a run due beyond the lookahead window adds no timer", () =>
 		withHarness(async ({ context, repos }) => {
 			const timerPriorityQueue = createTimerPriorityQueue();
@@ -808,5 +834,61 @@ describe("WorkflowRunService imminent run timers", () => {
 			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
 				{ type: "scheduled", id: cancellationRun.id, rank: computeRank({ dueAt: cancelledAtMs }) },
 			]);
+		}));
+
+	test("the cancellation run inherits the cancelled parent's priority", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ options: { priority: 2 } }
+			);
+			const timerPriorityQueue = createTimerPriorityQueue();
+			const { service } = createService(
+				repos,
+				createTestImminentRunTimerQueue({ timerPriorityQueue, lookaheadWindowMs: 30_000 })
+			);
+
+			// The child carries no priority of its own: the cascade's priority can only come
+			// from the cancelled parent.
+			const childInput = { orderId: "order-9" };
+			const childRunId = await service.createWorkflowRun(context, {
+				name: parent.workflowName,
+				versionId: parent.workflowVersionId,
+				input: childInput,
+				inputHash: { value: await hashInput(childInput) },
+				parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed },
+			});
+			await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 });
+
+			const cancelledAtMs = Date.now();
+			await withFakeClock(cancelledAtMs, () => service.cancelByIds(context, { ids: [parent.runId] }));
+
+			const scheduledRuns = await repos.workflowRun.listByFilters(
+				{ namespaceId: context.namespaceId, status: ["scheduled"] },
+				10,
+				0,
+				{ order: "asc" }
+			);
+			const cancellationRun = scheduledRuns.rows.find((row) => row.id !== childRunId);
+			if (!cancellationRun) {
+				throw new Error("cancel-child-runs run was not scheduled");
+			}
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "scheduled", id: cancellationRun.id, rank: computeRank({ dueAt: cancelledAtMs, priority: 2 }) },
+			]);
+
+			const cancellationRunRecord = await repos.workflowRun.getByIdWithState({
+				namespaceId: context.namespaceId,
+				id: cancellationRun.id,
+			});
+			expect(cancellationRunRecord).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({
+						id: cancellationRun.id,
+						options: expect.objectContaining({ priority: 2 }),
+					}),
+				})
+			);
 		}));
 });

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -374,7 +374,7 @@ async function createWorkflowRunInTx(
 		status: "scheduled",
 		input,
 		inputHash: inputHash.value,
-		options: options && { retry: options.retry, pool: options.pool },
+		options: options && { retry: options.retry, pool: options.pool, priority: options.priority },
 		referenceId,
 		latestStateTransitionId: transitionId,
 		scheduledAt: scheduledAt as TimestampMs,
@@ -396,7 +396,7 @@ async function createWorkflowRunInTx(
 	});
 
 	if (imminentRunTimerQueue) {
-		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt }]));
+		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt, priority: options?.priority }]));
 	}
 
 	logger.info("Created workflow run", {
@@ -452,6 +452,7 @@ async function cancelByIdsInTx(
 			namespaceId,
 			id: run.id,
 			pool: run.options?.pool,
+			priority: run.options?.priority,
 		});
 		if (run.parentWorkflowRunId !== null) {
 			cancelledRunsHavingParent.push({

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -34,7 +34,7 @@ export interface SeedRunDeps {
 	namespaceRequestContext?: NamespaceRequestContext;
 }
 
-interface SeedRunOverrides {
+export interface SeedRunOverrides {
 	options?: WorkflowStartOptions;
 	parent?: { workflowRunId: string; expectedRevision: number };
 }
@@ -231,9 +231,9 @@ export async function seedSleepingRun(
 	};
 }
 
-export async function seedStalledRun(deps: SeedRunDeps) {
+export async function seedStalledRun(deps: SeedRunDeps, overrides?: SeedRunOverrides) {
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
-	const seeded = await withFakeClock(1 as TimestampMs, () => seedQueuedRun(deps));
+	const seeded = await withFakeClock(1 as TimestampMs, () => seedQueuedRun(deps, overrides));
 
 	await stallUndeliverableRuns(daemonContext, { repos: deps.repos }, { maxAgeMs: 60_000, limit: 100 });
 

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -1,8 +1,9 @@
 import { hashInput } from "@aikirun/lib/crypto";
 import type { FakePublisher } from "@aikirun/testing/infra/queue";
 
-import { type SeedRunDeps, seedClaimedRun } from "./run";
+import { type SeedRunDeps, type SeedRunOverrides, seedClaimedRun } from "./run";
 import { createTaskStateMachine } from "../../service/state-machine/task";
+import { withFakeClock } from "../clock";
 import { namespaceRequestContextFactory } from "../data-factory/middleware/context";
 
 const seededTask = {
@@ -11,10 +12,10 @@ const seededTask = {
 	output: { reservationId: "rsv-1" },
 } as const;
 
-export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePublisher }) {
+export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePublisher }, overrides?: SeedRunOverrides) {
 	const { repos } = deps;
 	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
-	const seeded = await seedClaimedRun({ ...deps, namespaceRequestContext });
+	const seeded = await seedClaimedRun({ ...deps, namespaceRequestContext }, overrides);
 
 	const taskStateMachine = createTaskStateMachine({ repos });
 	const taskInfo = await taskStateMachine.transitionState(namespaceRequestContext, {
@@ -27,6 +28,36 @@ export async function seedRunningTask(deps: SeedRunDeps & { publisher: FakePubli
 	});
 
 	return { ...seeded, taskInfo, taskInput: seededTask.input };
+}
+
+export async function seedAwaitingRetryTask(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	params: { nextAttemptAt: number },
+	overrides?: SeedRunOverrides
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedRunningTask({ ...deps, namespaceRequestContext }, overrides);
+
+	const taskStateMachine = createTaskStateMachine({ repos });
+	// The transition takes a relative delay, so a frozen clock turns the authored absolute
+	// due time into that delay. Frozen at 1, not 0: bun's setSystemTime treats the zero
+	// timestamp as a reset to the real clock.
+	const taskInfo = await withFakeClock(1, () =>
+		taskStateMachine.transitionState(namespaceRequestContext, {
+			id: seeded.taskInfo.id,
+			workflowRunId: seeded.runId,
+			expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
+			taskState: {
+				status: "awaiting_retry",
+				attempts: 1,
+				error: { name: "Error", message: "inventory service unavailable" },
+				nextAttemptInMs: params.nextAttemptAt - 1,
+			},
+		})
+	);
+
+	return { ...seeded, taskInfo, nextAttemptAt: params.nextAttemptAt };
 }
 
 export async function seedCompletedTask(

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -696,6 +696,33 @@ describe("creating a workflow run", () => {
 
 				expect(handle.run.id).toBe(newRunRecord.id);
 			}));
+
+		test("passes the priority option to the run creation", () =>
+			withFakeClient(async (client) => {
+				const workflowVersion = workflow({ name: "greet" }).v("1.0.0", {
+					async handler(_run, name: string) {
+						return name;
+					},
+				});
+				const newRunRecord = runningWorkflowRunRecordFactory.build();
+				const inputHash = await hashInput("world");
+
+				client.api.workflowRun.createV1.once(
+					{
+						name: "greet",
+						versionId: "1.0.0",
+						input: "world",
+						inputHash: { value: inputHash },
+						options: { priority: 2 },
+					},
+					{ id: newRunRecord.id }
+				);
+				client.api.workflowRun.getByIdV1.once({ id: newRunRecord.id }, { run: newRunRecord });
+
+				const handle = await workflowVersion.with("priority", 2).start(client, "world");
+
+				expect(handle.run.id).toBe(newRunRecord.id);
+			}));
 	});
 
 	describe("startAsChild", () => {
@@ -814,6 +841,96 @@ describe("creating a workflow run", () => {
 				client.api.workflowRun.getByIdV1.once({ id: childRunRecord.id }, { run: childRunRecord });
 
 				const childHandle = await childWorkflow.startAsChild(parentRun, "payload");
+
+				expect(childHandle.run.id).toBe(childRunRecord.id);
+			}));
+
+		test("the child's own pool wins over the parent's", () =>
+			withFakeClient(async (client) => {
+				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
+					async handler(_run, payload: string) {
+						return payload;
+					},
+				});
+				const parentRunRecord = runningWorkflowRunRecordFactory.build({ options: { pool: "eu-west" } });
+				const parentRun = createTestWorkflowRun(client, parentRunRecord);
+				const childRunRecord = runningWorkflowRunRecordFactory.build();
+				const inputHash = await hashInput("payload");
+
+				client.api.workflowRun.createV1.once(
+					{
+						name: "child-workflow",
+						versionId: "1.0.0",
+						input: "payload",
+						inputHash: { value: inputHash },
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
+						options: { pool: "us-east" },
+					},
+					{ id: childRunRecord.id }
+				);
+				client.api.workflowRun.getByIdV1.once({ id: childRunRecord.id }, { run: childRunRecord });
+
+				const childHandle = await childWorkflow.with("pool", "us-east").startAsChild(parentRun, "payload");
+
+				expect(childHandle.run.id).toBe(childRunRecord.id);
+			}));
+
+		test("the child inherits the parent's priority when it sets none", () =>
+			withFakeClient(async (client) => {
+				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
+					async handler(_run, payload: string) {
+						return payload;
+					},
+				});
+				const parentRunRecord = runningWorkflowRunRecordFactory.build({ options: { priority: 2 } });
+				const parentRun = createTestWorkflowRun(client, parentRunRecord);
+				const childRunRecord = runningWorkflowRunRecordFactory.build();
+				const inputHash = await hashInput("payload");
+
+				client.api.workflowRun.createV1.once(
+					{
+						name: "child-workflow",
+						versionId: "1.0.0",
+						input: "payload",
+						inputHash: { value: inputHash },
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
+						options: { priority: 2 },
+					},
+					{ id: childRunRecord.id }
+				);
+				client.api.workflowRun.getByIdV1.once({ id: childRunRecord.id }, { run: childRunRecord });
+
+				const childHandle = await childWorkflow.startAsChild(parentRun, "payload");
+
+				expect(childHandle.run.id).toBe(childRunRecord.id);
+			}));
+
+		test("the child's own priority wins over the parent's", () =>
+			withFakeClient(async (client) => {
+				const childWorkflow = workflow({ name: "child-workflow" }).v("1.0.0", {
+					async handler(_run, payload: string) {
+						return payload;
+					},
+				});
+				const parentRunRecord = runningWorkflowRunRecordFactory.build({ options: { priority: 7 } });
+				const parentRun = createTestWorkflowRun(client, parentRunRecord);
+				const childRunRecord = runningWorkflowRunRecordFactory.build();
+				const inputHash = await hashInput("payload");
+
+				client.api.workflowRun.createV1.once(
+					{
+						name: "child-workflow",
+						versionId: "1.0.0",
+						input: "payload",
+						inputHash: { value: inputHash },
+						parent: { workflowRunId: parentRunRecord.id, expectedRevision: parentRunRecord.revision },
+						options: { priority: 1 },
+					},
+					{ id: childRunRecord.id }
+				);
+				client.api.workflowRun.getByIdV1.once({ id: childRunRecord.id }, { run: childRunRecord });
+
+				const childHandle = await childWorkflow.with("priority", 1).startAsChild(parentRun, "payload");
 
 				expect(childHandle.run.id).toBe(childRunRecord.id);
 			}));

--- a/sdk/workflow/src/workflow-version.ts
+++ b/sdk/workflow/src/workflow-version.ts
@@ -146,8 +146,8 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 	}
 
 	private runOptions(): WorkflowRunOptions {
-		const { retry, pool } = this.startOptionsBuilder.build();
-		return { retry, pool };
+		const { retry, pool, priority } = this.startOptionsBuilder.build();
+		return { retry, pool, priority };
 	}
 
 	public with<Path extends PathFromObject<WorkflowStartOptions>>(
@@ -270,7 +270,6 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 			);
 		}
 
-		const pool = parentRun.options.pool;
 		let newRunId: string | undefined;
 		try {
 			const response = await client.api.workflowRun.createV1({
@@ -279,7 +278,11 @@ export class WorkflowVersionImpl<Input, Output, Context, TEvents extends EventsD
 				input,
 				inputHash,
 				parent: { workflowRunId: parentRun.id, expectedRevision: parentRunHandle.run.revision },
-				options: pool === undefined ? startOptions : { ...startOptions, pool },
+				options: {
+					...startOptions,
+					pool: startOptions.pool ?? parentRun.options.pool,
+					priority: startOptions.priority ?? parentRun.options.priority,
+				},
 			});
 			newRunId = response.id;
 		} catch (err) {

--- a/types/src/workflow/run/run.ts
+++ b/types/src/workflow/run/run.ts
@@ -61,6 +61,11 @@ export interface WorkflowReference {
 export interface WorkflowRunOptions {
 	retry?: RetryStrategy;
 	pool?: string;
+	/**
+	 * Integer 0 (highest) to 9 (lowest), default 5. Breaks dispatch ties between runs due in the
+	 * same millisecond; a run due earlier always dispatches first, whatever the priorities.
+	 */
+	priority?: number;
 }
 
 export interface WorkflowStartOptions extends WorkflowRunOptions {


### PR DESCRIPTION
## Background

Every run ready to dispatch gets one rank: `rank = dueAt * 10 + priority`. Lower dispatches first. Time wins — the priority digit (0 highest, 9 lowest, default 5) only breaks ties between runs due in the same millisecond. The digit already survives the whole dispatch path: outbox, timers, worker queue.

## Problem

Nothing can set it. Run options have no priority field, so every rank uses the default.

## Solution

Add `priority` to the run options:

```typescript
const handle = await orderWorkflowV1
	.with("priority", 2)
	.start(client, { orderId: "123" });
```

An integer from 0 to 9, default 5. It is a run option like `pool` and `retry`: it stays on the run for life, so the run keeps its priority every time it comes back — after a sleep, a retry, or an event — and schedules stamp it on every run they create. Priority never moves a run ahead of its due time.

Every place that computes a rank now reads the run's priority. That is most of the diff: the daemons take it from the rows they scan, and timers are created with it, so a timer's rank is already the dispatch rank.

Two behavior changes ride along:

- **Task retries read the run rows once.** The daemon used to build lookahead timer ranks from task rows, which don't carry options. It now reads the run rows once per chunk and uses them for both the due tasks and the timers. A task whose run stopped running gets neither; the next poll covers it.
- **Children inherit.** A child run takes its parent's `priority` and `pool` unless it sets its own. For `pool` this is a change: the parent's pool used to win over the child's. Cancellation cascade runs also take the cancelled run's pool and priority.

The schedules docs page said `"allow"` was the default overlap policy; the code default is `"skip"`. Fixed alongside.

## Breaking changes

- A child run's explicit `pool` now wins over its parent's; previously the parent's pool replaced it.