### PR TITLE
Task attempts and options on the record

### DIFF
--- a/app/dashboard/src/api/hooks.ts
+++ b/app/dashboard/src/api/hooks.ts
@@ -64,11 +64,12 @@ export function useWorkflowRun(
 }
 
 // The task's status and attempts from the polled run record are part of the key:
-// every task transition changes at least one of them, so a poll that observes a
-// change refetches the detail, and an unchanged task never refetches.
+// every task transition that changes anything visible changes at least one of them,
+// so a poll that observes a change refetches the detail, and an unchanged task
+// never refetches.
 export function useTask(task: TaskInfo) {
 	return useQuery({
-		queryKey: ["task", task.id, task.state.status, task.state.attempts],
+		queryKey: ["task", task.id, task.state.status, task.attempts],
 		queryFn: () => namespaceAuthedClient.task.getByIdV1({ id: task.id }),
 		placeholderData: keepPreviousData,
 	});

--- a/app/dashboard/src/components/run-detail/ExecutionTab.tsx
+++ b/app/dashboard/src/components/run-detail/ExecutionTab.tsx
@@ -156,7 +156,7 @@ const TaskCard = memo(function TaskCard({ task, scrollTo }: { task: TaskInfo; sc
 
 	const color = TASK_STATUS_COLORS[task.state.status];
 	const glyph = TASK_STATUS_GLYPHS[task.state.status];
-	const attempts = task.state.attempts;
+	const attempts = task.attempts;
 
 	useEffect(() => {
 		if (scrollTo && ref.current) {

--- a/app/dashboard/src/components/run-detail/TimelineTab.tsx
+++ b/app/dashboard/src/components/run-detail/TimelineTab.tsx
@@ -256,7 +256,7 @@ function TimelineItem({
 			transition.taskState.status === "awaiting_retry" ||
 			transition.taskState.status === "completed" ||
 			transition.taskState.status === "failed"
-				? transition.taskState.attempts
+				? transition.attempt
 				: undefined;
 
 		return (

--- a/sdk/server/src/contract/procedure/task.ts
+++ b/sdk/server/src/contract/procedure/task.ts
@@ -19,7 +19,6 @@ import {
 	taskStateAwaitingRetrySchema,
 	taskStateCompletedSchema,
 	taskStateFailedSchema,
-	taskStateRunningSchema,
 } from "../schema/task";
 
 const getByIdV1: ContractProcedure<TaskGetByIdRequestV1, TaskGetByIdResponseV1> = oc
@@ -49,25 +48,27 @@ const transitionStateV1: ContractProcedure<TaskTransitionStateRequestV1, TaskTra
 				type: "'retry'",
 				id: "string > 0",
 				workflowRunId: "string > 0",
-				"options?": taskOptionsSchema,
-				taskState: taskStateRunningSchema,
+				attempts: "number.integer > 0",
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 			.or({
 				id: "string > 0",
 				workflowRunId: "string > 0",
+				attempts: "number.integer > 0",
 				taskState: taskStateCompletedSchema.omit("output").and({ "output?": "unknown" }),
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 			.or({
 				id: "string > 0",
 				workflowRunId: "string > 0",
+				attempts: "number.integer > 0",
 				taskState: taskStateFailedSchema,
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 			.or({
 				id: "string > 0",
 				workflowRunId: "string > 0",
+				attempts: "number.integer > 0",
 				taskState: taskStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }),
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})

--- a/sdk/server/src/contract/procedure/task.ts
+++ b/sdk/server/src/contract/procedure/task.ts
@@ -55,21 +55,21 @@ const transitionStateV1: ContractProcedure<TaskTransitionStateRequestV1, TaskTra
 				id: "string > 0",
 				workflowRunId: "string > 0",
 				attempts: "number.integer > 0",
-				taskState: taskStateCompletedSchema.omit("output").and({ "output?": "unknown" }),
+				state: taskStateCompletedSchema.omit("output").and({ "output?": "unknown" }),
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 			.or({
 				id: "string > 0",
 				workflowRunId: "string > 0",
 				attempts: "number.integer > 0",
-				taskState: taskStateFailedSchema,
+				state: taskStateFailedSchema,
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 			.or({
 				id: "string > 0",
 				workflowRunId: "string > 0",
 				attempts: "number.integer > 0",
-				taskState: taskStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }),
+				state: taskStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" }),
 				expectedWorkflowRunRevision: "number.integer >= 0",
 			})
 	)

--- a/sdk/server/src/contract/schema/task.ts
+++ b/sdk/server/src/contract/schema/task.ts
@@ -9,26 +9,26 @@ export const taskOptionsSchema = type({
 
 export const taskStateRunningSchema = type({
 	status: "'running'",
-	attempts: "number.integer > 0",
+});
+
+export const taskStateAwaitingRetrySchema = type({
+	status: "'awaiting_retry'",
+	error: serializedErrorSchema,
+	nextAttemptAt: "number > 0",
 });
 
 export const taskStateCompletedSchema = type({
 	status: "'completed'",
-	attempts: "number.integer > 0",
 	output: "unknown",
 });
 
 export const taskStateFailedSchema = type({
 	status: "'failed'",
-	attempts: "number.integer > 0",
 	error: serializedErrorSchema,
 });
 
-export const taskStateAwaitingRetrySchema = type({
-	status: "'awaiting_retry'",
-	attempts: "number.integer > 0",
-	error: serializedErrorSchema,
-	nextAttemptAt: "number > 0",
+const taskStateDiscardedSchema = type({
+	status: "'discarded'",
 });
 
 const nonDiscardedTaskStateSchema = taskStateRunningSchema
@@ -36,16 +36,15 @@ const nonDiscardedTaskStateSchema = taskStateRunningSchema
 	.or(taskStateCompletedSchema)
 	.or(taskStateFailedSchema);
 
-export const taskStateSchema = nonDiscardedTaskStateSchema.or({
-	status: "'discarded'",
-	attempts: "number.integer > 0",
-});
+export const taskStateSchema = nonDiscardedTaskStateSchema.or(taskStateDiscardedSchema);
 
 export const taskInfoSchema = type({
 	id: "string > 0",
 	name: "string > 0",
 	state: nonDiscardedTaskStateSchema,
 	inputHash: "string > 0",
+	"options?": taskOptionsSchema.or("undefined"),
+	attempts: "number.integer > 0",
 });
 
 export const taskRecordSchema = type({
@@ -55,11 +54,12 @@ export const taskRecordSchema = type({
 	"input?": "unknown",
 	inputHash: "string > 0",
 	"options?": taskOptionsSchema.or("undefined"),
+	attempts: "number.integer > 0",
 	state: taskStateSchema,
 });
 
 export const taskSetStateRequestSchema = type({
 	id: "string > 0",
 	workflowRunId: "string > 0",
-	state: taskStateCompletedSchema.or(taskStateFailedSchema).omit("attempts"),
+	state: taskStateCompletedSchema.or(taskStateFailedSchema),
 });

--- a/sdk/server/src/daemon/imminent-retryable-tasks.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-retryable-tasks.integration.test.ts
@@ -1,4 +1,4 @@
-import { createConsoleLogger, noopLogger } from "@aikirun/lib/logger";
+import { noopLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 
 import { processImminentRetryableTasks } from "./imminent-retryable-tasks";
@@ -14,7 +14,7 @@ import { seedAwaitingRetryTask } from "../testing/seed/task";
 
 const withHarness = createDaemonHarness();
 
-const namespaceRequestContext = namespaceRequestContextFactory.build({ logger: createConsoleLogger() });
+const namespaceRequestContext = namespaceRequestContextFactory.build({});
 
 const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
 

--- a/sdk/server/src/infra/db/pg/repository/task.ts
+++ b/sdk/server/src/infra/db/pg/repository/task.ts
@@ -1,7 +1,7 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
-import type { TaskStatus } from "@aikirun/types/workflow/task";
+import type { DiscardableTaskStatus, TaskStatus } from "@aikirun/types/workflow/task";
 import { and, count, eq, inArray, lte, min, ne, sql } from "drizzle-orm";
 
 import { keysetStreamCursorFilter } from "./lib/keyset-stream";
@@ -43,6 +43,7 @@ export const createTaskRepository = (db: PgDb) => ({
 				input: task.input,
 				inputHash: task.inputHash,
 				options: task.options,
+				attempts: task.attempts,
 				state: stateTransition.state,
 			})
 			.from(task)
@@ -81,6 +82,8 @@ export const createTaskRepository = (db: PgDb) => ({
 				id: task.id,
 				name: task.name,
 				inputHash: task.inputHash,
+				options: task.options,
+				attempts: task.attempts,
 				state: stateTransition.state,
 			})
 			.from(task)
@@ -142,9 +145,9 @@ export const createTaskRepository = (db: PgDb) => ({
 		return result;
 	},
 
-	async bulkDiscard(
+	async bulkTransitionToDiscarded(
 		tasks: NonEmptyArray<{
-			filter: { id: string; workflowRunId: string; status: TaskStatus; attempts: number };
+			filter: { id: string; workflowRunId: string; status: DiscardableTaskStatus; attempts: number };
 			update: { latestStateTransitionId: string };
 		}>
 	): Promise<string[]> {

--- a/sdk/server/src/infra/db/task.integration.test.ts
+++ b/sdk/server/src/infra/db/task.integration.test.ts
@@ -20,7 +20,7 @@ describe("task repository state reads", () => {
 			const row = await repos.task.getByIdWithState(context.namespaceId, taskInfo.id);
 
 			expect(row?.state).toContainKey("output");
-			expect(row?.state).toEqual({ status: "completed", attempts: 1, output: undefined });
+			expect(row?.state).toEqual({ status: "completed", output: undefined });
 		}));
 });
 
@@ -59,7 +59,7 @@ describe("task repository compare-and-swap guards", () => {
 				id: taskInfo.id,
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
-				taskState: { status: "running", attempts: 2 },
+				attempts: 2,
 			});
 			const rowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
 
@@ -72,7 +72,7 @@ describe("task repository compare-and-swap guards", () => {
 			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(rowBefore);
 		}));
 
-	test("bulkDiscard skips a task whose attempts moved past the expected value", () =>
+	test("bulkTransitionToDiscarded skips a task whose attempts moved past the expected value", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const { runId, revisionWhenClaimed, taskInfo } = await seedRunningTask({
 				namespaceRequestContext: context,
@@ -86,11 +86,11 @@ describe("task repository compare-and-swap guards", () => {
 				id: taskInfo.id,
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
-				taskState: { status: "running", attempts: 2 },
+				attempts: 2,
 			});
 			const rowBefore = await repos.task.getById({ id: taskInfo.id, workflowRunId: runId });
 
-			const discardedTaskIds = await repos.task.bulkDiscard([
+			const discardedTaskIds = await repos.task.bulkTransitionToDiscarded([
 				{
 					filter: { id: taskInfo.id, workflowRunId: runId, status: "running", attempts: 1 },
 					update: { latestStateTransitionId: "never-applied" },
@@ -101,7 +101,7 @@ describe("task repository compare-and-swap guards", () => {
 			expect(await repos.task.getById({ id: taskInfo.id, workflowRunId: runId })).toEqual(rowBefore);
 		}));
 
-	test("bulkDiscard discards only the tasks whose expected status still matches", () =>
+	test("bulkTransitionToDiscarded discards only the tasks whose expected status still matches", () =>
 		withHarness(async ({ context, repos, publisher }) => {
 			const staleTaskSeed = await seedRunningTask({ namespaceRequestContext: context, repos, publisher });
 			const completedTaskSeed = await seedCompletedTask({ namespaceRequestContext: context, repos, publisher });
@@ -113,7 +113,7 @@ describe("task repository compare-and-swap guards", () => {
 			// Both discards expect "running" — the read-time status. The completed row keeps
 			// attempts 1, so only its status differs and its discard must match nothing.
 			const staleTransitionId = "stale-transition-1";
-			const discardedTaskIds = await repos.task.bulkDiscard([
+			const discardedTaskIds = await repos.task.bulkTransitionToDiscarded([
 				{
 					filter: { id: staleTaskSeed.taskInfo.id, workflowRunId: staleTaskSeed.runId, status: "running", attempts: 1 },
 					update: { latestStateTransitionId: staleTransitionId },

--- a/sdk/server/src/service/discard-stale-tasks.ts
+++ b/sdk/server/src/service/discard-stale-tasks.ts
@@ -1,12 +1,10 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import { asNonEmptyArray, isNonEmptyArray } from "@aikirun/lib/collection/array";
-import type { TaskStateDiscarded } from "@aikirun/types/workflow/task";
+import type { DiscardableTaskStatus, TaskStateDiscarded } from "@aikirun/types/workflow/task";
 import { ulid } from "ulidx";
 
 import type { TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
-
-type DiscardableTaskStatus = "running" | "awaiting_retry" | "failed";
 
 export async function discardStaleTasks(
 	workflowRunIds: string | NonEmptyArray<string>,
@@ -22,13 +20,18 @@ export async function discardStaleTasks(
 		staleTasks.map((task) => [
 			task.id,
 			{
-				filter: { id: task.id, workflowRunId: task.workflowRunId, status: task.status, attempts: task.attempts },
+				filter: {
+					id: task.id,
+					workflowRunId: task.workflowRunId,
+					status: task.status as DiscardableTaskStatus,
+					attempts: task.attempts,
+				},
 				update: { latestStateTransitionId: ulid() },
 			},
 		])
 	);
 	const taskUpdates = Array.from(taskUpdatesById.values());
-	const discardedTaskIds = await txRepos.task.bulkDiscard(asNonEmptyArray(taskUpdates));
+	const discardedTaskIds = await txRepos.task.bulkTransitionToDiscarded(asNonEmptyArray(taskUpdates));
 	if (!isNonEmptyArray(discardedTaskIds)) {
 		return;
 	}
@@ -47,7 +50,7 @@ export async function discardStaleTasks(
 			taskId: discardedTaskId,
 			status: "discarded",
 			attempt: taskUpdate.filter.attempts,
-			state: { status: "discarded", attempts: taskUpdate.filter.attempts } satisfies TaskStateDiscarded,
+			state: { status: "discarded" } satisfies TaskStateDiscarded,
 		});
 	}
 

--- a/sdk/server/src/service/state-machine/task.integration.test.ts
+++ b/sdk/server/src/service/state-machine/task.integration.test.ts
@@ -37,7 +37,8 @@ describe("TaskStateMachine transitionState", () => {
 					workflowRunId: attackerRunSeed.runId,
 					expectedWorkflowRunRevision: attackerRunSeed.revisionWhenClaimed,
 					id: victimTaskSeed.taskInfo.id,
-					taskState: { status: "completed", attempts: 2, output: "hijacked" },
+					attempts: 2,
+					taskState: { status: "completed", output: "hijacked" },
 				})
 			).rejects.toBeInstanceOf(NotFoundError);
 

--- a/sdk/server/src/service/state-machine/task.integration.test.ts
+++ b/sdk/server/src/service/state-machine/task.integration.test.ts
@@ -38,7 +38,7 @@ describe("TaskStateMachine transitionState", () => {
 					expectedWorkflowRunRevision: attackerRunSeed.revisionWhenClaimed,
 					id: victimTaskSeed.taskInfo.id,
 					attempts: 2,
-					taskState: { status: "completed", output: "hijacked" },
+					state: { status: "completed", output: "hijacked" },
 				})
 			).rejects.toBeInstanceOf(NotFoundError);
 

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -143,7 +143,7 @@ async function transitionStateInTx(
 		request.type satisfies "retry";
 		taskState = { status: "running" };
 	} else {
-		const requestTaskState = request.taskState;
+		const requestTaskState = request.state;
 		taskState =
 			requestTaskState.status === "completed"
 				? {

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -7,6 +7,7 @@ import type {
 	TaskInfo,
 	TaskName,
 	TaskState,
+	TaskStateDiscarded,
 	TaskStateFailed,
 	TaskStateRunning,
 	TaskStatus,
@@ -90,10 +91,10 @@ async function transitionStateInTx(
 		const taskName = request.taskName as TaskName;
 		const taskId = ulid() as TaskId;
 		const stateTransitionId = ulid();
+		const attempts = 1;
 
 		const taskState: TaskStateRunning = {
 			status: "running",
-			attempts: 1,
 		};
 
 		assertIsValidTaskStateTransition(runId, taskName, taskId, undefined, taskState.status);
@@ -103,7 +104,7 @@ async function transitionStateInTx(
 			name: taskName,
 			workflowRunId: runId,
 			status: taskState.status,
-			attempts: taskState.attempts,
+			attempts,
 			input: request.input,
 			inputHash,
 			options: request.options,
@@ -115,7 +116,7 @@ async function transitionStateInTx(
 			type: "task",
 			taskId,
 			status: taskState.status,
-			attempt: taskState.attempts,
+			attempt: attempts,
 			state: taskState,
 		});
 
@@ -125,7 +126,7 @@ async function transitionStateInTx(
 			"aiki.taskState": taskState,
 		});
 
-		return { id: taskId, name: taskName, state: taskState, inputHash };
+		return { id: taskId, name: taskName, state: taskState, inputHash, options: request.options, attempts };
 	}
 
 	const taskId = request.id as TaskId;
@@ -137,30 +138,30 @@ async function transitionStateInTx(
 	const inputHash = existingTask.inputHash;
 	const taskName = existingTask.name as TaskName;
 
-	const requestTaskState = request.taskState;
-
-	const taskState: TaskState =
-		requestTaskState.status === "running"
-			? {
-					status: requestTaskState.status,
-					attempts: requestTaskState.attempts,
-				}
-			: requestTaskState.status === "completed"
+	let taskState: Exclude<TaskState, TaskStateDiscarded>;
+	if ("type" in request) {
+		request.type satisfies "retry";
+		taskState = { status: "running" };
+	} else {
+		const requestTaskState = request.taskState;
+		taskState =
+			requestTaskState.status === "completed"
 				? {
 						status: requestTaskState.status,
-						attempts: requestTaskState.attempts,
 						output: requestTaskState.output,
 					}
 				: requestTaskState.status === "awaiting_retry"
 					? {
 							status: requestTaskState.status,
-							attempts: requestTaskState.attempts,
 							error: requestTaskState.error,
 							nextAttemptAt: Date.now() + requestTaskState.nextAttemptInMs,
 						}
 					: (requestTaskState satisfies TaskStateFailed);
+	}
 
 	assertIsValidTaskStateTransition(runId, taskName, taskId, existingTask.status, taskState.status);
+
+	const attempts = request.attempts;
 
 	const stateTransitionId = ulid();
 	await txRepos.stateTransition.append({
@@ -169,7 +170,7 @@ async function transitionStateInTx(
 		type: "task",
 		taskId,
 		status: taskState.status,
-		attempt: taskState.attempts,
+		attempt: attempts,
 		state: taskState,
 	});
 
@@ -177,7 +178,7 @@ async function transitionStateInTx(
 		{ id: taskId, workflowRunId: runId, status: existingTask.status, attempts: existingTask.attempts },
 		{
 			status: taskState.status,
-			attempts: taskState.attempts,
+			attempts,
 			latestStateTransitionId: stateTransitionId,
 			nextAttemptAt: taskState.status === "awaiting_retry" ? (taskState.nextAttemptAt as TimestampMs) : null,
 		}
@@ -206,5 +207,12 @@ async function transitionStateInTx(
 		"aiki.taskState": taskState,
 	});
 
-	return { id: taskId, name: taskName, state: taskState, inputHash };
+	return {
+		id: taskId,
+		name: taskName,
+		state: taskState,
+		inputHash,
+		options: existingTask.options ?? undefined,
+		attempts,
+	};
 }

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -29,7 +29,8 @@ describe("TaskService getTaskById", () => {
 				input: taskInput,
 				inputHash: taskInfo.inputHash,
 				options: undefined,
-				state: { status: "running", attempts: 1 },
+				attempts: 1,
+				state: { status: "running" },
 			});
 		}));
 
@@ -47,12 +48,12 @@ describe("TaskService getTaskById", () => {
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
 				id: taskInfo.id,
-				taskState: { status: "running", attempts: 2 },
+				attempts: 2,
 			});
 
 			const taskService = createTaskService({ repos });
 			expect(await taskService.getTaskById(context, taskInfo.id)).toEqual(
-				expect.objectContaining({ id: taskInfo.id, state: { status: "running", attempts: 2 } })
+				expect.objectContaining({ id: taskInfo.id, attempts: 2, state: { status: "running" } })
 			);
 		}));
 
@@ -90,7 +91,8 @@ describe("TaskService setTaskState", () => {
 			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([
 				expect.objectContaining({
 					id: taskInfo.id,
-					state: { status: "completed", attempts: 2, output },
+					attempts: 2,
+					state: { status: "completed", output },
 				}),
 			]);
 		}));
@@ -114,7 +116,8 @@ describe("TaskService setTaskState", () => {
 			expect(await repos.task.listByWorkflowRunIdWithState(runId)).toEqual([
 				expect.objectContaining({
 					id: taskInfo.id,
-					state: { status: "failed", attempts: 2, error },
+					attempts: 2,
+					state: { status: "failed", error },
 				}),
 			]);
 		}));
@@ -211,9 +214,9 @@ describe("TaskService setTaskState", () => {
 				id: taskInfo.id,
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
+				attempts: 1,
 				taskState: {
 					status: "awaiting_retry",
-					attempts: 1,
 					error: { name: "Error", message: "boom" },
 					nextAttemptInMs: 60_000,
 				},

--- a/sdk/server/src/service/task.integration.test.ts
+++ b/sdk/server/src/service/task.integration.test.ts
@@ -215,7 +215,7 @@ describe("TaskService setTaskState", () => {
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
 				attempts: 1,
-				taskState: {
+				state: {
 					status: "awaiting_retry",
 					error: { name: "Error", message: "boom" },
 					nextAttemptInMs: 60_000,

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -27,6 +27,7 @@ export const createTaskService = ({ repos }: TaskServiceDeps) => ({
 			input: task.input,
 			inputHash: task.inputHash,
 			options: task.options !== null ? task.options : undefined,
+			attempts: task.attempts,
 			state: task.state,
 		};
 	},
@@ -70,12 +71,12 @@ async function setTaskStateInTx(
 		request.state.status
 	);
 
-	const attempts = existingTaskRow.attempts;
+	const attempts = existingTaskRow.attempts + 1;
 
 	const state: TaskState =
 		request.state.status === "completed"
-			? { status: "completed", attempts: attempts + 1, output: request.state.output }
-			: { status: request.state.status satisfies "failed", attempts: attempts + 1, error: request.state.error };
+			? { status: "completed", output: request.state.output }
+			: { status: request.state.status satisfies "failed", error: request.state.error };
 
 	const transitionId = ulid();
 	await txRepos.stateTransition.append({
@@ -84,7 +85,7 @@ async function setTaskStateInTx(
 		type: "task",
 		taskId: existingTaskRow.id,
 		status: state.status,
-		attempt: state.attempts,
+		attempt: attempts,
 		state: state,
 	});
 	const updatedTask = await txRepos.task.update(
@@ -96,7 +97,7 @@ async function setTaskStateInTx(
 		},
 		{
 			status: state.status,
-			attempts: state.attempts,
+			attempts,
 			latestStateTransitionId: transitionId,
 		}
 	);

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -115,8 +115,10 @@ describe("WorkflowRunService getWorkflowRunById", () => {
 					{
 						id: taskInfo.id,
 						name: taskInfo.name,
-						state: { status: "running", attempts: 1 },
+						state: { status: "running" },
 						inputHash: taskInfo.inputHash,
+						options: undefined,
+						attempts: 1,
 					},
 				],
 			]);
@@ -588,7 +590,7 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 				workflowRunId: runId,
 				expectedWorkflowRunRevision: revisionWhenClaimed,
 				id: taskInfo.id,
-				taskState: { status: "running", attempts: 2 },
+				attempts: 2,
 			});
 
 			const { service } = createService(repos);
@@ -604,7 +606,7 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 					type: "task",
 					attempt: 1,
 					taskId: taskInfo.id,
-					taskState: { status: "running", attempts: 1 },
+					taskState: { status: "running" },
 				},
 				{
 					id: expect.any(String),
@@ -612,7 +614,7 @@ describe("WorkflowRunService listWorkflowRunTransitions", () => {
 					type: "task",
 					attempt: 2,
 					taskId: taskInfo.id,
-					taskState: { status: "running", attempts: 2 },
+					taskState: { status: "running" },
 				},
 			]);
 		}));

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -26,7 +26,13 @@ import type {
 	WorkflowRunStateCancelled,
 	WorkflowRunStateScheduledByNew,
 } from "@aikirun/types/workflow/run";
-import type { TaskInfo, TaskState, TaskStateDiscarded, TaskStatus } from "@aikirun/types/workflow/task";
+import type {
+	TaskInfo,
+	TaskStartOptions,
+	TaskState,
+	TaskStateDiscarded,
+	TaskStatus,
+} from "@aikirun/types/workflow/task";
 import { ulid } from "ulidx";
 
 import { WorkflowRunReferenceConflictError, WorkflowRunRevisionConflictError } from "../errors";
@@ -532,6 +538,8 @@ function buildTasksByAddress(
 		id: string;
 		name: string;
 		inputHash: string;
+		options: TaskStartOptions | null;
+		attempts: number;
 		state: TaskState;
 	}>
 ): Record<string, TaskInfo[]> {
@@ -543,6 +551,8 @@ function buildTasksByAddress(
 			name: task.name,
 			state: task.state as Exclude<TaskState, TaskStateDiscarded>,
 			inputHash: task.inputHash,
+			options: task.options ?? undefined,
+			attempts: task.attempts,
 		};
 		const tasksForAddress = tasksByAddress[address];
 		if (tasksForAddress) {

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -49,7 +49,7 @@ export async function seedAwaitingRetryTask(
 			workflowRunId: seeded.runId,
 			expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
 			attempts: 1,
-			taskState: {
+			state: {
 				status: "awaiting_retry",
 				error: { name: "Error", message: "inventory service unavailable" },
 				nextAttemptInMs: params.nextAttemptAt - 1,
@@ -76,7 +76,7 @@ export async function seedCompletedTask(
 		workflowRunId: seeded.runId,
 		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
 		attempts: 1,
-		taskState: { status: "completed", output },
+		state: { status: "completed", output },
 	});
 
 	return { ...seeded, taskInfo, taskOutput: output };

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -48,9 +48,9 @@ export async function seedAwaitingRetryTask(
 			id: seeded.taskInfo.id,
 			workflowRunId: seeded.runId,
 			expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
+			attempts: 1,
 			taskState: {
 				status: "awaiting_retry",
-				attempts: 1,
 				error: { name: "Error", message: "inventory service unavailable" },
 				nextAttemptInMs: params.nextAttemptAt - 1,
 			},
@@ -75,7 +75,8 @@ export async function seedCompletedTask(
 		id: seeded.taskInfo.id,
 		workflowRunId: seeded.runId,
 		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
-		taskState: { status: "completed", attempts: 1, output },
+		attempts: 1,
+		taskState: { status: "completed", output },
 	});
 
 	return { ...seeded, taskInfo, taskOutput: output };

--- a/sdk/workflow/src/system/cancel-child-runs.test.ts
+++ b/sdk/workflow/src/system/cancel-child-runs.test.ts
@@ -112,6 +112,7 @@ describe("createCancelChildRunsV1", () => {
 				.once(
 					{
 						id: runningListNonTerminalChildrenTask.id,
+						attempts: 1,
 						taskState: completedListNonTerminalChildrenTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
@@ -133,6 +134,7 @@ describe("createCancelChildRunsV1", () => {
 				.once(
 					{
 						id: runningCancelRunsTask.id,
+						attempts: 1,
 						taskState: completedCancelRunsTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
@@ -210,6 +212,7 @@ describe("createCancelChildRunsV1", () => {
 				.once(
 					{
 						id: runningListNonTerminalChildrenTask.id,
+						attempts: 1,
 						taskState: completedListNonTerminalChildrenTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,

--- a/sdk/workflow/src/system/cancel-child-runs.test.ts
+++ b/sdk/workflow/src/system/cancel-child-runs.test.ts
@@ -113,7 +113,7 @@ describe("createCancelChildRunsV1", () => {
 					{
 						id: runningListNonTerminalChildrenTask.id,
 						attempts: 1,
-						taskState: completedListNonTerminalChildrenTask.state,
+						state: completedListNonTerminalChildrenTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
@@ -135,7 +135,7 @@ describe("createCancelChildRunsV1", () => {
 					{
 						id: runningCancelRunsTask.id,
 						attempts: 1,
-						taskState: completedCancelRunsTask.state,
+						state: completedCancelRunsTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},
@@ -213,7 +213,7 @@ describe("createCancelChildRunsV1", () => {
 					{
 						id: runningListNonTerminalChildrenTask.id,
 						attempts: 1,
-						taskState: completedListNonTerminalChildrenTask.state,
+						state: completedListNonTerminalChildrenTask.state,
 						workflowRunId: runRecord.id,
 						expectedWorkflowRunRevision: runRecord.revision,
 					},

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -102,7 +102,7 @@ describe("task", () => {
 							{
 								id: runningTaskInfo.id,
 								attempts: 1,
-								taskState: completedTaskInfo.state,
+								state: completedTaskInfo.state,
 								workflowRunId: runRecord.id,
 								expectedWorkflowRunRevision: runRecord.revision,
 							},
@@ -161,7 +161,7 @@ describe("task", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 2,
-							taskState: completedTaskInfo.state,
+							state: completedTaskInfo.state,
 							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},
@@ -207,7 +207,7 @@ describe("task", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 1,
-							taskState: {
+							state: {
 								status: "awaiting_retry",
 								error: expect.objectContaining({ message: "down" }),
 								nextAttemptInMs: 1_000,
@@ -254,7 +254,7 @@ describe("task", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 1,
-							taskState: {
+							state: {
 								status: "failed",
 								error: expect.objectContaining({ message: "declined" }),
 							},
@@ -473,7 +473,7 @@ describe("task", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 1,
-							taskState: completedTaskInfo.state,
+							state: completedTaskInfo.state,
 							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
 						},

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -101,6 +101,7 @@ describe("task", () => {
 						.once(
 							{
 								id: runningTaskInfo.id,
+								attempts: 1,
 								taskState: completedTaskInfo.state,
 								workflowRunId: runRecord.id,
 								expectedWorkflowRunRevision: runRecord.revision,
@@ -139,7 +140,8 @@ describe("task", () => {
 				const completedTaskInfo = completedTaskInfoFactory.build({
 					id: runningTaskInfo.id,
 					name: chargeCard.name,
-					state: { attempts: 2, output },
+					attempts: 2,
+					state: { output },
 				});
 
 				client.api.task.transitionStateV1
@@ -158,6 +160,7 @@ describe("task", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 2,
 							taskState: completedTaskInfo.state,
 							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,
@@ -203,9 +206,9 @@ describe("task", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 1,
 							taskState: {
 								status: "awaiting_retry",
-								attempts: 1,
 								error: expect.objectContaining({ message: "down" }),
 								nextAttemptInMs: 1_000,
 							},
@@ -250,9 +253,9 @@ describe("task", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 1,
 							taskState: {
 								status: "failed",
-								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
 							workflowRunId: runRecord.id,
@@ -469,6 +472,7 @@ describe("task", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 1,
 							taskState: completedTaskInfo.state,
 							workflowRunId: runRecord.id,
 							expectedWorkflowRunRevision: runRecord.revision,

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -183,7 +183,8 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 
 		await handle[INTERNAL].transitionTaskState({
 			id: taskInfo.id,
-			taskState: { status: "completed", attempts: lastAttempt, output },
+			attempts: lastAttempt,
+			taskState: { status: "completed", output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
 
@@ -206,14 +207,14 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		if (existingTaskState.status === "failed") {
 			throw new TaskFailedError(
 				existingTaskInfo.id as TaskId,
-				existingTaskState.attempts,
+				existingTaskInfo.attempts,
 				existingTaskState.error.message
 			);
 		}
 
 		existingTaskState.status satisfies "running" | "awaiting_retry";
 
-		const attempts = existingTaskState.attempts;
+		const attempts = existingTaskInfo.attempts;
 		const retryStrategy = startOptions.retry ?? { type: "never" };
 		this.assertRetryAllowed(existingTaskInfo.id as TaskId, attempts, retryStrategy, run.logger);
 
@@ -224,7 +225,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			"aiki.taskStatus": existingTaskState.status,
 		});
 
-		return this.retryAndExecute(run, handle, input, existingTaskInfo.id, startOptions, retryStrategy, attempts);
+		return this.retryAndExecute(run, handle, input, existingTaskInfo.id, retryStrategy, attempts);
 	}
 
 	private async throwNonDeterminismError(
@@ -252,7 +253,6 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		handle: UnknownWorkflowRunHandle,
 		input: Input,
 		taskId: string,
-		startOptions: TaskStartOptions,
 		retryStrategy: RetryStrategy,
 		previousAttempts: number
 	): Promise<Output> {
@@ -261,8 +261,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		const taskInfo = await handle[INTERNAL].transitionTaskState({
 			type: "retry",
 			id: taskId,
-			options: startOptions,
-			taskState: { status: "running", attempts },
+			attempts,
 		});
 
 		const logger = run.logger.child({
@@ -283,7 +282,8 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 
 		await handle[INTERNAL].transitionTaskState({
 			id: taskInfo.id,
-			taskState: { status: "completed", attempts: lastAttempt, output },
+			attempts: lastAttempt,
+			taskState: { status: "completed", output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
 
@@ -338,7 +338,8 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 					});
 					await handle[INTERNAL].transitionTaskState({
 						id: taskId,
-						taskState: { status: "failed", attempts, error: serializableError },
+						attempts,
+						taskState: { status: "failed", error: serializableError },
 					});
 					throw new TaskFailedError(taskId, attempts, serializableError.message);
 				}
@@ -357,9 +358,9 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 
 				await handle[INTERNAL].transitionTaskState({
 					id: taskId,
+					attempts,
 					taskState: {
 						status: "awaiting_retry",
-						attempts,
 						error: serializableError,
 						nextAttemptInMs: retryParams.delayMs,
 					},

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -184,7 +184,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		await handle[INTERNAL].transitionTaskState({
 			id: taskInfo.id,
 			attempts: lastAttempt,
-			taskState: { status: "completed", output },
+			state: { status: "completed", output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
 
@@ -283,7 +283,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		await handle[INTERNAL].transitionTaskState({
 			id: taskInfo.id,
 			attempts: lastAttempt,
-			taskState: { status: "completed", output },
+			state: { status: "completed", output },
 		});
 		logger.info("Task complete", { "aiki.attempts": lastAttempt });
 
@@ -339,7 +339,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 					await handle[INTERNAL].transitionTaskState({
 						id: taskId,
 						attempts,
-						taskState: { status: "failed", error: serializableError },
+						state: { status: "failed", error: serializableError },
 					});
 					throw new TaskFailedError(taskId, attempts, serializableError.message);
 				}
@@ -359,7 +359,7 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 				await handle[INTERNAL].transitionTaskState({
 					id: taskId,
 					attempts,
-					taskState: {
+					state: {
 						status: "awaiting_retry",
 						error: serializableError,
 						nextAttemptInMs: retryParams.delayMs,

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -367,9 +367,9 @@ describe("workflow version execution", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 1,
 							taskState: {
 								status: "failed",
-								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
 							workflowRunId: runRecord.id,
@@ -440,9 +440,9 @@ describe("workflow version execution", () => {
 					.once(
 						{
 							id: runningTaskInfo.id,
+							attempts: 1,
 							taskState: {
 								status: "failed",
-								attempts: 1,
 								error: expect.objectContaining({ message: "declined" }),
 							},
 							workflowRunId: runRecord.id,

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -368,7 +368,7 @@ describe("workflow version execution", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 1,
-							taskState: {
+							state: {
 								status: "failed",
 								error: expect.objectContaining({ message: "declined" }),
 							},
@@ -441,7 +441,7 @@ describe("workflow version execution", () => {
 						{
 							id: runningTaskInfo.id,
 							attempts: 1,
-							taskState: {
+							state: {
 								status: "failed",
 								error: expect.objectContaining({ message: "declined" }),
 							},

--- a/testing/src/data-factory/workflow/task.ts
+++ b/testing/src/data-factory/workflow/task.ts
@@ -5,14 +5,16 @@ export const runningTaskInfoFactory = Factory.define<TaskInfo & { state: TaskSta
 	id: `task-${sequence}`,
 	name: "task",
 	inputHash: "hash",
-	state: { status: "running", attempts: 1 },
+	attempts: 1,
+	state: { status: "running" },
 }));
 
 export const failedTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateFailed }>(({ sequence }) => ({
 	id: `task-${sequence}`,
 	name: "task",
 	inputHash: "hash",
-	state: { status: "failed", attempts: 1, error: { name: "Error", message: "task failed" } },
+	attempts: 1,
+	state: { status: "failed", error: { name: "Error", message: "task failed" } },
 }));
 
 export const completedTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateCompleted<unknown> }>(
@@ -20,6 +22,7 @@ export const completedTaskInfoFactory = Factory.define<TaskInfo & { state: TaskS
 		id: `task-${sequence}`,
 		name: "task",
 		inputHash: "hash",
-		state: { status: "completed", attempts: 1, output: undefined },
+		attempts: 1,
+		state: { status: "completed", output: undefined },
 	})
 );

--- a/types/src/api/task.ts
+++ b/types/src/api/task.ts
@@ -47,7 +47,7 @@ export type TransitionTaskStateToRunning = TransitionTaskStateToRunningCreate | 
 export interface TransitionTaskStateToCompleted extends TransitionTaskStateBase {
 	id: string;
 	attempts: number;
-	taskState: TaskStateCompletedRequest;
+	state: TaskStateCompletedRequest;
 }
 
 export type TaskStateCompletedRequest = OptionalProp<TaskStateCompleted<unknown>, "output">;
@@ -55,13 +55,13 @@ export type TaskStateCompletedRequest = OptionalProp<TaskStateCompleted<unknown>
 export interface TransitionTaskStateToFailed extends TransitionTaskStateBase {
 	id: string;
 	attempts: number;
-	taskState: TaskStateFailed;
+	state: TaskStateFailed;
 }
 
 export interface TransitionTaskStateToAwaitingRetry extends TransitionTaskStateBase {
 	id: string;
 	attempts: number;
-	taskState: TaskStateAwaitingRetryRequest;
+	state: TaskStateAwaitingRetryRequest;
 }
 
 export type TaskStateAwaitingRetryRequest = Omit<TaskStateAwaitingRetry, "nextAttemptAt"> & {

--- a/types/src/api/task.ts
+++ b/types/src/api/task.ts
@@ -1,4 +1,4 @@
-import type { DistributiveOmit, OptionalProp } from "@aikirun/lib/object";
+import type { OptionalProp } from "@aikirun/lib/object";
 
 import type {
 	TaskInfo,
@@ -7,7 +7,6 @@ import type {
 	TaskStateAwaitingRetry,
 	TaskStateCompleted,
 	TaskStateFailed,
-	TaskStateRunning,
 } from "../workflow/task";
 
 export interface TaskApi {
@@ -40,14 +39,14 @@ export interface TransitionTaskStateToRunningCreate extends TransitionTaskStateB
 export interface TransitionTaskStateToRunningRetry extends TransitionTaskStateBase {
 	type: "retry";
 	id: string;
-	options?: TaskStartOptions;
-	taskState: TaskStateRunning;
+	attempts: number;
 }
 
 export type TransitionTaskStateToRunning = TransitionTaskStateToRunningCreate | TransitionTaskStateToRunningRetry;
 
 export interface TransitionTaskStateToCompleted extends TransitionTaskStateBase {
 	id: string;
+	attempts: number;
 	taskState: TaskStateCompletedRequest;
 }
 
@@ -55,11 +54,13 @@ export type TaskStateCompletedRequest = OptionalProp<TaskStateCompleted<unknown>
 
 export interface TransitionTaskStateToFailed extends TransitionTaskStateBase {
 	id: string;
+	attempts: number;
 	taskState: TaskStateFailed;
 }
 
 export interface TransitionTaskStateToAwaitingRetry extends TransitionTaskStateBase {
 	id: string;
+	attempts: number;
 	taskState: TaskStateAwaitingRetryRequest;
 }
 
@@ -80,5 +81,5 @@ export interface TaskTransitionStateResponseV1 {
 export interface TaskSetStateRequestV1 {
 	id: string;
 	workflowRunId: string;
-	state: DistributiveOmit<TaskStateCompleted<unknown> | TaskStateFailed, "attempts">;
+	state: TaskStateCompleted<unknown> | TaskStateFailed;
 }

--- a/types/src/workflow/task/task.ts
+++ b/types/src/workflow/task/task.ts
@@ -10,36 +10,33 @@ export type TaskAddress = string & { _brand: "task_address" };
 export const TASK_STATUSES = ["running", "awaiting_retry", "completed", "failed", "discarded"] as const;
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 
+export type DiscardableTaskStatus = "running" | "awaiting_retry" | "failed";
+
 export interface TaskStartOptions {
 	retry?: RetryStrategy;
 }
 
-interface TaskStateBase {
-	status: TaskStatus;
-	attempts: number;
-}
-
-export interface TaskStateRunning extends TaskStateBase {
+export interface TaskStateRunning {
 	status: "running";
 }
 
-export interface TaskStateAwaitingRetry extends TaskStateBase {
+export interface TaskStateAwaitingRetry {
 	status: "awaiting_retry";
 	error: SerializableError;
 	nextAttemptAt: number;
 }
 
-export interface TaskStateCompleted<Output> extends TaskStateBase {
+export interface TaskStateCompleted<Output> {
 	status: "completed";
 	output: Output;
 }
 
-export interface TaskStateFailed extends TaskStateBase {
+export interface TaskStateFailed {
 	status: "failed";
 	error: SerializableError;
 }
 
-export interface TaskStateDiscarded extends TaskStateBase {
+export interface TaskStateDiscarded {
 	status: "discarded";
 }
 
@@ -53,8 +50,10 @@ export type TaskState<Output = unknown> =
 export interface TaskInfo {
 	id: string;
 	name: string;
-	state: Exclude<TaskState, TaskStateDiscarded>;
 	inputHash: string;
+	options?: TaskStartOptions;
+	attempts: number;
+	state: Exclude<TaskState, TaskStateDiscarded>;
 }
 
 export interface TaskRecord<Input = unknown, Output = unknown> {
@@ -64,5 +63,6 @@ export interface TaskRecord<Input = unknown, Output = unknown> {
 	input?: Input;
 	inputHash: string;
 	options?: TaskStartOptions;
+	attempts: number;
 	state: TaskState<Output>;
 }


### PR DESCRIPTION
## Motivation

A task's `attempts` counter was copied into every state payload — `running`, `awaiting_retry`, `completed`, and `failed` all carried it — even though it is a property of the task, not of any one state. The task row and the transition history already record it: the task row has an `attempts` column, and every transition row has an `attempt` column. The payload copy was a third location, and it was the one the dashboard happened to read.

The task row also persists the `options` a task was created with, but no read shape returned them. `TaskInfo`, the per-task shape a worker replays from, carried only id, name, state, and input hash. With the stored options unreachable, replay reads the retry strategy from the task definition at the call site — so editing a definition changes the retry budget of tasks already in flight. Switching replay to the stored options is a follow-up; this PR makes them readable and moves `attempts` to where the other copies live.

## Solution

State payloads now carry only state-specific data. `TaskInfo` and `TaskRecord` carry `attempts` and `options` at the top level, and the read queries behind them select both columns.

```ts
// before
interface TaskStateCompleted<Output> {
	status: "completed";
	attempts: number;
	output: Output;
}
interface TaskInfo {
	id: string;
	name: string;
	inputHash: string;
	state: Exclude<TaskState, TaskStateDiscarded>;
}

// after
interface TaskStateCompleted<Output> {
	status: "completed";
	output: Output;
}
interface TaskInfo {
	id: string;
	name: string;
	inputHash: string;
	options?: TaskStartOptions;
	attempts: number;
	state: Exclude<TaskState, TaskStateDiscarded>;
}
```

Transition requests carry `attempts` beside the state payload instead of inside it, and the payload field is named `state` — matching `TaskInfo`, `TaskRecord`, and the set-state request, where it already had that name. The retry request shrinks to `{ type: "retry", id, attempts }`: its state payload was only ever `{ status: "running" }` plus the counter, and the server never persisted the options it carried — the options a task was created with are the stored ones.

The dashboard reads `task.attempts` from the run record and, on the timeline, the transition row's own `attempt` field. Transition rows written before this change still contain `attempts` inside their payloads; nothing reads it there anymore.

## Breaking changes

The task API shapes changed: transition requests carry a top-level `attempts`, `TaskInfo` and `TaskRecord` gained required `attempts`, and state payloads lost theirs.
