### PR TITLE
Lock rows in id order in bulk transitions so concurrent updaters cannot deadlock

### DIFF
--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -74,7 +74,9 @@ export const createScheduleRepository = (db: PgDb) => ({
 	},
 
 	async bulkUpdateOccurrence(entries: NonEmptyArray<ScheduleOccurrenceUpdate>): Promise<void> {
-		const valueRows = entries.map(({ filter, update }, index) => {
+		// Locked in id order so concurrent bulk promoters acquire the same rows the same way.
+		const sortedEntries = [...entries].sort((a, b) => (a.filter.id < b.filter.id ? -1 : 1));
+		const valueRows = sortedEntries.map(({ filter, update }, index) => {
 			const expectedNextRunAtIso = new Date(filter.nextRunAt).toISOString();
 			const lastOccurrenceIso = update.lastOccurrence ? new Date(update.lastOccurrence).toISOString() : null;
 			const nextRunAtIso = new Date(update.nextRunAt).toISOString();

--- a/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run-outbox.ts
@@ -92,7 +92,9 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 	async markPublished(entries: NonEmptyArray<{ id: string; nextPublishAttemptRank: number }>): Promise<void> {
 		const now = Date.now() as TimestampMs;
 
-		const valueRows = entries.map((entry, index) => {
+		// Locked in id order so concurrent bulk publishers acquire the same rows the same way.
+		const sortedEntries = [...entries].sort((a, b) => (a.id < b.id ? -1 : 1));
+		const valueRows = sortedEntries.map((entry, index) => {
 			if (index === 0) {
 				return sql`(${entry.id}::text, ${entry.nextPublishAttemptRank}::float8)`;
 			}
@@ -114,7 +116,9 @@ export const createWorkflowRunOutboxRepository = (db: PgDb) => ({
 	async setNextPublishAttemptRank(
 		entries: NonEmptyArray<{ id: string; nextPublishAttemptRank: number }>
 	): Promise<void> {
-		const valueRows = entries.map((entry, index) => {
+		// Locked in id order so concurrent bulk publishers acquire the same rows the same way.
+		const sortedEntries = [...entries].sort((a, b) => (a.id < b.id ? -1 : 1));
+		const valueRows = sortedEntries.map((entry, index) => {
 			if (index === 0) {
 				return sql`(${entry.id}::text, ${entry.nextPublishAttemptRank}::float8)`;
 			}

--- a/sdk/server/src/infra/db/pg/repository/workflow-run.ts
+++ b/sdk/server/src/infra/db/pg/repository/workflow-run.ts
@@ -775,7 +775,9 @@ export const createWorkflowRunRepository = (db: PgDb) => ({
 		runs: NonEmptyArray<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }>,
 		options?: { incrementAttempts?: boolean }
 	): Promise<string[]> {
-		const valueRows = runs.map(({ filter, update }, index) => {
+		// Locked in id order so concurrent bulk promoters acquire the same rows the same way.
+		const sortedRuns = [...runs].sort((a, b) => (a.filter.id < b.filter.id ? -1 : 1));
+		const valueRows = sortedRuns.map(({ filter, update }, index) => {
 			if (index === 0) {
 				return sql`(${filter.id}::text, ${filter.revision}::integer, ${update.stateTransitionId}::text)`;
 			}


### PR DESCRIPTION
`bulkTransitionToQueued`, `bulkUpdateOccurrence`, `markPublished` and `setNextPublishAttemptRank` each update many rows through one VALUES join. 
Two writers can reach the same rows at once: the polling daemon and the due-timers consumer both promote scheduled runs and fire schedules, and the inline publish after promotion can overlap the outbox daemon on an entry it just leased. When two such statements take overlapping rows in different orders, Postgres aborts one with a deadlock. Sorting the VALUES rows by id gives every writer the same order, so the loser waits instead. The revision and status guards already make that wait harmless.