### PR TITLE
The worker-side task-retry park

### DIFF
--- a/sdk/server/src/daemon/imminent-task-retryable-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-task-retryable-runs.integration.test.ts
@@ -107,11 +107,12 @@ describe("processImminentTaskRetryableRuns", () => {
 					run: expect.objectContaining({ id: runId, status: "running" }),
 				})
 			);
+			// The delivery's claimed outbox row stays with the run until it parks.
 			expect(
 				await repos.workflowRunOutbox.getByWorkflowRunId({
 					namespaceId: namespaceRequestContext.namespaceId,
 					workflowRunId: runId,
 				})
-			).toBeNull();
+			).toEqual(expect.objectContaining({ workflowRunId: runId, status: "claimed" }));
 		}));
 });

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -190,13 +190,6 @@ async function transitionStateInTx(
 		});
 	}
 
-	if (taskState.status === "awaiting_retry") {
-		// The workflow run stays in `running` while the task waits for its retry, so the outbox row
-		// is not cleared by the workflow state machine. Delete it here so `recoverOverdueOutboxEntries`
-		// cannot re-dispatch the run before it parks for the retry.
-		await txRepos.workflowRunOutbox.deleteByWorkflowRunId({ namespaceId, workflowRunId: runId });
-	}
-
 	logger.info("Transitioning task state", {
 		"aiki.runId": runId,
 		"aiki.taskId": taskId,

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -354,8 +354,11 @@ describe("WorkflowRunStateMachine task-retry park", () => {
 		withHarness(async ({ context, repos, publisher }) => {
 			const { runId, revisionWhenClaimed, attemptsWhenClaimed } = await seedSiblingAwaitingRetryTasks(
 				{ namespaceRequestContext: context, repos, publisher },
-				{ firstNextAttemptAt: 1, siblingNextAttemptAt: 4_000_000_000_000 }
+				{ firstNextAttemptAt: 1, siblingNextAttemptAt: 2 }
 			);
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({ namespaceId: context.namespaceId, workflowRunId: runId })
+			).toEqual(expect.objectContaining({ workflowRunId: runId, status: "claimed" }));
 
 			const stateMachine = createStateMachine(repos);
 			const parked = await stateMachine.transitionState(context, {
@@ -364,6 +367,10 @@ describe("WorkflowRunStateMachine task-retry park", () => {
 				state: { status: "awaiting_task_retry" },
 				expectedRevision: revisionWhenClaimed,
 			});
+
+			expect(
+				await repos.workflowRunOutbox.getByWorkflowRunId({ namespaceId: context.namespaceId, workflowRunId: runId })
+			).toBeNull();
 
 			expect(parked).toEqual({
 				revision: revisionWhenClaimed + 1,

--- a/sdk/workflow/src/run/execute.test.ts
+++ b/sdk/workflow/src/run/execute.test.ts
@@ -1,7 +1,10 @@
 import { createBinaryLatch, delay } from "@aikirun/lib/async";
 import { asConfigProvider } from "@aikirun/lib/config";
+import { hashInput } from "@aikirun/lib/crypto";
+import { getCompositeId } from "@aikirun/lib/id";
 import { withFakeClient } from "@aikirun/testing/client";
 import { runningWorkflowRunRecordFactory } from "@aikirun/testing/data-factory/workflow/run";
+import { awaitingRetryTaskInfoFactory } from "@aikirun/testing/data-factory/workflow/task";
 import { INTERNAL } from "@aikirun/types/symbols";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
@@ -17,6 +20,7 @@ import type { EventsDefinition } from "./event";
 import { executeWorkflowRun } from "./execute";
 import type { WorkflowRun } from "./index";
 import { describe, expect, spyOn, test } from "bun:test";
+import { task } from "../task";
 import type { AnyWorkflowVersion } from "../workflow-version";
 
 const configProvider = asConfigProvider(() => ({
@@ -97,6 +101,60 @@ describe("executeWorkflowRun", () => {
 			withFakeClient(async (client) => {
 				const workflowRun = runningWorkflowRunRecordFactory.build();
 				const workflowVersion = fakeWorkflowVersion(async () => {});
+
+				const result = await executeWorkflowRun({
+					client,
+					workflowRun,
+					workflowVersion,
+					logger: client.logger,
+					configProvider,
+				});
+
+				expect(result).toBe(true);
+			}));
+	});
+
+	describe("awaiting_task_retry", () => {
+		test("a replayed task whose retry is not due transitions the run to awaiting_task_retry", () =>
+			withFakeClient(async (client) => {
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 60_000 } as const;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => "charged",
+					retry,
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getCompositeId({ name: chargeCard.name, referenceId: inputHash });
+				// The clock cannot be pinned in unit tests (files run concurrently), so "not due"
+				// is a deadline a day out — far beyond the lifetime of a test run.
+				const nextAttemptAt = Date.now() + 24 * 60 * 60 * 1000;
+				const awaitingRetryTaskInfo = awaitingRetryTaskInfoFactory.build({
+					name: chargeCard.name,
+					options: { retry },
+					state: { nextAttemptAt },
+				});
+				const workflowRun = runningWorkflowRunRecordFactory.build({
+					tasks: { [address]: [awaitingRetryTaskInfo] },
+				});
+				const workflowVersion = fakeWorkflowVersion(async (run) => {
+					await chargeCard.start(run, input);
+				});
+
+				client.api.workflowRun.transitionStateV1.once(
+					{
+						type: "optimistic",
+						id: workflowRun.id,
+						state: { status: "awaiting_task_retry" },
+						expectedRevision: workflowRun.revision,
+					},
+					{
+						revision: workflowRun.revision + 1,
+						state: { status: "awaiting_task_retry", nextAttemptAt },
+						attempts: workflowRun.attempts,
+					}
+				);
 
 				const result = await executeWorkflowRun({
 					client,

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -18,6 +18,7 @@ import { createEventWaiters } from "./event";
 import { workflowRunHandle } from "./handle";
 import { createReplayManifest } from "./replay-manifest";
 import { createSleeper } from "./sleeper";
+import { taskExecutionTracker } from "./task-execution-tracker";
 import type { AnyWorkflowVersion } from "../workflow-version";
 
 export interface ExecuteWorkflowParams<Context> {
@@ -63,6 +64,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 	const workflowRunId = workflowRun.id as WorkflowRunId;
 
 	const intervals: Array<{ stop: () => void }> = [];
+	let flushTaskExecutions: (() => Promise<void>) | undefined;
 	try {
 		intervals.push(
 			runOnInterval(() => client.api.workflowRun.claimRefreshV1({ id: workflowRunId }), {
@@ -91,6 +93,8 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 
 		const eventsDefinition = workflowVersion[INTERNAL].eventsDefinition;
 		const handle = workflowRunHandle(client, workflowRun, eventsDefinition, logger);
+		const { create: createTaskExecutionTracker, flush: taskExecutionsFlusher } = taskExecutionTracker(handle, logger);
+		flushTaskExecutions = taskExecutionsFlusher;
 
 		const createContext = client[INTERNAL].context;
 		const context = createContext ? createContext(workflowRun) : null;
@@ -117,6 +121,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 				[INTERNAL]: {
 					handle,
 					replayManifest: createReplayManifest(workflowRun),
+					createTaskExecutionTracker,
 					configProvider,
 					hasher,
 				},
@@ -140,6 +145,11 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 
 		return false;
 	} finally {
+		// Flushed before the claim refresh stops, so the claim stays live while the
+		// tracker waits out task executions that are still running.
+		if (flushTaskExecutions) {
+			await flushTaskExecutions();
+		}
 		for (const interval of intervals) {
 			interval.stop();
 		}

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -9,6 +9,7 @@ import type { ReplayManifest, SleepResult, WorkflowRunId, WorkflowRunOptions } f
 import type { EventsDefinition, EventWaiters } from "./event";
 import type { WorkflowExecutionConfig } from "./execute";
 import type { WorkflowRunHandle } from "./handle";
+import type { CreateTaskExecutionTracker } from "./task-execution-tracker";
 
 export interface WorkflowRun<Input, Context, TEvents extends EventsDefinition = EventsDefinition> {
 	id: WorkflowRunId;
@@ -22,6 +23,7 @@ export interface WorkflowRun<Input, Context, TEvents extends EventsDefinition = 
 	[INTERNAL]: {
 		handle: WorkflowRunHandle<Input, unknown, Context, TEvents>;
 		replayManifest: ReplayManifest;
+		createTaskExecutionTracker: CreateTaskExecutionTracker;
 		configProvider: ConfigProvider<WorkflowExecutionConfig>;
 		hasher: BoundHasher;
 	};

--- a/sdk/workflow/src/run/task-execution-tracker.test.ts
+++ b/sdk/workflow/src/run/task-execution-tracker.test.ts
@@ -1,0 +1,134 @@
+import { delay } from "@aikirun/lib/async";
+import { withFakeClient } from "@aikirun/testing/client";
+import { runningWorkflowRunRecordFactory } from "@aikirun/testing/data-factory/workflow/run";
+import { INTERNAL } from "@aikirun/types/symbols";
+
+import { workflowRunHandle } from "./handle";
+import { taskExecutionTracker } from "./task-execution-tracker";
+import { describe, expect, test } from "bun:test";
+
+describe("taskExecutionTracker", () => {
+	test("flush waits for open task executions even when none awaited a retry", () =>
+		withFakeClient(async (client) => {
+			const handle = workflowRunHandle(client, runningWorkflowRunRecordFactory.build());
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const tracker = createTracker();
+
+			let flushed = false;
+			const flushing = flush().then(() => {
+				flushed = true;
+			});
+			await delay(5);
+			expect(flushed).toBe(false);
+
+			tracker.end();
+
+			await flushing;
+			expect(flushed).toBe(true);
+		}));
+
+	test("flush does nothing when no task execution awaited a retry", () =>
+		withFakeClient(async (client) => {
+			const handle = workflowRunHandle(client, runningWorkflowRunRecordFactory.build());
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const tracker = createTracker();
+			tracker.end();
+
+			expect(flush()).resolves.toBeUndefined();
+		}));
+
+	test("flush transitions the run only after every task execution ends", () =>
+		withFakeClient(async (client) => {
+			const record = runningWorkflowRunRecordFactory.build({ revision: 3, attempts: 1 });
+			const handle = workflowRunHandle(client, record);
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const awaitingRetryExecution = createTracker();
+			awaitingRetryExecution.awaitingRetry();
+			awaitingRetryExecution.end();
+			const openExecution = createTracker();
+
+			client.api.workflowRun.transitionStateV1.once(
+				{ type: "optimistic", id: record.id, state: { status: "awaiting_task_retry" }, expectedRevision: 3 },
+				{ revision: 4, state: { status: "awaiting_task_retry", nextAttemptAt: 1 }, attempts: 1 }
+			);
+			let transitioned = false;
+			client.api.workflowRun.transitionStateV1.onNextCall(() => {
+				transitioned = true;
+			});
+
+			const flushing = flush();
+			await delay(5);
+			expect(transitioned).toBe(false);
+
+			openExecution.end();
+			await flushing;
+			expect(transitioned).toBe(true);
+
+			expect(handle.run.state).toEqual({ status: "awaiting_task_retry", nextAttemptAt: 1 });
+		}));
+
+	test("flush skips the awaiting_retry transition when the run is no longer running", () =>
+		withFakeClient(async (client) => {
+			const record = runningWorkflowRunRecordFactory.build({ revision: 3, attempts: 1 });
+			const handle = workflowRunHandle(client, record);
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const tracker = createTracker();
+			tracker.awaitingRetry();
+			tracker.end();
+
+			client.api.workflowRun.transitionStateV1.once(
+				{
+					type: "optimistic",
+					id: record.id,
+					state: { status: "sleeping", sleepName: "nap", durationMs: 60_000 },
+					expectedRevision: 3,
+				},
+				{ revision: 4, state: { status: "sleeping", sleepName: "nap", wakeupAt: 60_001 }, attempts: 1 }
+			);
+			await handle[INTERNAL].transitionState({ status: "sleeping", sleepName: "nap", durationMs: 60_000 });
+
+			await flush();
+
+			expect(handle.run.state).toEqual({ status: "sleeping", sleepName: "nap", wakeupAt: 60_001 });
+		}));
+
+	test("flush resolves even when the transition fails", () =>
+		withFakeClient(async (client) => {
+			const record = runningWorkflowRunRecordFactory.build({ revision: 3 });
+			const handle = workflowRunHandle(client, record);
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const tracker = createTracker();
+			tracker.awaitingRetry();
+			tracker.end();
+
+			client.api.workflowRun.transitionStateV1.rejectsOnce(
+				{ type: "optimistic", id: record.id, state: { status: "awaiting_task_retry" }, expectedRevision: 3 },
+				{ code: "SOME_OTHER_ERROR" }
+			);
+
+			expect(flush()).resolves.toBeUndefined();
+		}));
+
+	test("flush resolves even when the transition hits a revision conflict", () =>
+		withFakeClient(async (client) => {
+			const record = runningWorkflowRunRecordFactory.build({ revision: 3 });
+			const handle = workflowRunHandle(client, record);
+			const { create: createTracker, flush } = taskExecutionTracker(handle, client.logger);
+
+			const tracker = createTracker();
+			tracker.awaitingRetry();
+			tracker.end();
+
+			client.api.workflowRun.transitionStateV1.rejectsOnce(
+				{ type: "optimistic", id: record.id, state: { status: "awaiting_task_retry" }, expectedRevision: 3 },
+				{ code: "WORKFLOW_RUN_REVISION_CONFLICT" }
+			);
+
+			expect(flush()).resolves.toBeUndefined();
+		}));
+});

--- a/sdk/workflow/src/run/task-execution-tracker.ts
+++ b/sdk/workflow/src/run/task-execution-tracker.ts
@@ -1,0 +1,79 @@
+import { createBinaryLatch } from "@aikirun/lib/async";
+import type { Logger } from "@aikirun/lib/logger";
+import { INTERNAL } from "@aikirun/types/symbols";
+import { WorkflowRunRevisionConflictError } from "@aikirun/types/workflow/run";
+
+import type { WorkflowRunHandle } from "./handle";
+
+export type CreateTaskExecutionTracker = () => TaskExecutionTracker;
+
+export interface TaskExecutionTracker {
+	/** Call when the task being tracked is awaiting a retry. */
+	awaitingRetry(): void;
+	end(): void;
+}
+
+/**
+ * Tracks the task executions of one execution of a workflow run.
+ *
+ * `create` mints a tracker for a single task execution: the task reports through it
+ * that it is awaiting a retry, and `end` marks the execution finished. `flush` waits
+ * until every created tracker has ended, then transitions the run to
+ * `awaiting_task_retry` when a task reported awaiting a retry and the run is still
+ * `running`; otherwise it does nothing. `flush` never throws.
+ */
+export function taskExecutionTracker(
+	handle: WorkflowRunHandle<unknown, unknown, unknown>,
+	logger: Logger
+): {
+	create: CreateTaskExecutionTracker;
+	flush: () => Promise<void>;
+} {
+	const idle = createBinaryLatch();
+	let openExecutions = 0;
+	let anyAwaitingRetry = false;
+
+	return {
+		create() {
+			openExecutions++;
+			let ended = false;
+			return {
+				awaitingRetry() {
+					anyAwaitingRetry = true;
+				},
+				end() {
+					if (ended) {
+						return;
+					}
+					ended = true;
+					openExecutions--;
+					if (openExecutions === 0) {
+						idle.signal();
+					}
+				},
+			};
+		},
+		async flush() {
+			while (openExecutions > 0) {
+				await idle.wait();
+			}
+
+			if (!anyAwaitingRetry) {
+				return;
+			}
+
+			if (handle.run.state.status !== "running") {
+				return;
+			}
+
+			try {
+				await handle[INTERNAL].transitionState({ status: "awaiting_task_retry" });
+			} catch (err) {
+				if (err instanceof WorkflowRunRevisionConflictError) {
+					return;
+				}
+				logger.warn("Failed to transition the run to awaiting_task_retry", { err });
+			}
+		},
+	};
+}

--- a/sdk/workflow/src/system/cancel-child-runs.test.ts
+++ b/sdk/workflow/src/system/cancel-child-runs.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from "bun:test";
 import type { WorkflowRun } from "../run";
 import { workflowRunHandle } from "../run/handle";
 import { createReplayManifest } from "../run/replay-manifest";
+import { taskExecutionTracker } from "../run/task-execution-tracker";
 
 const LIST_NON_TERMINAL_CHILDREN_TASK_NAME = "list-non-terminal-child-runs";
 const CANCEL_RUNS_TASK_NAME = "cancel-runs";
@@ -37,6 +38,7 @@ function createTestWorkflowRun(
 		[INTERNAL]: {
 			handle,
 			replayManifest: createReplayManifest(record),
+			createTaskExecutionTracker: taskExecutionTracker(handle, client.logger).create,
 			configProvider: asConfigProvider(() => ({ claimRefreshIntervalMs: 30_000, maxInlineWaitMs: 10 })),
 			hasher: hashInput,
 		},

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -8,6 +8,7 @@ import {
 	workflowRunStateByStatus,
 } from "@aikirun/testing/data-factory/workflow/run";
 import {
+	awaitingRetryTaskInfoFactory,
 	completedTaskInfoFactory,
 	failedTaskInfoFactory,
 	runningTaskInfoFactory,
@@ -29,6 +30,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { WorkflowRun } from "./run";
 import { workflowRunHandle } from "./run/handle";
 import { createReplayManifest } from "./run/replay-manifest";
+import { taskExecutionTracker } from "./run/task-execution-tracker";
 import { task } from "./task";
 import { describe, expect, test } from "bun:test";
 
@@ -52,6 +54,7 @@ function createTestWorkflowRun(
 		[INTERNAL]: {
 			handle,
 			replayManifest: createReplayManifest(record),
+			createTaskExecutionTracker: taskExecutionTracker(handle, client.logger).create,
 			configProvider: asConfigProvider(() => ({
 				claimRefreshIntervalMs: 30_000,
 				maxInlineWaitMs: options.maxInlineWaitMs ?? 10,
@@ -219,6 +222,197 @@ describe("task", () => {
 					);
 
 				expect(chargeCard.start(run, input)).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
+			}));
+
+		test("retries a due replayed task with the strategy from its stored options", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 60_000 } as const;
+				let handlerCalls = 0;
+				// The definition carries no retry; the stored options are what allow this retry.
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						return "charged";
+					},
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getCompositeId({ name: chargeCard.name, referenceId: inputHash });
+				const awaitingRetryTaskInfo = awaitingRetryTaskInfoFactory.build({
+					name: chargeCard.name,
+					options: { retry },
+					state: { nextAttemptAt: 1 },
+				});
+				const recordWithTask = { ...runRecord, tasks: { [address]: [awaitingRetryTaskInfo] } };
+				const run = createTestWorkflowRun(client, recordWithTask);
+
+				const retriedTaskInfo = runningTaskInfoFactory.build({
+					id: awaitingRetryTaskInfo.id,
+					name: chargeCard.name,
+					attempts: 2,
+				});
+				client.api.task.transitionStateV1
+					.once(
+						{
+							type: "retry",
+							id: awaitingRetryTaskInfo.id,
+							attempts: 2,
+							workflowRunId: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: retriedTaskInfo }
+					)
+					.once(
+						{
+							id: awaitingRetryTaskInfo.id,
+							attempts: 2,
+							state: { status: "completed", output: "charged" },
+							workflowRunId: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{
+							taskInfo: completedTaskInfoFactory.build({
+								id: awaitingRetryTaskInfo.id,
+								name: chargeCard.name,
+								attempts: 2,
+								state: { output: "charged" },
+							}),
+						}
+					);
+
+				expect(await chargeCard.start(run, input)).toBe("charged");
+				expect(handlerCalls).toBe(1);
+			}));
+
+		test("suspends without a request when a replayed task's retry is not due", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 60_000 } as const;
+				let handlerCalls = 0;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						return "charged";
+					},
+					retry,
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getCompositeId({ name: chargeCard.name, referenceId: inputHash });
+				// The clock cannot be pinned in unit tests (files run concurrently), so "not due"
+				// is a deadline a day out — far beyond the lifetime of a test run.
+				const awaitingRetryTaskInfo = awaitingRetryTaskInfoFactory.build({
+					name: chargeCard.name,
+					options: { retry },
+					state: { nextAttemptAt: Date.now() + 24 * 60 * 60 * 1000 },
+				});
+				const recordWithTask = { ...runRecord, tasks: { [address]: [awaitingRetryTaskInfo] } };
+				const run = createTestWorkflowRun(client, recordWithTask, { maxInlineWaitMs: 0 });
+
+				expect(chargeCard.start(run, input)).rejects.toBeInstanceOf(WorkflowRunSuspendedError);
+				expect(handlerCalls).toBe(0);
+			}));
+
+		test("retries in process when the remaining wait is within the max inline wait", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 60_000 } as const;
+				let handlerCalls = 0;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						return "charged";
+					},
+					retry,
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getCompositeId({ name: chargeCard.name, referenceId: inputHash });
+				// The max inline wait admits every remaining wait, so the branch is decided by
+				// configuration; the deadline sits a few milliseconds out only to keep the
+				// in-process wait short.
+				const awaitingRetryTaskInfo = awaitingRetryTaskInfoFactory.build({
+					name: chargeCard.name,
+					options: { retry },
+					state: { nextAttemptAt: Date.now() + 5 },
+				});
+				const recordWithTask = { ...runRecord, tasks: { [address]: [awaitingRetryTaskInfo] } };
+				const run = createTestWorkflowRun(client, recordWithTask, { maxInlineWaitMs: Number.MAX_SAFE_INTEGER });
+
+				const retriedTaskInfo = runningTaskInfoFactory.build({
+					id: awaitingRetryTaskInfo.id,
+					name: chargeCard.name,
+					attempts: 2,
+				});
+				client.api.task.transitionStateV1
+					.once(
+						{
+							type: "retry",
+							id: awaitingRetryTaskInfo.id,
+							attempts: 2,
+							workflowRunId: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{ taskInfo: retriedTaskInfo }
+					)
+					.once(
+						{
+							id: awaitingRetryTaskInfo.id,
+							attempts: 2,
+							state: { status: "completed", output: "charged" },
+							workflowRunId: runRecord.id,
+							expectedWorkflowRunRevision: runRecord.revision,
+						},
+						{
+							taskInfo: completedTaskInfoFactory.build({
+								id: awaitingRetryTaskInfo.id,
+								name: chargeCard.name,
+								attempts: 2,
+								state: { output: "charged" },
+							}),
+						}
+					);
+
+				expect(await chargeCard.start(run, input)).toBe("charged");
+				expect(handlerCalls).toBe(1);
+			}));
+
+		test("does not retry a replayed task whose stored options have no retry", () =>
+			withFakeClient(async (client) => {
+				const runRecord = runningWorkflowRunRecordFactory.build();
+
+				// The definition carries a retry, but the stored options do not — the stored
+				// options are the ones that count.
+				const retry = { type: "fixed", maxAttempts: 3, delayMs: 60_000 } as const;
+				let handlerCalls = 0;
+				const chargeCard = task<{ cardId: string }, string>({
+					name: "charge-card",
+					handler: async () => {
+						handlerCalls++;
+						return "charged";
+					},
+					retry,
+				});
+
+				const input = { cardId: "card-1" };
+				const inputHash = await hashInput(input);
+				const address = getCompositeId({ name: chargeCard.name, referenceId: inputHash });
+				const awaitingRetryTaskInfo = awaitingRetryTaskInfoFactory.build({ name: chargeCard.name });
+				const recordWithTask = { ...runRecord, tasks: { [address]: [awaitingRetryTaskInfo] } };
+				const run = createTestWorkflowRun(client, recordWithTask);
+
+				expect(chargeCard.start(run, input)).rejects.toBeInstanceOf(TaskFailedError);
+				expect(handlerCalls).toBe(0);
 			}));
 
 		test("fails the task and throws TaskFailedError when there is no retry budget", () =>

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -21,7 +21,14 @@ import {
 	WorkflowRunRevisionConflictError,
 	WorkflowRunSuspendedError,
 } from "@aikirun/types/workflow/run";
-import type { TaskAddress, TaskId, TaskInfo, TaskName, TaskStartOptions } from "@aikirun/types/workflow/task";
+import type {
+	TaskAddress,
+	TaskId,
+	TaskInfo,
+	TaskName,
+	TaskStartOptions,
+	TaskStateAwaitingRetry,
+} from "@aikirun/types/workflow/task";
 import { TaskFailedError } from "@aikirun/types/workflow/task";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
@@ -29,6 +36,7 @@ import type { WorkflowRun } from "./run";
 import type { WorkflowExecutionConfig } from "./run/execute";
 import type { WorkflowRunHandle } from "./run/handle";
 import { validateWithSchema } from "./run/schema-validation";
+import type { TaskExecutionTracker } from "./run/task-execution-tracker";
 
 type UnknownWorkflowRun = WorkflowRun<unknown, unknown>;
 type UnknownWorkflowRunHandle = WorkflowRunHandle<unknown, unknown, unknown>;
@@ -120,37 +128,44 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 	}
 
 	public async start(run: UnknownWorkflowRun, ...args: Input extends void ? [] : [Input]): Promise<Output> {
-		return this.startWithOptions(run, this.startOptionsBuilder.build(), ...args);
+		const executionTracker = run[INTERNAL].createTaskExecutionTracker();
+		try {
+			return await this.startWithOptions(run, this.startOptionsBuilder.build(), executionTracker, ...args);
+		} finally {
+			executionTracker.end();
+		}
 	}
 
 	private async startWithOptions(
 		run: UnknownWorkflowRun,
 		startOptions: TaskStartOptions,
+		executionTracker: TaskExecutionTracker,
 		...args: Input extends void ? [] : [Input]
 	): Promise<Output> {
-		const handle = run[INTERNAL].handle;
-		const hasher = run[INTERNAL].hasher;
+		const {
+			logger,
+			[INTERNAL]: { handle, hasher, replayManifest, configProvider },
+		} = run;
+
 		handle[INTERNAL].assertExecutionAllowed();
 
 		const inputRaw = args[0];
 		const inputSchema = this.params.schema?.input;
 		const inputSchemaValidationResult = inputSchema
-			? validateWithSchema(handle, inputSchema, inputRaw, run.logger, "Invalid task data")
+			? validateWithSchema(handle, inputSchema, inputRaw, logger, "Invalid task data")
 			: (inputRaw as Input);
 		const input =
 			inputSchemaValidationResult instanceof Promise ? await inputSchemaValidationResult : inputSchemaValidationResult;
 		const inputHash = await hasher(input);
 		const address = getCompositeId<TaskAddress>({ name: this.name, referenceId: inputHash });
 
-		const replayManifest = run[INTERNAL].replayManifest;
-
 		if (replayManifest.hasUnconsumedEntries()) {
 			const existingTaskInfo = replayManifest.consumeNextTask(address);
 			if (existingTaskInfo) {
-				return this.getExistingTaskResult(run, handle, startOptions, input, existingTaskInfo);
+				return this.getExistingTaskResult(handle, executionTracker, input, existingTaskInfo, configProvider, logger);
 			}
 
-			await this.throwNonDeterminismError(run, handle, inputHash, replayManifest.getUnconsumedEntries());
+			await this.throwNonDeterminismError(handle, inputHash, replayManifest.getUnconsumedEntries(), logger);
 		}
 
 		const attempts = 1;
@@ -164,21 +179,22 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			inputHash,
 		});
 
-		const logger = run.logger.child({
+		const taskLogger = logger.child({
 			"aiki.taskName": this.name,
 			"aiki.taskId": taskInfo.id,
 		});
 
-		logger.info("Task started", { "aiki.attempts": attempts });
+		taskLogger.info("Task started", { "aiki.attempts": attempts });
 
 		const { output, lastAttempt } = await this.tryExecuteTask(
 			handle,
+			executionTracker,
 			input,
 			taskInfo.id as TaskId,
 			retryStrategy,
 			attempts,
-			run[INTERNAL].configProvider,
-			logger
+			configProvider,
+			taskLogger
 		);
 
 		await handle[INTERNAL].transitionTaskState({
@@ -186,17 +202,18 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			attempts: lastAttempt,
 			state: { status: "completed", output },
 		});
-		logger.info("Task complete", { "aiki.attempts": lastAttempt });
+		taskLogger.info("Task complete", { "aiki.attempts": lastAttempt });
 
 		return output;
 	}
 
 	private async getExistingTaskResult(
-		run: UnknownWorkflowRun,
 		handle: UnknownWorkflowRunHandle,
-		startOptions: TaskStartOptions,
+		executionTracker: TaskExecutionTracker,
 		input: Input,
-		existingTaskInfo: TaskInfo
+		existingTaskInfo: TaskInfo,
+		configProvider: ConfigProvider<WorkflowExecutionConfig>,
+		logger: Logger
 	) {
 		const existingTaskState = existingTaskInfo.state;
 
@@ -215,46 +232,47 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 		existingTaskState.status satisfies "running" | "awaiting_retry";
 
 		const attempts = existingTaskInfo.attempts;
-		const retryStrategy = startOptions.retry ?? { type: "never" };
-		this.assertRetryAllowed(existingTaskInfo.id as TaskId, attempts, retryStrategy, run.logger);
+		const retryStrategy = existingTaskInfo.options?.retry ?? { type: "never" };
+		this.assertRetryAttemptsLeft(existingTaskInfo.id as TaskId, attempts, retryStrategy, logger);
+		if (existingTaskState.status === "awaiting_retry") {
+			await this.assertRetryIsDue(
+				handle,
+				executionTracker,
+				existingTaskInfo.id as TaskId,
+				existingTaskState,
+				configProvider,
+				logger
+			);
+		}
 
-		run.logger.debug("Retrying task", {
+		logger.debug("Retrying task", {
 			"aiki.taskName": this.name,
 			"aiki.taskId": existingTaskInfo.id,
 			"aiki.attempts": attempts,
 			"aiki.taskStatus": existingTaskState.status,
 		});
 
-		return this.retryAndExecute(run, handle, input, existingTaskInfo.id, retryStrategy, attempts);
+		return this.retryExecute(
+			handle,
+			executionTracker,
+			input,
+			existingTaskInfo.id,
+			retryStrategy,
+			attempts,
+			configProvider,
+			logger
+		);
 	}
 
-	private async throwNonDeterminismError(
-		run: UnknownWorkflowRun,
+	private async retryExecute(
 		handle: UnknownWorkflowRunHandle,
-		inputHash: string,
-		unconsumedManifestEntries: UnconsumedManifestEntries
-	): Promise<never> {
-		run.logger.error("Replay divergence", {
-			"aiki.taskName": this.name,
-			"aiki.inputHash": inputHash,
-			"aiki.unconsumedManifestEntries": unconsumedManifestEntries,
-		});
-		const err = new NonDeterminismError(run.id, handle.run.attempts, unconsumedManifestEntries);
-		await handle[INTERNAL].transitionState({
-			status: "failed",
-			cause: "self",
-			error: createSerializableError(err),
-		});
-		throw err;
-	}
-
-	private async retryAndExecute(
-		run: UnknownWorkflowRun,
-		handle: UnknownWorkflowRunHandle,
+		executionTracker: TaskExecutionTracker,
 		input: Input,
 		taskId: string,
 		retryStrategy: RetryStrategy,
-		previousAttempts: number
+		previousAttempts: number,
+		configProvider: ConfigProvider<WorkflowExecutionConfig>,
+		logger: Logger
 	): Promise<Output> {
 		const attempts = previousAttempts + 1;
 
@@ -264,20 +282,21 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			attempts,
 		});
 
-		const logger = run.logger.child({
+		const taskLogger = logger.child({
 			"aiki.taskName": this.name,
 			"aiki.taskId": taskInfo.id,
 		});
-		logger.info("Task started", { "aiki.attempts": attempts });
+		taskLogger.info("Task started", { "aiki.attempts": attempts });
 
 		const { output, lastAttempt } = await this.tryExecuteTask(
 			handle,
+			executionTracker,
 			input,
 			taskInfo.id as TaskId,
 			retryStrategy,
 			attempts,
-			run[INTERNAL].configProvider,
-			logger
+			configProvider,
+			taskLogger
 		);
 
 		await handle[INTERNAL].transitionTaskState({
@@ -285,13 +304,14 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 			attempts: lastAttempt,
 			state: { status: "completed", output },
 		});
-		logger.info("Task complete", { "aiki.attempts": lastAttempt });
+		taskLogger.info("Task complete", { "aiki.attempts": lastAttempt });
 
 		return output;
 	}
 
 	private async tryExecuteTask(
 		handle: UnknownWorkflowRunHandle,
+		executionTracker: TaskExecutionTracker,
 		input: Input,
 		taskId: TaskId,
 		retryStrategy: RetryStrategy,
@@ -365,12 +385,38 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 						nextAttemptInMs: retryParams.delayMs,
 					},
 				});
+				executionTracker.awaitingRetry();
 				throw new WorkflowRunSuspendedError(handle.run.id as WorkflowRunId);
 			}
 		}
 	}
 
-	private assertRetryAllowed(taskId: TaskId, attempts: number, retryStrategy: RetryStrategy, logger: Logger): void {
+	private async throwNonDeterminismError(
+		handle: UnknownWorkflowRunHandle,
+		inputHash: string,
+		unconsumedManifestEntries: UnconsumedManifestEntries,
+		logger: Logger
+	): Promise<never> {
+		logger.error("Replay divergence", {
+			"aiki.taskName": this.name,
+			"aiki.inputHash": inputHash,
+			"aiki.unconsumedManifestEntries": unconsumedManifestEntries,
+		});
+		const err = new NonDeterminismError(handle.run.id as WorkflowRunId, handle.run.attempts, unconsumedManifestEntries);
+		await handle[INTERNAL].transitionState({
+			status: "failed",
+			cause: "self",
+			error: createSerializableError(err),
+		});
+		throw err;
+	}
+
+	private assertRetryAttemptsLeft(
+		taskId: TaskId,
+		attempts: number,
+		retryStrategy: RetryStrategy,
+		logger: Logger
+	): void {
 		const retryParams = getRetryParams(attempts, retryStrategy);
 		if (!retryParams.retriesLeft) {
 			logger.error("Task retry not allowed", {
@@ -379,6 +425,29 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 				"aiki.attempts": attempts,
 			});
 			throw new TaskFailedError(taskId, attempts, "Task retry not allowed");
+		}
+	}
+
+	private async assertRetryIsDue(
+		handle: UnknownWorkflowRunHandle,
+		executionTracker: TaskExecutionTracker,
+		taskId: TaskId,
+		taskState: TaskStateAwaitingRetry,
+		configProvider: ConfigProvider<WorkflowExecutionConfig>,
+		logger: Logger
+	): Promise<void> {
+		const remainingDelayMs = taskState.nextAttemptAt - Date.now();
+		if (remainingDelayMs > configProvider.config.maxInlineWaitMs) {
+			executionTracker.awaitingRetry();
+			logger.debug("Task retry not due, suspending", {
+				"aiki.taskName": this.name,
+				"aiki.taskId": taskId,
+				"aiki.remainingDelayMs": remainingDelayMs,
+			});
+			throw new WorkflowRunSuspendedError(handle.run.id as WorkflowRunId);
+		}
+		if (remainingDelayMs > 0) {
+			await delay(remainingDelayMs);
 		}
 	}
 }

--- a/sdk/workflow/src/workflow-version.test.ts
+++ b/sdk/workflow/src/workflow-version.test.ts
@@ -28,6 +28,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { WorkflowRun } from "./run";
 import { workflowRunHandle } from "./run/handle";
 import { createReplayManifest } from "./run/replay-manifest";
+import { taskExecutionTracker } from "./run/task-execution-tracker";
 import { task } from "./task";
 import { workflow } from "./workflow";
 import { describe, expect, test } from "bun:test";
@@ -51,6 +52,7 @@ function createTestWorkflowRun(
 		[INTERNAL]: {
 			handle,
 			replayManifest: createReplayManifest(record),
+			createTaskExecutionTracker: taskExecutionTracker(handle, client.logger).create,
 			configProvider: asConfigProvider(() => ({ claimRefreshIntervalMs: 30_000, maxInlineWaitMs: 10 })),
 			hasher: hashInput,
 		},

--- a/testing/src/data-factory/workflow/task.ts
+++ b/testing/src/data-factory/workflow/task.ts
@@ -1,4 +1,10 @@
-import type { TaskInfo, TaskStateCompleted, TaskStateFailed, TaskStateRunning } from "@aikirun/types/workflow/task";
+import type {
+	TaskInfo,
+	TaskStateAwaitingRetry,
+	TaskStateCompleted,
+	TaskStateFailed,
+	TaskStateRunning,
+} from "@aikirun/types/workflow/task";
 import { Factory } from "fishery";
 
 export const runningTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateRunning }>(({ sequence }) => ({
@@ -8,6 +14,20 @@ export const runningTaskInfoFactory = Factory.define<TaskInfo & { state: TaskSta
 	attempts: 1,
 	state: { status: "running" },
 }));
+
+export const awaitingRetryTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateAwaitingRetry }>(
+	({ sequence }) => ({
+		id: `task-${sequence}`,
+		name: "task",
+		inputHash: "hash",
+		attempts: 1,
+		state: {
+			status: "awaiting_retry",
+			error: { name: "Error", message: "task failed" },
+			nextAttemptAt: 1,
+		},
+	})
+);
 
 export const failedTaskInfoFactory = Factory.define<TaskInfo & { state: TaskStateFailed }>(({ sequence }) => ({
 	id: `task-${sequence}`,


### PR DESCRIPTION
## Motivation

Since #189 the server side is complete: a run parked as `awaiting_task_retry` is requeued when its deadline passes. But no worker parks. A task park still leaves the run `running`, with the task transition deleting the run's outbox row so recovery cannot redispatch it early — and with the task scan gone, nothing wakes that run. Replay is also wrong twice: it retries an `awaiting_retry` task immediately, ignoring its `nextAttemptAt`, and it reads the retry strategy from the call site instead of the options the task was started with.

## Solution

Replay now honors the task's deadline. A due task is retried now. A remaining wait within `maxInlineWaitMs` is waited out in process, then retried. A longer wait marks the run for parking and throws `WorkflowRunSuspendedError`.

After the handler unwinds, the worker parks the run: `running → awaiting_task_retry`. Before parking it waits for every task execution it started to finish, otherwise parking immediately would bump the run revision and make their results lose the revision check. The park is skipped when the run already moved another way (a sleep, event wait, or cancel won the revision check), and a failed park just leaves the run's claimed outbox row for claim recovery to redeliver.

The retry strategy on replay comes from the options stored on the task row; the call-site strategy applies only when the task is created.

The task state machine stops deleting the run's outbox row on a task park. The claimed row now stays until the run parks — the run park deletes it — so a run cannot be requeued or redelivered while a worker is still executing it.

This is the worker half of #189's release constraint: the two ship in the same release, or task parks have no waker.