### PR TITLE
Announce candidate for hasher rotation

### DIFF
--- a/sdk/server/src/contract/schema/hash.ts
+++ b/sdk/server/src/contract/schema/hash.ts
@@ -3,4 +3,5 @@ import { type } from "arktype";
 export const inputHashSchema = type({
 	value: "string > 0",
 	"deprecatedValues?": type("string > 0").array().or("undefined"),
+	"nextValue?": "string > 0 | undefined",
 });

--- a/sdk/server/src/lib/hash.test.ts
+++ b/sdk/server/src/lib/hash.test.ts
@@ -1,0 +1,25 @@
+import { candidateHashes } from "./hash";
+import { describe, expect, test } from "bun:test";
+
+describe("candidateHashes", () => {
+	test("is the current value alone when the hash carries no others", () => {
+		expect(candidateHashes({ value: "h2" })).toEqual(["h2"]);
+	});
+
+	test("lists the deprecated values", () => {
+		expect(candidateHashes({ value: "h2", deprecatedValues: ["h0", "h1"] })).toEqual(["h2", "h0", "h1"]);
+	});
+
+	test("lists the deprecated values and the next value after the current one", () => {
+		expect(candidateHashes({ value: "h2", deprecatedValues: ["h0", "h1"], nextValue: "h3" })).toEqual([
+			"h2",
+			"h0",
+			"h1",
+			"h3",
+		]);
+	});
+
+	test("drops a value that appears more than once", () => {
+		expect(candidateHashes({ value: "h2", deprecatedValues: ["h2"], nextValue: "h2" })).toEqual(["h2"]);
+	});
+});

--- a/sdk/server/src/lib/hash.ts
+++ b/sdk/server/src/lib/hash.ts
@@ -1,0 +1,10 @@
+import type { Hash } from "@aikirun/types/infra/hasher";
+
+/** Every value a stored hash may equal to count as `hash`: the current, the deprecated, and the next. */
+export function candidateHashes(hash: Hash): string[] {
+	const candidates = [hash.value].concat(hash.deprecatedValues ?? []);
+	if (hash.nextValue !== undefined) {
+		candidates.push(hash.nextValue);
+	}
+	return Array.from(new Set(candidates));
+}

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -354,3 +354,104 @@ describe("ScheduleService activateSchedule recording the client codec", () => {
 			);
 		}));
 });
+
+describe("ScheduleService activateSchedule under an announced key", () => {
+	const spec = { type: "interval" as const, everyMs: 60_000 };
+	const workflowRunInput = { region: "eu-west" };
+	// Written under the announced key by a client one rotation ahead.
+	const announcedHash = "announced-hash";
+	const aheadInput = asOpaquePayload({ encoded: "eu-west", key: "2025" });
+	const behindInput = asOpaquePayload({ encoded: "eu-west", key: "2024" });
+
+	test("matches a schedule stored under the announced hash and leaves its payload alone", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: aheadInput,
+				workflowRunInputHash: { value: announcedHash },
+				clientCodecApplied: true,
+				spec,
+			});
+			const stored = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+
+			const { schedule: matched } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: behindInput,
+				workflowRunInputHash: { value: await hashInput(workflowRunInput), nextValue: announcedHash },
+				clientCodecApplied: true,
+				spec,
+			});
+
+			expect(matched.id).toBe(schedule.id);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(stored);
+		}));
+
+	test("recognises a referenced schedule stored under the announced hash and leaves its payload alone", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const options = { reference: { id: "invoices-eu-west" } };
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: aheadInput,
+				workflowRunInputHash: { value: announcedHash },
+				clientCodecApplied: true,
+				spec,
+				options,
+			});
+			const stored = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+
+			const { schedule: matched } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: behindInput,
+				workflowRunInputHash: { value: await hashInput(workflowRunInput), nextValue: announcedHash },
+				clientCodecApplied: true,
+				spec,
+				options,
+			});
+
+			expect(matched.id).toBe(schedule.id);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(stored);
+		}));
+
+	test("adopting a reference id onto a schedule stored under the announced hash leaves its payload alone", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+
+			const { schedule: unreferenced } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: aheadInput,
+				workflowRunInputHash: { value: announcedHash },
+				clientCodecApplied: true,
+				spec,
+			});
+
+			const { schedule: referenced } = await scheduleService.activateSchedule(context.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: behindInput,
+				workflowRunInputHash: { value: await hashInput(workflowRunInput), nextValue: announcedHash },
+				clientCodecApplied: true,
+				spec,
+				options: { reference: { id: "invoices-eu-west" } },
+			});
+
+			expect(referenced.id).toBe(unreferenced.id);
+			expect(await repos.schedule.get(context.namespaceId, { id: unreferenced.id })).toEqual(
+				expect.objectContaining({
+					id: unreferenced.id,
+					referenceId: "invoices-eu-west",
+					workflowRunInput: aheadInput,
+					workflowRunInputHash: announcedHash,
+					clientCodecApplied: true,
+				})
+			);
+		}));
+});

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -3,6 +3,7 @@ import { hashInput } from "@aikirun/lib/crypto";
 import { NotFoundError } from "@aikirun/lib/error";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
 import type { ScheduleActivateRequestV1, ScheduleListRequestV1 } from "@aikirun/types/api/schedule";
+import type { Hash } from "@aikirun/types/infra/hasher";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { OpaquePayload } from "@aikirun/types/payload";
 import type { Schedule, ScheduleSpec, ScheduleStatus } from "@aikirun/types/schedule";
@@ -15,6 +16,7 @@ import { getOrCreateWorkflowInTx } from "./workflow";
 import { ScheduleConflictError } from "../errors";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ScheduleRow } from "../infra/db/types/schedule";
+import { candidateHashes } from "../lib/hash";
 
 export function getReferenceId(scheduleId: string, occurrence: number) {
 	return `schedule:${scheduleId}:${occurrence}`;
@@ -145,8 +147,8 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 		namespaceId: NamespaceId,
 		request: ScheduleActivateRequestV1
 	): Promise<{ schedule: Schedule }> {
-		const definition = await hashScheduleDefinitions(request);
-		return repos.transaction(async (txRepos) => activateScheduleInTx(namespaceId, request, definition, txRepos));
+		const definitionHashes = await hashScheduleDefinitions(request);
+		return repos.transaction(async (txRepos) => activateScheduleInTx(namespaceId, request, definitionHashes, txRepos));
 	},
 
 	async getScheduleById(namespaceId: NamespaceId, id: string) {
@@ -233,10 +235,8 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 
 export type ScheduleService = ReturnType<typeof createScheduleService>;
 
-async function hashScheduleDefinitions(request: ScheduleActivateRequestV1): Promise<{
-	currentHash: string;
-	candidateHashes: string[];
-}> {
+/** The definition hash under each rotation the request's input hash carries. */
+async function hashScheduleDefinitions(request: ScheduleActivateRequestV1): Promise<Hash> {
 	const { workflowName, workflowVersionId, workflowRunInputHash, workflowRunOptions, spec } = request;
 	const hashDefinition = (inputHash: string) =>
 		// insecure hashing is safe here as workflowRunInputHash already has keyed hashing
@@ -248,12 +248,13 @@ async function hashScheduleDefinitions(request: ScheduleActivateRequestV1): Prom
 			workflowRunOptions,
 		});
 
-	const [currentHash, ...deprecatedHashes] = await Promise.all([
+	const [currentHash, deprecatedHashes, nextHash] = await Promise.all([
 		hashDefinition(workflowRunInputHash.value),
-		...(workflowRunInputHash.deprecatedValues ?? []).map(hashDefinition),
+		Promise.all((workflowRunInputHash.deprecatedValues ?? []).map(hashDefinition)),
+		workflowRunInputHash.nextValue === undefined ? undefined : hashDefinition(workflowRunInputHash.nextValue),
 	]);
 
-	return { currentHash, candidateHashes: Array.from(new Set([currentHash].concat(deprecatedHashes))) };
+	return { value: currentHash, deprecatedValues: deprecatedHashes, nextValue: nextHash };
 }
 
 interface SchedulePayload {
@@ -266,10 +267,11 @@ interface SchedulePayload {
 async function activateScheduleInTx(
 	namespaceId: NamespaceId,
 	request: ScheduleActivateRequestV1,
-	definition: { currentHash: string; candidateHashes: string[] },
+	definitionHashes: Hash,
 	txRepos: TxRepositories
 ) {
 	const { workflowName, workflowVersionId, workflowRunOptions, spec, options } = request;
+	const currentDefinitionHash = definitionHashes.value;
 	// The activating client computed these together, with its own codec and keys, so they are
 	// always stored together: a row mixing one client's input with another's hash or declaration
 	// would mint runs whose input does not decode.
@@ -277,7 +279,7 @@ async function activateScheduleInTx(
 		workflowRunInput: request.workflowRunInput ?? null,
 		workflowRunInputHash: request.workflowRunInputHash.value,
 		clientCodecApplied: request.clientCodecApplied,
-		definitionHash: definition.currentHash,
+		definitionHash: currentDefinitionHash,
 	};
 
 	const referenceId = options?.reference?.id;
@@ -299,7 +301,7 @@ async function activateScheduleInTx(
 
 	if (!referenceId) {
 		const existingScheduleByDefinition = await txRepos.schedule.get(namespaceId, {
-			definitionHashes: definition.candidateHashes,
+			definitionHashes: candidateHashes(definitionHashes),
 		});
 
 		const schedule = existingScheduleByDefinition
@@ -307,6 +309,7 @@ async function activateScheduleInTx(
 					namespaceId,
 					existing: existingScheduleByDefinition,
 					payload,
+					nextDefinitionHash: definitionHashes.nextValue,
 					nextRunAt,
 				})
 			: await createSchedule(txRepos.schedule, {
@@ -324,9 +327,9 @@ async function activateScheduleInTx(
 
 	const existingScheduleByReference = await txRepos.schedule.get(namespaceId, { referenceId });
 	if (existingScheduleByReference) {
-		if (!definition.candidateHashes.includes(existingScheduleByReference.definitionHash)) {
+		if (!candidateHashes(definitionHashes).includes(existingScheduleByReference.definitionHash)) {
 			if (conflictPolicy === "error") {
-				throw new ScheduleConflictError({ definitionHash: payload.definitionHash, referenceId });
+				throw new ScheduleConflictError({ definitionHash: currentDefinitionHash, referenceId });
 			}
 			conflictPolicy satisfies "return_existing";
 			return { schedule: scheduleRowToDomain(existingScheduleByReference, workflowInfo) };
@@ -336,6 +339,7 @@ async function activateScheduleInTx(
 			namespaceId,
 			existing: existingScheduleByReference,
 			payload,
+			nextDefinitionHash: definitionHashes.nextValue,
 			nextRunAt,
 		});
 
@@ -344,23 +348,29 @@ async function activateScheduleInTx(
 
 	// Reference id is free, but the definition may already exist.
 	const existingNonReferencedSchedule = await txRepos.schedule.get(namespaceId, {
-		definitionHashes: definition.candidateHashes,
+		definitionHashes: candidateHashes(definitionHashes),
 		referenceId: null,
 	});
 
 	if (existingNonReferencedSchedule) {
+		const updates: Partial<SchedulePayload> & { referenceId: string; status: "active"; nextRunAt: TimestampMs } = {
+			referenceId,
+			status: "active",
+			nextRunAt,
+		};
+		// Matching the request's next hash means the stored schedule was written by a client that
+		// has already switched to the rotation this request has only been told about. The stored
+		// payload is the newer one, so it stays.
+		if (existingNonReferencedSchedule.definitionHash !== definitionHashes.nextValue) {
+			updates.workflowRunInput = payload.workflowRunInput;
+			updates.workflowRunInputHash = payload.workflowRunInputHash;
+			updates.clientCodecApplied = payload.clientCodecApplied;
+			updates.definitionHash = payload.definitionHash;
+		}
 		const schedule = await txRepos.schedule.update(
 			namespaceId,
 			{ id: existingNonReferencedSchedule.id, referenceId: null },
-			{
-				referenceId,
-				status: "active",
-				nextRunAt,
-				workflowRunInput: payload.workflowRunInput,
-				workflowRunInputHash: payload.workflowRunInputHash,
-				clientCodecApplied: payload.clientCodecApplied,
-				definitionHash: payload.definitionHash,
-			}
+			updates
 		);
 
 		if (schedule) {
@@ -387,17 +397,22 @@ async function reuseSchedule(
 		namespaceId: NamespaceId;
 		existing: ScheduleRow;
 		payload: SchedulePayload;
+		nextDefinitionHash: string | undefined;
 		nextRunAt: TimestampMs;
 	}
 ): Promise<ScheduleRow> {
 	const { existing, payload } = params;
 	const needsActivation = existing.status !== "active";
-	// The stored input itself is not compared: a codec may encode the same input differently
-	// each time, and an unchanged hash and declaration mean the stored value still decodes.
+	// Matching the request's next hash means the stored schedule was written by a client that has
+	// already switched to the rotation this request has only been told about. The stored payload
+	// is the newer one, so it stays. The stored input itself is never compared: a codec may encode
+	// the same input differently each time, and an unchanged hash and declaration mean the stored
+	// value still decodes.
 	const payloadChanged =
-		existing.workflowRunInputHash !== payload.workflowRunInputHash ||
-		existing.definitionHash !== payload.definitionHash ||
-		existing.clientCodecApplied !== payload.clientCodecApplied;
+		existing.definitionHash !== params.nextDefinitionHash &&
+		(existing.workflowRunInputHash !== payload.workflowRunInputHash ||
+			existing.definitionHash !== payload.definitionHash ||
+			existing.clientCodecApplied !== payload.clientCodecApplied);
 
 	if (!needsActivation && !payloadChanged) {
 		return existing;

--- a/sdk/server/src/service/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/workflow-run.integration.test.ts
@@ -719,6 +719,36 @@ describe("WorkflowRunService createWorkflowRun reference matching", () => {
 			expect(matchedRunId).toBe(runId);
 		}));
 
+	test("returns the existing run when the stored hash is the announced value", () =>
+		withHarness(async ({ context, repos }) => {
+			const { service } = createService(repos);
+			const input = { orderId: "order-1" };
+			const announcedHash = "announced-hash";
+			const options = { reference: { id: "order-ref-1" } };
+
+			// Stored by a client already writing under the announced key.
+			const runId = await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input: asOpaquePayload(input),
+				clientCodecApplied: false,
+				inputHash: { value: announcedHash },
+				options,
+			});
+
+			// Retried by a client that only recognises that key so far.
+			const matchedRunId = await service.createWorkflowRun(context, {
+				name: "checkout",
+				versionId: "v1",
+				input: asOpaquePayload(input),
+				clientCodecApplied: false,
+				inputHash: { value: await hashInput(input), nextValue: announcedHash },
+				options,
+			});
+
+			expect(matchedRunId).toBe(runId);
+		}));
+
 	test("rejects when the stored hash is neither the current value nor a deprecated value", () =>
 		withHarness(async ({ context, repos }) => {
 			const { service } = createService(repos);

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -44,6 +44,7 @@ import type { SleepRow } from "../infra/db/types/sleep";
 import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { ChildRunWithWorkflow, WorkflowRunWithWorkflowAndState } from "../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
+import { candidateHashes } from "../lib/hash";
 import type { NamespaceRequestContext } from "../middleware/context";
 import type { CancelledRunMeta, ChildRunCanceller } from "../service/cancel-child-runs";
 import { deliverTerminatedSignalToParentRun, type TerminatedChildRun } from "../service/deliver-terminated-signals";
@@ -344,9 +345,7 @@ async function createWorkflowRunInTx(
 			referenceId,
 		});
 		if (existingRun) {
-			const hashCandidates = [inputHash.value, ...(inputHash.deprecatedValues ?? [])];
-
-			if (!hashCandidates.includes(existingRun.inputHash)) {
+			if (!candidateHashes(inputHash).includes(existingRun.inputHash)) {
 				const conflictPolicy = options?.reference?.conflictPolicy ?? "error";
 				if (conflictPolicy === "error") {
 					throw new WorkflowRunReferenceConflictError(name, versionId, referenceId);

--- a/sdk/workflow/src/run/execute.ts
+++ b/sdk/workflow/src/run/execute.ts
@@ -105,6 +105,7 @@ export async function executeWorkflowRun<Context>(params: ExecuteWorkflowParams<
 		if (!hasher) {
 			logger.error("Failed to determine the bound hasher for the workflow run. Check hasher configuration.", {
 				workflowRunId,
+				"aiki.inputHash": workflowRun.inputHash,
 			});
 
 			return false;

--- a/types/src/infra/hasher.ts
+++ b/types/src/infra/hasher.ts
@@ -1,9 +1,20 @@
 import type { Logger } from "@aikirun/lib/logger";
 
+/**
+ * A hasher may rotate: from then on it produces a different hash for the same input, while the
+ * hashes it produced before stay stored. The optional fields carry the same input under other
+ * rotations, so those stored hashes still match.
+ */
 export interface Hash {
 	value: string;
-	/** Prior hashes that still identify this definition. */
+	/** The hash under rotations this hasher has switched away from, whose stored hashes still match. */
 	deprecatedValues?: string[];
+	/**
+	 * The hash under a rotation this hasher has been told about but has not switched to yet.
+	 * Matched like `value`, never stored, so an instance that has not switched yet still finds what
+	 * an instance that already has stored.
+	 */
+	nextValue?: string;
 }
 
 export interface HasherContext {
@@ -12,6 +23,11 @@ export interface HasherContext {
 
 export interface Hasher {
 	(input: unknown): Promise<Hash>;
+	/**
+	 * This hasher under the rotation that produced `hash`, or null when it cannot hash under that
+	 * rotation. A run is replayed with it, so every hash computed inside the run stays comparable
+	 * with the run's record.
+	 */
 	for(hash: string): Promise<BoundHasher | null>;
 }
 


### PR DESCRIPTION
A client can plug in its own hasher, and a hasher may rotate: from then on it produces a different hash for the same input, while the hashes it produced before stay stored. A request already carries the hashes it has rotated away from, as `deprecatedValues`. `Hash` now also carries `nextValue`: the same input under a rotation this hasher has been told about but has not switched to yet. The server matches on it wherever it compares hashes and never stores it.

A rotation reaches a fleet one instance at a time, so it is done in three steps. Below, `h2024` and `h2025` are one input hashed under the old and the new rotation, and the fleet is two instances, A and B.

**1. Announce.** Every instance is told about the new rotation and keeps writing with the old one. Every request now carries the new hash as its next value:

```
A and B   value h2024   next h2025
```

**2. Switch, one instance at a time.** A has switched, B has not:

```
A   value h2025   deprecated [h2024]
B   value h2024   next h2025
```

This is the window the next value exists for:

```
A   starts run "order-7" under reference "order-7"     stores h2025
    dies before its caller sees the outcome; the retry lands on B
B   retries "order-7"   sends value h2024, next h2025   h2025 matches the next value: same run, no conflict
```

Without step 1, B would send `h2024` alone, nothing would match, and an honest retry would be rejected as a different input.

The same window decides what a schedule activation writes, and here the direction matters:

```
schedule S stored under h2024
A   activates S   h2024 matches a deprecated value   S is behind A: rewritten to h2025
B   activates S   h2025 matches the next value       S is ahead of B: left alone
```

Without the second line, B would rewrite S back to `h2024`, the next A forward again, for as long as the switch is rolling out. With it every rewrite moves forward and the fleet converges.

**3. Retire.** Once every instance has switched, `h2024` is dropped from the deprecated values. Nothing in this PR is involved in that step.