### PR TITLE
# The awaiting_task_retry park

### DIFF
--- a/sdk/server/src/contract/procedure/workflow-run.ts
+++ b/sdk/server/src/contract/procedure/workflow-run.ts
@@ -46,6 +46,7 @@ import {
 	workflowRunStateAwaitingChildWorkflowSchema,
 	workflowRunStateAwaitingEventSchema,
 	workflowRunStateAwaitingRetrySchema,
+	workflowRunStateAwaitingTaskRetrySchema,
 	workflowRunStateCancelledSchema,
 	workflowRunStateCompletedSchema,
 	workflowRunStateFailedSchema,
@@ -187,6 +188,7 @@ const transitionStateV1: ContractProcedure<WorkflowRunTransitionStateRequestV1, 
 							.or(
 								workflowRunStateAwaitingRetrySchema.omit("nextAttemptAt").and({ nextAttemptInMs: "number.integer > 0" })
 							)
+							.or(workflowRunStateAwaitingTaskRetrySchema.omit("nextAttemptAt"))
 							.or(workflowRunStateCompletedSchema.omit("output").and({ "output?": "unknown" }))
 							.or(workflowRunStateFailedSchema),
 					}).or({

--- a/sdk/server/src/infra/db/pg/repository/task.ts
+++ b/sdk/server/src/infra/db/pg/repository/task.ts
@@ -111,6 +111,14 @@ export const createTaskRepository = (db: PgDb) => ({
 			.limit(limit);
 	},
 
+	async getEarliestNextAttemptAt(workflowRunId: string): Promise<TimestampMs | null> {
+		const result = await db
+			.select({ nextAttemptAt: sql`${min(task.nextAttemptAt)}`.mapWith(task.nextAttemptAt) })
+			.from(task)
+			.where(and(eq(task.workflowRunId, workflowRunId), eq(task.status, "awaiting_retry")));
+		return result[0]?.nextAttemptAt ?? null;
+	},
+
 	async listByWorkflowRunIdsAndStatuses(workflowRunIds: string | NonEmptyArray<string>, statuses: TaskStatus[]) {
 		const runIdsFilter =
 			typeof workflowRunIds === "string"

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -18,6 +18,7 @@ import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness, withRepos } from "../../testing/harness";
 import { claimRun, seedClaimedRun, seedCompletedRun, seedScheduledRun, seedStalledRun } from "../../testing/seed/run";
+import { seedRunningTask, seedSiblingAwaitingRetryTasks } from "../../testing/seed/task";
 import { createChildRunCanceller } from "../cancel-child-runs";
 import { createEventService } from "../event";
 
@@ -343,6 +344,65 @@ describe("WorkflowRunStateMachine attempt counting", () => {
 						attempts: result.attempts,
 					}),
 					state: { status: "queued", reason: "new" },
+				})
+			);
+		}));
+});
+
+describe("WorkflowRunStateMachine task-retry park", () => {
+	test("parking a run for its retrying tasks stores the earliest task deadline", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedSiblingAwaitingRetryTasks(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ firstNextAttemptAt: 1, siblingNextAttemptAt: 4_000_000_000_000 }
+			);
+
+			const stateMachine = createStateMachine(repos);
+			const parked = await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "awaiting_task_retry" },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			expect(parked).toEqual({
+				revision: revisionWhenClaimed + 1,
+				attempts: attemptsWhenClaimed,
+				state: { status: "awaiting_task_retry", nextAttemptAt: 1 },
+			});
+
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "awaiting_task_retry" }),
+					state: { status: "awaiting_task_retry", nextAttemptAt: 1 },
+				})
+			);
+		}));
+
+	test("a park with no task awaiting a retry is rejected", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			// The seeded task is running, not awaiting a retry — there is no deadline to park on.
+			const { runId, revisionWhenClaimed } = await seedRunningTask({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const stateMachine = createStateMachine(repos);
+			expect(
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "awaiting_task_retry" },
+					expectedRevision: revisionWhenClaimed,
+				})
+			).rejects.toBeInstanceOf(InvalidWorkflowRunStateTransitionError);
+
+			const run = await repos.workflowRun.getByIdWithState({ namespaceId: context.namespaceId, id: runId });
+			expect(run).toEqual(
+				expect.objectContaining({
+					run: expect.objectContaining({ id: runId, status: "running", revision: revisionWhenClaimed }),
 				})
 			);
 		}));

--- a/sdk/server/src/service/state-machine/workflow-run.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.test.ts
@@ -40,6 +40,7 @@ describe("assertIsValidWorkflowRunStateTransition", () => {
 			sleeping: {},
 			awaiting_event: {},
 			awaiting_retry: {},
+			awaiting_task_retry: {},
 			awaiting_child_workflow: {},
 			cancelled: {},
 			completed: {},

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -6,13 +6,17 @@ import type {
 	WorkflowRunTransitionStateRequestV1,
 	WorkflowRunTransitionStateResponseV1,
 } from "@aikirun/types/api/workflow-run";
-import type { WorkflowRunId, WorkflowRunState, WorkflowRunStatus } from "@aikirun/types/workflow/run";
+import type {
+	WaitingForSignalWorkflowRunStatus,
+	WorkflowRunId,
+	WorkflowRunState,
+	WorkflowRunStatus,
+} from "@aikirun/types/workflow/run";
 import { isTerminalWorkflowRunStatus, WORKFLOW_RUN_SCHEDULED_REASONS } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { InvalidWorkflowRunStateTransitionError, WorkflowRunRevisionConflictError } from "../../errors";
 import type { Repositories, TxRepositories } from "../../infra/db/types";
-import type { UpdateWorkflowRunParams } from "../../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../../infra/timer/imminent-run-timer-queue";
 import type { NamespaceRequestContext } from "../../middleware/context";
 import type { ChildRunCanceller } from "../cancel-child-runs";
@@ -47,6 +51,7 @@ const workflowRunStateTransitionValidator: Record<
 		sleeping: true,
 		awaiting_event: true,
 		awaiting_retry: true,
+		awaiting_task_retry: true,
 		awaiting_child_workflow: true,
 		cancelled: true,
 		completed: true,
@@ -176,7 +181,21 @@ async function transitionStateInTx(
 	}
 
 	const now = Date.now() as TimestampMs;
-	let toState = convertDurationToTimestamp(request.state, now);
+	let toState: WorkflowRunState;
+	if (request.state.status === "awaiting_task_retry") {
+		const nextAttemptAt = await txRepos.task.getEarliestNextAttemptAt(runId);
+		if (nextAttemptAt === null) {
+			throw new InvalidWorkflowRunStateTransitionError(
+				runId,
+				fromState.status,
+				request.state.status,
+				"no task awaiting retry"
+			);
+		}
+		toState = { status: "awaiting_task_retry", nextAttemptAt };
+	} else {
+		toState = convertDurationToTimestamp(request.state, now);
+	}
 
 	if (fromState.status === "sleeping" && (toState.status === "scheduled" || toState.status === "cancelled")) {
 		await cancelSleep(runId, fromState.sleepName, now, txRepos);
@@ -354,31 +373,12 @@ async function updateWorkflowRun(
 		return { revision: result.revision, state: toState };
 	}
 
-	let updates: Extract<UpdateWorkflowRunParams, { waitForSignal: false }>["updates"];
-	if (toState.status === "scheduled") {
-		updates = {
-			status: toState.status,
-			attempts,
-			latestStateTransitionId: stateTransitionId,
-			scheduledAt: toState.scheduledAt as TimestampMs,
-		};
-	} else if (toState.status === "sleeping") {
-		updates = {
-			status: toState.status,
-			attempts,
-			latestStateTransitionId: stateTransitionId,
-			wakeupAt: toState.wakeupAt as TimestampMs,
-		};
-	} else if (toState.status === "awaiting_retry") {
-		updates = {
-			status: toState.status,
-			attempts,
-			latestStateTransitionId: stateTransitionId,
-			nextAttemptAt: toState.nextAttemptAt as TimestampMs,
-		};
-	} else {
-		updates = { status: toState.status, attempts, latestStateTransitionId: stateTransitionId };
-	}
+	const updates = {
+		status: toState.status,
+		attempts,
+		latestStateTransitionId: stateTransitionId,
+		...extractDueTimestamp(toState),
+	};
 
 	if (request.type === "optimistic") {
 		const result = await txRepos.workflowRun.update({
@@ -403,7 +403,31 @@ async function updateWorkflowRun(
 	}
 }
 
-export function convertDurationToTimestamp(request: WorkflowRunStateRequest, now: TimestampMs): WorkflowRunState {
+function extractDueTimestamp(state: Exclude<WorkflowRunState, { status: WaitingForSignalWorkflowRunStatus }>) {
+	switch (state.status) {
+		case "scheduled":
+			return { scheduledAt: state.scheduledAt as TimestampMs };
+		case "sleeping":
+			return { wakeupAt: state.wakeupAt as TimestampMs };
+		case "awaiting_retry":
+		case "awaiting_task_retry":
+			return { nextAttemptAt: state.nextAttemptAt as TimestampMs };
+		default:
+			state satisfies {
+				status: WorkflowRunStatus;
+				scheduledAt?: never;
+				wakeupAt?: never;
+				nextAttemptAt?: never;
+				timeoutAt?: never;
+			};
+			return {};
+	}
+}
+
+export function convertDurationToTimestamp(
+	request: Exclude<WorkflowRunStateRequest, { status: "awaiting_task_retry" }>,
+	now: TimestampMs
+): WorkflowRunState {
 	if (request.status === "scheduled") {
 		return {
 			status: "scheduled",

--- a/sdk/server/src/testing/seed/task.ts
+++ b/sdk/server/src/testing/seed/task.ts
@@ -60,6 +60,47 @@ export async function seedAwaitingRetryTask(
 	return { ...seeded, taskInfo, nextAttemptAt: params.nextAttemptAt };
 }
 
+/**
+ * Two `awaiting_retry` tasks on one running run.
+ */
+export async function seedSiblingAwaitingRetryTasks(
+	deps: SeedRunDeps & { publisher: FakePublisher },
+	params: { firstNextAttemptAt: number; siblingNextAttemptAt: number }
+) {
+	const { repos } = deps;
+	const namespaceRequestContext = deps.namespaceRequestContext ?? namespaceRequestContextFactory.build();
+	const seeded = await seedAwaitingRetryTask(
+		{ ...deps, namespaceRequestContext },
+		{ nextAttemptAt: params.firstNextAttemptAt }
+	);
+
+	const siblingInput = { invoiceId: "inv-9" };
+	const taskStateMachine = createTaskStateMachine({ repos });
+	const createdSibling = await taskStateMachine.transitionState(namespaceRequestContext, {
+		type: "create",
+		workflowRunId: seeded.runId,
+		expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
+		taskName: "charge-payment",
+		input: siblingInput,
+		inputHash: await hashInput(siblingInput),
+	});
+	const siblingTaskInfo = await withFakeClock(1, () =>
+		taskStateMachine.transitionState(namespaceRequestContext, {
+			id: createdSibling.id,
+			workflowRunId: seeded.runId,
+			expectedWorkflowRunRevision: seeded.revisionWhenClaimed,
+			attempts: 1,
+			state: {
+				status: "awaiting_retry",
+				error: { name: "Error", message: "payment gateway unavailable" },
+				nextAttemptInMs: params.siblingNextAttemptAt - 1,
+			},
+		})
+	);
+
+	return { ...seeded, siblingTaskInfo, siblingNextAttemptAt: params.siblingNextAttemptAt };
+}
+
 export async function seedCompletedTask(
 	deps: SeedRunDeps & { publisher: FakePublisher },
 	overrides?: { output: unknown }

--- a/types/src/api/workflow-run.ts
+++ b/types/src/api/workflow-run.ts
@@ -9,6 +9,7 @@ import type {
 	WorkflowRunStateAwaitingChildWorkflow,
 	WorkflowRunStateAwaitingEvent,
 	WorkflowRunStateAwaitingRetry,
+	WorkflowRunStateAwaitingTaskRetry,
 	WorkflowRunStateCancelled,
 	WorkflowRunStateCompleted,
 	WorkflowRunStatePaused,
@@ -124,11 +125,11 @@ export type WorkflowRunStateScheduledRequest = DistributiveOmit<WorkflowRunState
 	scheduledInMs: number;
 };
 
-export type WorkflowRunStateSleepingRequest = DistributiveOmit<WorkflowRunStateSleeping, "wakeupAt"> & {
+export type WorkflowRunStateSleepingRequest = Omit<WorkflowRunStateSleeping, "wakeupAt"> & {
 	durationMs: number;
 };
 
-export type WorkflowRunStateAwaitingEventRequest = DistributiveOmit<WorkflowRunStateAwaitingEvent, "timeoutAt"> & {
+export type WorkflowRunStateAwaitingEventRequest = Omit<WorkflowRunStateAwaitingEvent, "timeoutAt"> & {
 	timeoutInMs?: number;
 };
 
@@ -136,10 +137,9 @@ export type WorkflowRunStateAwaitingRetryRequest = DistributiveOmit<WorkflowRunS
 	nextAttemptInMs: number;
 };
 
-export type WorkflowRunStateAwaitingChildWorkflowRequest = DistributiveOmit<
-	WorkflowRunStateAwaitingChildWorkflow,
-	"timeoutAt"
-> & {
+export type WorkflowRunStateAwaitingTaskRetryRequest = Omit<WorkflowRunStateAwaitingTaskRetry, "nextAttemptAt">;
+
+export type WorkflowRunStateAwaitingChildWorkflowRequest = Omit<WorkflowRunStateAwaitingChildWorkflow, "timeoutAt"> & {
 	timeoutInMs?: number;
 };
 
@@ -163,6 +163,7 @@ export type WorkflowRunStateRequest =
 	| WorkflowRunStateSleepingRequest
 	| WorkflowRunStateAwaitingEventRequest
 	| WorkflowRunStateAwaitingRetryRequest
+	| WorkflowRunStateAwaitingTaskRetryRequest
 	| WorkflowRunStateAwaitingChildWorkflowRequest
 	| WorkflowRunStateCompletedRequest;
 


### PR DESCRIPTION
## Motivation

`awaiting_task_retry` is the parked status for a run with `awaiting_retry` tasks. #186 introduced the status, but nothing can transition a run into it. This PR adds that transition.

The park's deadline is not the client's to send. Each `awaiting_retry` task row already stores its own `nextAttemptAt`, so the run's deadline is derived from what the server holds.

## Solution

The request variant is `{ status: "awaiting_task_retry" }` — a state request with no payload at all. Inside the park transaction the server reads the earliest `nextAttemptAt` among the run's `awaiting_retry` tasks and stores it as the run's deadline. A park on a run with no task awaiting a retry is rejected as an invalid transition. The validity table gains `running → awaiting_task_retry`, and parking deletes the run's outbox row, as entering any parked state does.

Nothing sends the park yet: the worker-side park after a task-retry suspension and the daemon that requeues due `awaiting_task_retry` runs are follow-ups.