### PR TITLE
Random-start round-robin queue fills

### DIFF
--- a/sdk/adapter/memory/src/queue/in-memory-queue.test.ts
+++ b/sdk/adapter/memory/src/queue/in-memory-queue.test.ts
@@ -103,7 +103,12 @@ describe("inMemoryQueue publish/subscribe", () => {
 		]);
 
 		const subscriber = queue.subscriber(subscriberContext([defaultWorkflow, otherWorkflow]));
-		expect<string[]>((await subscriber.getReadyRuns(4)).map(({ data }) => data.id)).toEqual(["a1", "b1", "a2", "b2"]);
+		// There are 2 workflow queues and the can start at either,
+		// so either rotation of the interleave is valid.
+		expect([
+			["a1", "b1", "a2", "b2"],
+			["b1", "a1", "b2", "a2"],
+		]).toContainEqual((await subscriber.getReadyRuns(4)).map(({ data }) => data.id));
 	});
 
 	test("returns at most `limit` runs and leaves the rest", async () => {

--- a/sdk/adapter/memory/src/queue/subscriber.ts
+++ b/sdk/adapter/memory/src/queue/subscriber.ts
@@ -44,7 +44,8 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 					return [];
 				}
 
-				const initialBatch = store.roundRobinPop({ queueNames, startQueueIndex: 0, limit });
+				const startQueueIndex = Math.floor(Math.random() * queueNames.length);
+				const initialBatch = store.roundRobinPop({ queueNames, startQueueIndex, limit });
 				if (initialBatch.length > 0) {
 					return initialBatch;
 				}

--- a/sdk/adapter/redis/src/queue/subscriber.ts
+++ b/sdk/adapter/redis/src/queue/subscriber.ts
@@ -138,8 +138,8 @@ export function redisSubscriber(params: RedisConnectionParams, options?: RedisSu
 				if (remainingCapacity > 0) {
 					const workflowRunIds = (await redis.eval(
 						ROUND_ROBIN_ZPOPMIN_SCRIPT,
-						queueNames.length,
-						...queueNames,
+						shuffledQueueNames.length,
+						...shuffledQueueNames,
 						remainingCapacity
 					)) as WorkflowRunId[];
 


### PR DESCRIPTION
A worker fills its fetch batch round-robin across per-workflow queues: pop one item per queue, skip empty ones, stop when the batch is full. Both adapters started the walk at a fixed point — the Redis subscriber passed the fill script the keys in registration order (only the initial BZPOPMIN got a shuffled order), and the in-memory subscriber started at index 0. A walk that stops when capacity fills only reaches a prefix of the list, and with a fixed start it is the same prefix every call, so under backlog the tail queues starve. The default `maxConcurrentWorkflowRuns: 1` never runs the fill at all, which is why the bias doesn't show in the default config or in single-workflow load tests.

The fill now starts somewhere different on every call: the Redis subscriber passes the script the same shuffled key order its BZPOPMIN uses, and the in-memory subscriber picks a random start index. A truncated walk still serves a contiguous window of queues, but the window's position is uniformly random, so every queue gets equal expected service at any batch size.
