### PR TITLE
Task output as stored, strict and faster input hashing

### DIFF
--- a/lib/src/json/stable-stringify.test.ts
+++ b/lib/src/json/stable-stringify.test.ts
@@ -124,3 +124,20 @@ describe("stableStringify on objects JSON would change", () => {
 		expect(stableStringify({ value: Object.assign(Object.create(null), { a: 1 }) })).toBe('{"value":{"a":1}}');
 	});
 });
+
+describe("stableStringify output pinned for hash stability", () => {
+	test("formats numbers exactly as JSON.stringify does", () => {
+		expect(stableStringify({ zero: -0, big: 1e21, small: 1e-7, float: 0.1 + 0.2 })).toBe(
+			'{"big":1e+21,"float":0.30000000000000004,"small":1e-7,"zero":0}'
+		);
+	});
+
+	test("orders integer-like keys lexicographically, not in enumeration order", () => {
+		expect(stableStringify({ "10": 1, "2": 2, a: 3, "": 4 })).toBe('{"":4,"10":1,"2":2,"a":3}');
+	});
+
+	test("escapes strings exactly as JSON.stringify does", () => {
+		const text = `q"b\\${String.fromCharCode(10, 1, 0xd800)}é😀`;
+		expect(stableStringify({ text })).toBe(`{"text":${JSON.stringify(text)}}`);
+	});
+});

--- a/lib/src/json/stable-stringify.test.ts
+++ b/lib/src/json/stable-stringify.test.ts
@@ -67,14 +67,6 @@ describe("stableStringify", () => {
 		expect(stableStringify({ items: [1, undefined, 3] })).toBe('{"items":[1,null,3]}');
 	});
 
-	test("serializes Date as empty object", () => {
-		expect(stableStringify({ value: new Date("2024-01-01") })).toBe('{"value":{}}');
-	});
-
-	test("serializes RegExp as empty object", () => {
-		expect(stableStringify({ value: /test/ })).toBe('{"value":{}}');
-	});
-
 	test("throws on function value", () => {
 		expect(() => stableStringify({ value: () => {} })).toThrow("function");
 	});
@@ -97,5 +89,38 @@ describe("stableStringify", () => {
 
 	test("throws on promise inside array", () => {
 		expect(() => stableStringify({ items: [Promise.resolve()] })).toThrow("Promise");
+	});
+});
+
+describe("stableStringify on objects JSON would change", () => {
+	class Point {
+		constructor(
+			public x: number,
+			public y: number
+		) {}
+	}
+
+	test("throws for a Date instead of hashing it as an empty object", () => {
+		expect(() => stableStringify({ since: new Date(0) })).toThrow("Date");
+	});
+
+	test("throws for a Map", () => {
+		expect(() => stableStringify({ index: new Map() })).toThrow("Map");
+	});
+
+	test("throws for a Set", () => {
+		expect(() => stableStringify({ tags: new Set(["a"]) })).toThrow("Set");
+	});
+
+	test("throws for a RegExp", () => {
+		expect(() => stableStringify({ pattern: /x/ })).toThrow("RegExp");
+	});
+
+	test("throws for a class instance, naming the class", () => {
+		expect(() => stableStringify({ origin: new Point(1, 2) })).toThrow("Point");
+	});
+
+	test("accepts an object with a null prototype", () => {
+		expect(stableStringify({ value: Object.assign(Object.create(null), { a: 1 }) })).toBe('{"value":{"a":1}}');
 	});
 });

--- a/lib/src/json/stable-stringify.ts
+++ b/lib/src/json/stable-stringify.ts
@@ -2,6 +2,9 @@
  * Stable JSON serialization that sorts object keys for deterministic hashing.
  * Ensures {a: 1, b: 2} and {b: 2, a: 1} produce the same hash.
  *
+ * Throws for values JSON would change silently (Date, Map, Set, class instances),
+ * so two different values never appear equal.
+ *
  * @param value - The record to serialize
  * @returns A stable JSON string representation
  *
@@ -37,8 +40,9 @@ function stringifyValue(value: unknown): string {
 		return `[${value.map(stringifyValue).join(",")}]`;
 	}
 
-	if (value instanceof Promise) {
-		throw new Error("stableStringify does not support Promise values");
+	const prototype = Object.getPrototypeOf(value);
+	if (prototype !== Object.prototype && prototype !== null) {
+		throw new Error(`stableStringify does not support ${typeName(value)} values`);
 	}
 
 	const keys = Object.keys(value).sort();
@@ -50,4 +54,9 @@ function stringifyValue(value: unknown): string {
 		}
 	}
 	return `{${pairs.join(",")}}`;
+}
+
+function typeName(value: object): string {
+	const constructorName = typeof value.constructor === "function" ? value.constructor.name : "";
+	return constructorName === "" ? "object" : constructorName;
 }

--- a/lib/src/json/stable-stringify.ts
+++ b/lib/src/json/stable-stringify.ts
@@ -19,9 +19,38 @@ export function stableStringify(value: Record<string, unknown>): string {
 	return stringifyValue(value);
 }
 
+// Most keys and values are short, and scanning a short string here is cheaper than a native
+// call. A string that is long, or that holds anything JSON escapes, goes to JSON.stringify.
+const STRING_SCAN_LIMIT = 32;
+
+function quote(text: string): string {
+	if (text.length > STRING_SCAN_LIMIT) {
+		return JSON.stringify(text);
+	}
+	for (let index = 0; index < text.length; index++) {
+		const code = text.charCodeAt(index);
+		if (code < 32 || code === 34 || code === 92 || (code >= 0xd800 && code <= 0xdfff)) {
+			return JSON.stringify(text);
+		}
+	}
+	return `"${text}"`;
+}
+
 function stringifyValue(value: unknown): string {
 	if (value === null || value === undefined) {
 		return "null";
+	}
+
+	if (typeof value === "string") {
+		return quote(value);
+	}
+
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? String(value) : "null";
+	}
+
+	if (typeof value === "boolean") {
+		return value ? "true" : "false";
 	}
 
 	if (typeof value === "function") {
@@ -37,7 +66,14 @@ function stringifyValue(value: unknown): string {
 	}
 
 	if (Array.isArray(value)) {
-		return `[${value.map(stringifyValue).join(",")}]`;
+		let out = "[";
+		for (let index = 0; index < value.length; index++) {
+			if (index > 0) {
+				out += ",";
+			}
+			out += stringifyValue(value[index]);
+		}
+		return `${out}]`;
 	}
 
 	const prototype = Object.getPrototypeOf(value);
@@ -45,15 +81,24 @@ function stringifyValue(value: unknown): string {
 		throw new Error(`stableStringify does not support ${typeName(value)} values`);
 	}
 
-	const keys = Object.keys(value).sort();
-	const pairs: string[] = [];
+	const keys = Object.keys(value);
+	if (keys.length > 1) {
+		keys.sort();
+	}
+	let out = "{";
+	let first = true;
 	for (const key of keys) {
 		const keyValue = (value as Record<string, unknown>)[key];
-		if (keyValue !== undefined) {
-			pairs.push(`${JSON.stringify(key)}:${stringifyValue(keyValue)}`);
+		if (keyValue === undefined) {
+			continue;
 		}
+		if (!first) {
+			out += ",";
+		}
+		first = false;
+		out += `${quote(key)}:${stringifyValue(keyValue)}`;
 	}
-	return `{${pairs.join(",")}}`;
+	return `${out}}`;
 }
 
 function typeName(value: object): string {

--- a/sdk/workflow/src/task.test.ts
+++ b/sdk/workflow/src/task.test.ts
@@ -814,3 +814,86 @@ describe("task input/output serializability", () => {
 		task({ name: "charge", handler: async () => JSON.parse("{}") });
 	});
 });
+
+describe("task output on the first run", () => {
+	test("returns the output as JSON stores it, so the first run sees what a replay will see", () =>
+		withFakeClient(async (client) => {
+			const runRecord = runningWorkflowRunRecordFactory.build();
+			const run = createTestWorkflowRun(client, runRecord);
+			const syncInventory = task<string, { syncedAt: string }>({
+				name: "sync-inventory",
+				handler: async () => {
+					// The type says string but it really is a date
+					return { syncedAt: new Date(0) as unknown as string };
+				},
+			});
+			const input = "wh-1";
+			const storedOutput = { syncedAt: "1970-01-01T00:00:00.000Z" };
+			const runningTaskInfo = runningTaskInfoFactory.build({ name: syncInventory.name });
+			const completedTaskInfo = completedTaskInfoFactory.build({
+				id: runningTaskInfo.id,
+				name: syncInventory.name,
+				state: { output: asOpaquePayload(storedOutput) },
+			});
+
+			client.api.task.transitionStateV1
+				.once(
+					{
+						type: "create",
+						input: asOpaquePayload(input),
+						inputHash: await hashInput(input),
+						taskName: syncInventory.name,
+						options: {},
+						workflowRunId: runRecord.id,
+						expectedWorkflowRunRevision: runRecord.revision,
+					},
+					{ taskInfo: runningTaskInfo }
+				)
+				.once(
+					{
+						id: runningTaskInfo.id,
+						attempts: 1,
+						state: completedTaskInfo.state,
+						workflowRunId: runRecord.id,
+						expectedWorkflowRunRevision: runRecord.revision,
+					},
+					{ taskInfo: completedTaskInfo }
+				);
+
+			expect(await syncInventory.start(run, input)).toEqual(storedOutput);
+		}));
+
+	test("returns undefined when the handler returns nothing", () =>
+		withFakeClient(async (client) => {
+			const runRecord = runningWorkflowRunRecordFactory.build();
+			const run = createTestWorkflowRun(client, runRecord);
+			const ping = task({ name: "ping", handler: async () => {} });
+			const runningTaskInfo = runningTaskInfoFactory.build({ name: ping.name });
+
+			client.api.task.transitionStateV1
+				.once(
+					{
+						type: "create",
+						input: undefined,
+						inputHash: await hashInput(undefined),
+						taskName: ping.name,
+						options: {},
+						workflowRunId: runRecord.id,
+						expectedWorkflowRunRevision: runRecord.revision,
+					},
+					{ taskInfo: runningTaskInfo }
+				)
+				.once(
+					{
+						id: runningTaskInfo.id,
+						attempts: 1,
+						state: { status: "completed", output: undefined },
+						workflowRunId: runRecord.id,
+						expectedWorkflowRunRevision: runRecord.revision,
+					},
+					{ taskInfo: { ...runningTaskInfo, state: { status: "completed" } } }
+				);
+
+			expect(await ping.start(run)).toBeUndefined();
+		}));
+});

--- a/sdk/workflow/src/task.ts
+++ b/sdk/workflow/src/task.ts
@@ -338,7 +338,10 @@ class TaskImpl<Input, Output> implements Task<Input, Output> {
 					outputSchemaValidationResult instanceof Promise
 						? await outputSchemaValidationResult
 						: outputSchemaValidationResult;
-				return { output, lastAttempt: attempts };
+				return {
+					output: output !== undefined ? JSON.parse(JSON.stringify(output)) : output,
+					lastAttempt: attempts,
+				};
 			} catch (err) {
 				if (
 					err instanceof WorkflowRunSuspendedError ||


### PR DESCRIPTION
A task's result reaches the workflow live on the first run and from storage on every replay. Storage is JSON, so a handler that returns a Date, say a database driver's value for a column typed `string`, hands the workflow a Date on the first run and an ISO string after a restart. The bug only shows on replay.

Input hashing had a related hole. `stableStringify`, the serializer behind every input hash, wrote a Date, Map, or Set as `{}`, so two task calls with different Dates got the same task address and Aiki treated them as the same task.

**Task output goes through a JSON round trip before it is stored or returned**, so the first run sees exactly what a replay will see.

**`stableStringify` throws for any object that is not plain data**: Date, Map, Set, RegExp, and class instances. The error names the type.

**`stableStringify` is about twice as fast on large inputs.** It quotes short strings itself and formats scalars directly instead of calling `JSON.stringify` once per key and per value. Output bytes are unchanged, so existing hashes still match.

## Breaking changes

An input holding a Date, Map, Set, RegExp, or class instance now fails at hashing instead of hashing as `{}`. A task output holding a bigint or a cycle now fails inside the task.
