### PR TITLE
Extract PageProcessingConfig and unify daemon chunking

### DIFF
--- a/sdk/server/src/config/runtime.ts
+++ b/sdk/server/src/config/runtime.ts
@@ -1,9 +1,16 @@
 import type { DeepPartial } from "@aikirun/lib/object";
 import { DEFAULT_CLAIM_IDLE_TIMEOUT_MS } from "@aikirun/types/workflow/run";
 
-interface PollingDaemonConfig {
+export interface PageProcessingConfig {
+	pageSize: number;
+	chunk: {
+		size: number;
+		maxConcurrency: number;
+	};
+}
+
+interface PollingDaemonConfig extends PageProcessingConfig {
 	intervalMs: number;
-	limit: number;
 }
 
 interface ImminentPollingDaemonConfig extends PollingDaemonConfig {
@@ -34,7 +41,7 @@ export interface ServerRuntimeConfig {
 			maxAgeMs: number;
 		};
 		dueTimersConsumer: {
-			limit: number;
+			pageSize: number;
 			overshootMs: number;
 		};
 	};
@@ -47,42 +54,74 @@ export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 	daemons: {
 		imminentScheduledRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentSleepElapsedRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentRetryableRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentTaskRetryableRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentEventWaitTimedOutRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentChildRunWaitTimedOutRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		imminentRecurringRuns: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 		},
 		publishPendingOutboxEntries: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 			leaseDurationMs: 5_000,
 			republishBackoff: {
 				baseDelayMs: 5_000,
@@ -92,16 +131,24 @@ export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 		},
 		recoverOverdueOutboxEntries: {
 			intervalMs: 10_000,
-			limit: 1_000,
+			pageSize: 1_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 			claimIdleTimeoutMs: DEFAULT_CLAIM_IDLE_TIMEOUT_MS,
 		},
 		stallUndeliverableRuns: {
 			intervalMs: 60_000,
-			limit: 1_000,
+			pageSize: 1_000,
+			chunk: {
+				size: 100,
+				maxConcurrency: 10,
+			},
 			maxAgeMs: 24 * 60 * 60 * 1_000, // 24 hours
 		},
 		dueTimersConsumer: {
-			limit: 1_000,
+			pageSize: 1_000,
 			overshootMs: 30,
 		},
 	},

--- a/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
@@ -32,7 +32,7 @@ describe("processDueTimers", () => {
 						signal: new AbortController().signal,
 						timerPriorityQueue: inMemoryTimerPriorityQueue()({ logger: noopLogger }),
 						childRunCanceller: createChildRunCanceller(),
-						configProvider: asConfigProvider(() => ({ limit: 100, overshootMs: 0, republishBackoff })),
+						configProvider: asConfigProvider(() => ({ pageSize: 100, overshootMs: 0, republishBackoff })),
 					},
 					[{ type: "scheduled", id: runId, rank: computeRank({ dueAt: now, priority: 2 }) }]
 				);

--- a/sdk/server/src/daemon/due-timers-consumer.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.test.ts
@@ -37,7 +37,7 @@ describe("startDueTimersConsumer", () => {
 			timerPriorityQueue,
 			childRunCanceller: createChildRunCanceller(),
 			configProvider: asConfigProvider(() => ({
-				limit: 1,
+				pageSize: 1,
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
 			})),
@@ -82,7 +82,7 @@ describe("startDueTimersConsumer", () => {
 			timerPriorityQueue,
 			childRunCanceller: createChildRunCanceller(),
 			configProvider: asConfigProvider(() => ({
-				limit: 1_000,
+				pageSize: 1_000,
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
 			})),

--- a/sdk/server/src/daemon/due-timers-consumer.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.ts
@@ -25,7 +25,7 @@ import type { ChildRunCanceller } from "../service/cancel-child-runs";
 import { scheduleRowToDomain } from "../service/schedule";
 
 interface DueTimerConsumerConfig {
-	limit: number;
+	pageSize: number;
 	overshootMs: number;
 	republishBackoff: RepublishBackoff;
 }
@@ -113,11 +113,11 @@ async function dueTimersConsumerLoop(
 					timerPriorityQueue.popDue({
 						// The cutoff must cover every priority digit, so it takes the lowest priority, not the default.
 						maxRank: computeRank({ dueAt: Date.now(), priority: PRIORITY_LEVELS - 1 }),
-						limit: configProvider.config.limit,
+						limit: configProvider.config.pageSize,
 					});
 
 				for await (const dueTimers of streamChunks(next, {
-					until: (chunk) => chunk.length < configProvider.config.limit,
+					until: (page) => page.length < configProvider.config.pageSize,
 				})) {
 					try {
 						await processDueTimers(context, deps, dueTimers);

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.integration.test.ts
@@ -71,7 +71,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -98,7 +98,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 				processImminentChildRunWaitTimedOutRuns(
 					context,
 					{ repos },
-					{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 				)
 			);
 
@@ -134,7 +134,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			expect(
@@ -166,7 +166,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -188,7 +188,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos, publisher },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			expect(
@@ -207,7 +207,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -242,7 +242,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -282,7 +282,12 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 				processImminentChildRunWaitTimedOutRuns(
 					context,
 					{ repos, timerPriorityQueue },
-					{ limit: 100, lookaheadWindowMs: 2 * ONE_HOUR_MS, republishBackoff }
+					{
+						pageSize: 100,
+						lookaheadWindowMs: 2 * ONE_HOUR_MS,
+						republishBackoff,
+						chunk: { size: 100, maxConcurrency: 10 },
+					}
 				)
 			);
 
@@ -332,7 +337,7 @@ describe("processImminentChildRunWaitTimedOutRuns", () => {
 			await processImminentChildRunWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 2, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 2, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			for (const { parentRunId } of parked) {

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -7,6 +7,7 @@ import type { WorkflowRunState, WorkflowRunStateQueued } from "@aikirun/types/wo
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ChildWorkflowRunWaitRowInsert } from "../infra/db/types/child-workflow-run-wait";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
@@ -27,17 +28,17 @@ export interface ProcessImminentChildRunWaitTimedOutRunsDeps {
 export async function processImminentChildRunWaitTimedOutRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentChildRunWaitTimedOutRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listChildRunWaitTimedOutRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueChildRunWaitTimedOutRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueChildRunWaitTimedOutRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -60,9 +61,9 @@ export async function queueChildRunWaitTimedOutRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const stateTransitionIds: string[] = [];
 	const workflowIdSet = new Set<string>();
@@ -79,13 +80,18 @@ export async function queueChildRunWaitTimedOutRuns(
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.integration.test.ts
@@ -36,7 +36,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -63,7 +63,11 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 
 			const timedOutAt = Date.now() as TimestampMs;
 			await withFakeClock(timedOutAt, () =>
-				processImminentEventWaitTimedOutRuns(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff })
+				processImminentEventWaitTimedOutRuns(
+					context,
+					{ repos },
+					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
+				)
 			);
 
 			expect(await repos.eventWait.listByWorkflowRunId(runId)).toEqual([
@@ -109,7 +113,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			expect(
@@ -144,7 +148,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -171,7 +175,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos, publisher },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			expect(
@@ -193,7 +197,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -229,7 +233,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -275,7 +279,12 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 				processImminentEventWaitTimedOutRuns(
 					context,
 					{ repos, timerPriorityQueue },
-					{ limit: 100, lookaheadWindowMs: 2 * ONE_HOUR_MS, republishBackoff }
+					{
+						pageSize: 100,
+						lookaheadWindowMs: 2 * ONE_HOUR_MS,
+						republishBackoff,
+						chunk: { size: 100, maxConcurrency: 10 },
+					}
 				)
 			);
 
@@ -326,7 +335,7 @@ describe("processImminentEventWaitTimedOutRuns", () => {
 			await processImminentEventWaitTimedOutRuns(
 				context,
 				{ repos },
-				{ limit: 2, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 2, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			for (const { runId } of parked) {

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -8,6 +8,7 @@ import type { WorkflowRunId, WorkflowRunState, WorkflowRunStateQueued } from "@a
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { EventWaitRowInsert } from "../infra/db/types/event-wait";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
@@ -28,17 +29,17 @@ export interface ProcessImminentEventWaitTimedOutRunsDeps {
 export async function processImminentEventWaitTimedOutRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentEventWaitTimedOutRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listEventWaitTimedOutRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueEventWaitTimedOutRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueEventWaitTimedOutRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -61,9 +62,9 @@ export async function queueEventWaitTimedOutRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const stateTransitionIds: string[] = [];
 	const workflowIdSet = new Set<string>();
@@ -80,13 +81,18 @@ export async function queueEventWaitTimedOutRuns(
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
@@ -36,7 +36,7 @@ describe("processImminentRecurringRuns", () => {
 				processImminentRecurringRuns(
 					context,
 					{ repos, childRunCanceller: createChildRunCanceller() },
-					{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 				)
 			);
 

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -15,6 +15,7 @@ import {
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ScheduleOccurrenceUpdate } from "../infra/db/types/schedule";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
@@ -50,16 +51,16 @@ const advanceScheduleCursor = createKeysetStreamCursorAdvancer<{ schedule: { id:
 export async function processImminentRecurringRuns(
 	context: DaemonContext,
 	deps: ProcessImminentRecurringRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff } = config;
 	const dueBefore = (Date.now() + (deps.timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const rows of streamChunks(
-		(cursor) => deps.repos.schedule.listDueSchedules(context, dueBefore, limit, cursor),
+		(cursor) => deps.repos.schedule.listDueSchedules(context, dueBefore, pageSize, cursor),
 		{
 			advanceCursor: advanceScheduleCursor,
-			until: (chunk) => chunk.length < limit,
+			until: (page) => page.length < pageSize,
 		}
 	)) {
 		const schedules: DueSchedule[] = rows.map(({ schedule, workflow }) => ({

--- a/sdk/server/src/daemon/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-runs.ts
@@ -7,6 +7,7 @@ import type { WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
@@ -27,17 +28,17 @@ export interface ProcessImminentRetryableRunsDeps {
 export async function processImminentRetryableRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentRetryableRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listRetryableRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listRetryableRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueRetryableRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueRetryableRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -60,21 +61,26 @@ export async function queueRetryableRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
 	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/imminent-scheduled-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.integration.test.ts
@@ -19,7 +19,11 @@ describe("processImminentScheduledRuns", () => {
 			await withFakeClock(now, async () => {
 				const { runId } = await seedScheduledRun({ repos, namespaceRequestContext }, { options: { priority: 2 } });
 
-				await processImminentScheduledRuns(context, { repos }, { limit: 100, lookaheadWindowMs: 0, republishBackoff });
+				await processImminentScheduledRuns(
+					context,
+					{ repos },
+					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				const row = await repos.workflowRunOutbox.getByWorkflowRunId({
 					namespaceId: namespaceRequestContext.namespaceId,

--- a/sdk/server/src/daemon/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.ts
@@ -7,6 +7,7 @@ import type { WorkflowRunState, WorkflowRunStateQueued } from "@aikirun/types/wo
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
@@ -26,17 +27,17 @@ export interface ProcessImminentScheduledRunsDeps {
 export async function processImminentScheduledRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentScheduledRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listDueScheduleRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listDueScheduleRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueScheduledRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueScheduledRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -59,9 +60,9 @@ export async function queueScheduledRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const stateTransitionIds: string[] = [];
 	const workflowIdSet = new Set<string>();
@@ -78,13 +79,18 @@ export async function queueScheduledRuns(
 	const stateTransitionsById = new Map(stateTransitions.map((transition) => [transition.id, transition]));
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, stateTransitionsById, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
@@ -6,6 +6,7 @@ import type { WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
@@ -25,17 +26,17 @@ export interface ProcessImminentSleepElapsedRunsDeps {
 export async function processImminentSleepElapsedRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentSleepElapsedRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listSleepElapsedRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listSleepElapsedRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueSleepElapsedRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueSleepElapsedRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -58,21 +59,26 @@ export async function queueSleepElapsedRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
 	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/imminent-task-retryable-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-task-retryable-runs.integration.test.ts
@@ -28,7 +28,7 @@ describe("processImminentTaskRetryableRuns", () => {
 			await processImminentTaskRetryableRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({
@@ -68,7 +68,7 @@ describe("processImminentTaskRetryableRuns", () => {
 				processImminentTaskRetryableRuns(
 					context,
 					{ repos, timerPriorityQueue },
-					{ limit: 100, lookaheadWindowMs: 60_000, republishBackoff }
+					{ pageSize: 100, lookaheadWindowMs: 60_000, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 				)
 			);
 
@@ -95,7 +95,7 @@ describe("processImminentTaskRetryableRuns", () => {
 			await processImminentTaskRetryableRuns(
 				context,
 				{ repos },
-				{ limit: 100, lookaheadWindowMs: 0, republishBackoff }
+				{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			const run = await repos.workflowRun.getByIdWithState({

--- a/sdk/server/src/daemon/imminent-task-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-task-retryable-runs.ts
@@ -7,6 +7,7 @@ import type { WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
@@ -26,17 +27,17 @@ export interface ProcessImminentTaskRetryableRunsDeps {
 export async function processImminentTaskRetryableRuns(
 	context: DaemonContext,
 	{ repos, publisher, timerPriorityQueue }: ProcessImminentTaskRetryableRunsDeps,
-	config: { limit: number; lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
 ) {
-	const { limit, lookaheadWindowMs, republishBackoff } = config;
+	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const { dueNow: runsDueNow, dueSoon: runsDueSoon } of streamTimers(
-		(cursor) => repos.workflowRun.listTaskRetryableRuns(context, dueBefore, limit, cursor),
-		{ until: (chunk) => chunk.length < limit }
+		(cursor) => repos.workflowRun.listTaskRetryableRuns(context, dueBefore, pageSize, cursor),
+		{ until: (page) => page.length < pageSize }
 	)) {
 		if (isNonEmptyArray(runsDueNow)) {
-			await queueTaskRetryableRuns(context, repos, publisher, republishBackoff, runsDueNow);
+			await queueTaskRetryableRuns(context, repos, publisher, republishBackoff, runsDueNow, { chunk });
 		}
 
 		if (timerPriorityQueue && isNonEmptyArray(runsDueSoon)) {
@@ -59,21 +60,26 @@ export async function queueTaskRetryableRuns(
 	publisher: Publisher | undefined,
 	republishBackoff: RepublishBackoff,
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
-	options?: { chunkSize?: number }
+	options?: { chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { chunkSize = runs.length } = options ?? {};
+	const { size: chunkSize = runs.length, maxConcurrency } = options?.chunk ?? {};
 
 	const workflowIds = Array.from(new Set(runs.map((run) => run.workflowId))) as NonEmptyArray<string>;
 	const workflows = await repos.workflow.getByIds(context, workflowIds);
 	const workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]));
 
-	await runConcurrently(context, chunkLazy(runs, chunkSize), async (chunk, spanCtx) => {
-		try {
-			await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
-		} catch (err) {
-			spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
-		}
-	});
+	await runConcurrently(
+		context,
+		chunkLazy(runs, chunkSize),
+		async (chunk, spanCtx) => {
+			try {
+				await processChunk(spanCtx, repos, publisher, republishBackoff, chunk, workflowsById);
+			} catch (err) {
+				spanCtx.logger.warn("Failed to process chunk, will retry next tick", { err, "aiki.chunkSize": chunk.length });
+			}
+		},
+		maxConcurrency ? { concurrency: maxConcurrency } : undefined
+	);
 }
 
 async function processChunk(

--- a/sdk/server/src/daemon/publish-pending-outbox-entries.integration.test.ts
+++ b/sdk/server/src/daemon/publish-pending-outbox-entries.integration.test.ts
@@ -66,7 +66,7 @@ describe("publishPendingOutboxEntries", () => {
 						published: { runs: request.map((run) => ({ run })) },
 					}));
 
-				await publishPendingOutboxEntries(context, { repos, publisher }, configBuilder.with("limit", 2).build());
+				await publishPendingOutboxEntries(context, { repos, publisher }, configBuilder.with("pageSize", 2).build());
 
 				const pendingRows = await repos.workflowRunOutbox.listPending(context, 100);
 				expect(pendingRows).toEqual([]);

--- a/sdk/server/src/daemon/publish-pending-outbox-entries.ts
+++ b/sdk/server/src/daemon/publish-pending-outbox-entries.ts
@@ -1,13 +1,15 @@
 import { streamChunks } from "@aikirun/lib/async";
-import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { Equal, ExpectTrue } from "@aikirun/lib/testing/expect";
 import type { Publisher, PublishRunsResult, ReadyWorkflowRun } from "@aikirun/types/infra/queue";
 
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories } from "../infra/db/types";
 import type {
 	WorkflowRunOutboxRowInsertPending,
 	WorkflowRunOutboxRowPending,
 } from "../infra/db/types/workflow-run-outbox";
+import { runConcurrently } from "../lib/concurrency";
 import { computeRank, extractRankPriority } from "../lib/rank";
 import type { DaemonContext } from "../middleware/context";
 
@@ -22,11 +24,10 @@ export interface RepublishBackoff {
 	declinedBackoffMs: number;
 }
 
-export interface PublishPendingOutboxEntriesConfig {
-	limit: number;
+export type PublishPendingOutboxEntriesConfig = PageProcessingConfig & {
 	leaseDurationMs: number;
 	republishBackoff: RepublishBackoff;
-}
+};
 
 const PUBLISH_OUTCOMES = ["published", "deferred", "failed", "declined"] as const;
 declare const _publishOutcomeTypeTest: [ExpectTrue<Equal<(typeof PUBLISH_OUTCOMES)[number], keyof PublishRunsResult>>];
@@ -34,13 +35,20 @@ declare const _publishOutcomeTypeTest: [ExpectTrue<Equal<(typeof PUBLISH_OUTCOME
 export async function publishPendingOutboxEntries(
 	context: DaemonContext,
 	{ repos, publisher }: PublishPendingOutboxEntriesDeps,
-	{ limit, leaseDurationMs, republishBackoff }: PublishPendingOutboxEntriesConfig
+	{ pageSize, chunk, leaseDurationMs, republishBackoff }: PublishPendingOutboxEntriesConfig
 ) {
 	for await (const pendingEntries of streamChunks(
-		() => repos.workflowRunOutbox.leaseDuePending(context, { leaseDurationMs, limit }),
-		{ until: (chunk) => chunk.length < limit }
+		() => repos.workflowRunOutbox.leaseDuePending(context, { leaseDurationMs, limit: pageSize }),
+		{ until: (page) => page.length < pageSize }
 	)) {
-		await publishOutboxEntries(context, repos, publisher, pendingEntries, republishBackoff);
+		await runConcurrently(
+			context,
+			chunkLazy(pendingEntries, chunk.size),
+			async (entriesChunk, spanCtx) => {
+				await publishOutboxEntries(spanCtx, repos, publisher, entriesChunk, republishBackoff);
+			},
+			{ concurrency: chunk.maxConcurrency }
+		);
 	}
 }
 

--- a/sdk/server/src/daemon/recover-overdue-outbox-entries.integration.test.ts
+++ b/sdk/server/src/daemon/recover-overdue-outbox-entries.integration.test.ts
@@ -45,7 +45,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				const pendingRows = await repos.workflowRunOutbox.listPending(context, 100);
@@ -80,7 +80,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
@@ -101,7 +101,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				const run = await repos.workflowRun.getByIdWithState({
@@ -132,7 +132,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				const run = await repos.workflowRun.getByIdWithState({
@@ -156,7 +156,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				const run = await repos.workflowRun.getByIdWithState({
@@ -178,7 +178,11 @@ describe("recoverOverdueOutboxEntries", () => {
 					repos: deps.repos,
 				});
 
-				await recoverOverdueOutboxEntries(context, { repos }, { claimIdleTimeoutMs: ONE_HOUR_MS, limit: 100 });
+				await recoverOverdueOutboxEntries(
+					context,
+					{ repos },
+					{ claimIdleTimeoutMs: ONE_HOUR_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				expect(await repos.workflowRunOutbox.listPending(context, 100)).toHaveLength(0);
 				expect(
@@ -209,7 +213,11 @@ describe("recoverOverdueOutboxEntries", () => {
 				const outboxService = createWorkflowRunOutboxService({ repos });
 				await outboxService.refreshClaim(namespaceRequestContext, runId);
 
-				await recoverOverdueOutboxEntries(context, { repos }, { claimIdleTimeoutMs: ONE_HOUR_MS, limit: 100 });
+				await recoverOverdueOutboxEntries(
+					context,
+					{ repos },
+					{ claimIdleTimeoutMs: ONE_HOUR_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				expect(await repos.workflowRunOutbox.listPending(context, 100)).toHaveLength(0);
 				expect(
@@ -244,7 +252,7 @@ describe("recoverOverdueOutboxEntries", () => {
 				await recoverOverdueOutboxEntries(
 					context,
 					{ repos },
-					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+					{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 				);
 
 				const pendingRows = await repos.workflowRunOutbox.listPending(context, 100);
@@ -267,7 +275,11 @@ describe("recoverOverdueOutboxEntries", () => {
 					seedQueuedRun({ daemonContext: deps.context, namespaceRequestContext, repos: deps.repos })
 				);
 
-				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
+				await stallUndeliverableRuns(
+					context,
+					{ repos },
+					{ maxAgeMs: 60_000, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				const run = await repos.workflowRun.getByIdWithState({
 					namespaceId: namespaceRequestContext.namespaceId,
@@ -296,7 +308,11 @@ describe("recoverOverdueOutboxEntries", () => {
 					})
 				);
 
-				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
+				await stallUndeliverableRuns(
+					context,
+					{ repos },
+					{ maxAgeMs: 60_000, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				const run = await repos.workflowRun.getByIdWithState({
 					namespaceId: namespaceRequestContext.namespaceId,
@@ -326,7 +342,11 @@ describe("recoverOverdueOutboxEntries", () => {
 				);
 				await claimRun({ context: namespaceRequestContext, repos, runId });
 
-				await stallUndeliverableRuns(context, { repos }, { maxAgeMs: 60_000, limit: 100 });
+				await stallUndeliverableRuns(
+					context,
+					{ repos },
+					{ maxAgeMs: 60_000, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+				);
 
 				const run = await repos.workflowRun.getByIdWithState({
 					namespaceId: namespaceRequestContext.namespaceId,

--- a/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
+++ b/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
@@ -1,12 +1,14 @@
 import { streamChunks } from "@aikirun/lib/async";
-import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStateQueued } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import { runConcurrently } from "../lib/concurrency";
 import { createKeysetStreamCursorAdvancer } from "../lib/keyset-stream";
 import type { DaemonContext } from "../middleware/context";
 
@@ -30,44 +32,60 @@ const advancePublishedCursor = createKeysetStreamCursorAdvancer<{
 export async function recoverOverdueOutboxEntries(
 	context: DaemonContext,
 	{ repos }: RecoverOverdueOutboxEntriesDeps,
-	{ claimIdleTimeoutMs, limit }: { claimIdleTimeoutMs: number; limit: number }
+	config: PageProcessingConfig & { claimIdleTimeoutMs: number }
 ): Promise<void> {
+	const { claimIdleTimeoutMs, pageSize, chunk } = config;
+
 	for await (const staleEntries of streamChunks(
-		(cursor) => repos.workflowRunOutbox.listStaleClaimed(context, { claimIdleTimeoutMs, limit, cursor }),
+		(cursor) => repos.workflowRunOutbox.listStaleClaimed(context, { claimIdleTimeoutMs, limit: pageSize, cursor }),
 		{
 			advanceCursor: advanceClaimedCursor,
-			until: (chunk) => chunk.length < limit,
+			until: (page) => page.length < pageSize,
 		}
 	)) {
-		const entryIds: string[] = [];
-		const runIds: string[] = [];
-		for (const { id, workflowRunId } of staleEntries) {
-			entryIds.push(id);
-			runIds.push(workflowRunId);
-		}
+		await runConcurrently(
+			context,
+			chunkLazy(staleEntries, chunk.size),
+			async (entriesChunk, spanCtx) => {
+				const entryIds: string[] = [];
+				const runIds: string[] = [];
+				for (const { id, workflowRunId } of entriesChunk) {
+					entryIds.push(id);
+					runIds.push(workflowRunId);
+				}
 
-		if (!isNonEmptyArray(entryIds) || !isNonEmptyArray(runIds)) {
-			continue;
-		}
+				if (!isNonEmptyArray(entryIds) || !isNonEmptyArray(runIds)) {
+					return;
+				}
 
-		await repos.transaction(async (txRepos) => releaseStaleClaimsInTx(context, { entryIds, runIds }, txRepos));
-		context.logger.debug("Recovered stale claimed outbox entries", { "aiki.count": staleEntries.length });
+				await repos.transaction(async (txRepos) => releaseStaleClaimsInTx(spanCtx, { entryIds, runIds }, txRepos));
+				spanCtx.logger.debug("Recovered stale claimed outbox entries", { "aiki.count": entriesChunk.length });
+			},
+			{ concurrency: chunk.maxConcurrency }
+		);
 	}
 
 	for await (const publishableEntries of streamChunks(
-		(cursor) => repos.workflowRunOutbox.listPublishable(context, limit, cursor),
+		(cursor) => repos.workflowRunOutbox.listPublishable(context, pageSize, cursor),
 		{
 			advanceCursor: advancePublishedCursor,
-			until: (chunk) => chunk.length < limit,
+			until: (page) => page.length < pageSize,
 		}
 	)) {
-		const entryIds = publishableEntries.map((entry) => entry.id);
-		if (!isNonEmptyArray(entryIds)) {
-			continue;
-		}
+		await runConcurrently(
+			context,
+			chunkLazy(publishableEntries, chunk.size),
+			async (entriesChunk, spanCtx) => {
+				const entryIds = entriesChunk.map((entry) => entry.id);
+				if (!isNonEmptyArray(entryIds)) {
+					return;
+				}
 
-		await repos.workflowRunOutbox.returnToPending(entryIds, "published");
-		context.logger.debug("Recovered publishable outbox entries", { "aiki.count": publishableEntries.length });
+				await repos.workflowRunOutbox.returnToPending(entryIds, "published");
+				spanCtx.logger.debug("Recovered publishable outbox entries", { "aiki.count": entriesChunk.length });
+			},
+			{ concurrency: chunk.maxConcurrency }
+		);
 	}
 }
 

--- a/sdk/server/src/daemon/stall-undeliverable-runs.ts
+++ b/sdk/server/src/daemon/stall-undeliverable-runs.ts
@@ -1,11 +1,13 @@
 import { streamChunks } from "@aikirun/lib/async";
-import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
+import { chunkLazy, isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { WorkflowRunStateStalled } from "@aikirun/types/workflow/run";
 import { ulid } from "ulidx";
 
+import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import { runConcurrently } from "../lib/concurrency";
 import { ulidUpperBound } from "../lib/ulid";
 import type { DaemonContext } from "../middleware/context";
 import { discardStaleTasks } from "../service/discard-stale-tasks";
@@ -19,22 +21,30 @@ const advanceStreamCursor = (_cursor: string | undefined, item: { id: string }) 
 export async function stallUndeliverableRuns(
 	context: DaemonContext,
 	{ repos }: StallUndeliverableRunsDeps,
-	{ limit, maxAgeMs }: { limit: number; maxAgeMs: number }
+	config: PageProcessingConfig & { maxAgeMs: number }
 ): Promise<void> {
+	const { pageSize, chunk, maxAgeMs } = config;
 	const maxId = ulidUpperBound(Date.now() - maxAgeMs);
 
 	for await (const undeliverableEntries of streamChunks(
-		(cursorId) => repos.workflowRunOutbox.listUndeliverable(context, { maxId, limit, cursorId }),
+		(cursorId) => repos.workflowRunOutbox.listUndeliverable(context, { maxId, limit: pageSize, cursorId }),
 		{
 			advanceCursor: advanceStreamCursor,
-			until: (chunk) => chunk.length < limit,
+			until: (page) => page.length < pageSize,
 		}
 	)) {
-		const undeliverableRunIds = undeliverableEntries.map((entry) => entry.workflowRunId) as NonEmptyArray<string>;
-		const stalledRunIds = await repos.transaction(async (txRepos) =>
-			stallByRunIdsInTx(context, undeliverableRunIds, txRepos)
+		await runConcurrently(
+			context,
+			chunkLazy(undeliverableEntries, chunk.size),
+			async (entriesChunk, spanCtx) => {
+				const undeliverableRunIds = entriesChunk.map((entry) => entry.workflowRunId) as NonEmptyArray<string>;
+				const stalledRunIds = await repos.transaction(async (txRepos) =>
+					stallByRunIdsInTx(spanCtx, undeliverableRunIds, txRepos)
+				);
+				spanCtx.logger.info("Stalled undeliverable runs", { "aiki.count": stalledRunIds.length });
+			},
+			{ concurrency: chunk.maxConcurrency }
 		);
-		context.logger.info("Stalled undeliverable runs", { "aiki.count": stalledRunIds.length });
 	}
 }
 

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -518,9 +518,10 @@ describe("WorkflowRunStateMachine sleep lifecycle", () => {
 					daemonContext,
 					{ repos },
 					{
-						limit: 100,
+						pageSize: 100,
 						lookaheadWindowMs: 0,
 						republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+						chunk: { size: 100, maxConcurrency: 10 },
 					}
 				)
 			);
@@ -633,9 +634,10 @@ describe("WorkflowRunStateMachine redelivery", () => {
 				daemonContext,
 				{ repos },
 				{
-					limit: 100,
+					pageSize: 100,
 					lookaheadWindowMs: 0,
 					republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+					chunk: { size: 100, maxConcurrency: 10 },
 				}
 			);
 

--- a/sdk/server/src/service/workflow-run-outbox.integration.test.ts
+++ b/sdk/server/src/service/workflow-run-outbox.integration.test.ts
@@ -203,7 +203,7 @@ describe("claimReady visibility after recovery", () => {
 			await recoverOverdueOutboxEntries(
 				daemonContext,
 				{ repos },
-				{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, limit: 100 }
+				{ claimIdleTimeoutMs: EVERY_CLAIM_IS_STALE_MS, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
 			);
 
 			// Both runs are now visible to claimReady.

--- a/sdk/server/src/testing/seed/run.ts
+++ b/sdk/server/src/testing/seed/run.ts
@@ -85,7 +85,12 @@ export async function seedQueuedRun(deps: SeedRunDeps, overrides?: SeedRunOverri
 	await processImminentScheduledRuns(
 		daemonContext,
 		{ repos },
-		{ limit: 100, lookaheadWindowMs: 0, republishBackoff: publishPendingOutboxEntriesDaemonConfig.republishBackoff }
+		{
+			pageSize: 100,
+			lookaheadWindowMs: 0,
+			republishBackoff: publishPendingOutboxEntriesDaemonConfig.republishBackoff,
+			chunk: { size: 100, maxConcurrency: 10 },
+		}
 	);
 
 	const outboxRow = await repos.workflowRunOutbox.getByWorkflowRunId({
@@ -237,7 +242,11 @@ export async function seedStalledRun(deps: SeedRunDeps, overrides?: SeedRunOverr
 	const daemonContext = deps.daemonContext ?? daemonContextFactory.build();
 	const seeded = await withFakeClock(1 as TimestampMs, () => seedQueuedRun(deps, overrides));
 
-	await stallUndeliverableRuns(daemonContext, { repos: deps.repos }, { maxAgeMs: 60_000, limit: 100 });
+	await stallUndeliverableRuns(
+		daemonContext,
+		{ repos: deps.repos },
+		{ maxAgeMs: 60_000, pageSize: 100, chunk: { size: 100, maxConcurrency: 10 } }
+	);
 
 	return {
 		runId: seeded.runId,


### PR DESCRIPTION
- Rename limit → pageSize across all daemons. 
- Extract a `PageProcessingConfig` base type (pageSize + chunk) that `PollingDaemonConfig` extends, so every polling daemon inherits the same page/chunk vocabulary. 
- Wire `chunkLazy + runConcurrently` into the three non-imminent daemons (`publishPendingOutboxEntries`, `recoverOverdueOutboxEntries`, `stallUndeliverableRuns`) that previously processed pages as single batches.
- Reshape queue* function options from flat `{ chunkSize, maxConcurrency }` to nested `{ chunk: { size, maxConcurrency } }` so callers pass the config object through directly.

## Breaking changes

`limit` is renamed to `pageSize` in all daemon config types. Runtime config overrides that set `daemons.*.limit` need to change to `daemons.*.pageSize`. The three non-imminent daemon configs now require a `chunk` field.