### PR TITLE
Count schedule occurrences from the next run timestamp

### DIFF
--- a/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
@@ -32,10 +32,9 @@ describe("processImminentRecurringRuns", () => {
 				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
 				workflowRunOptions: { priority: 2 },
 			});
-			const { createdAt } = schedule;
-			expect(createdAt).toBeGreaterThan(0);
+			const occurrence = schedule.nextRunAt + 60_000;
 
-			await withFakeClock(createdAt + 120_000, () =>
+			await withFakeClock(occurrence, () =>
 				processImminentRecurringRuns(
 					context,
 					{ repos, childRunCanceller: createChildRunCanceller() },
@@ -48,8 +47,8 @@ describe("processImminentRecurringRuns", () => {
 				expect.objectContaining({
 					workflowName: "send-invoices",
 					status: "pending",
-					rank: (createdAt + 120_000) * 10 + 2,
-					nextPublishAttemptRank: (createdAt + 120_000) * 10 + 2,
+					rank: occurrence * 10 + 2,
+					nextPublishAttemptRank: occurrence * 10 + 2,
 				}),
 			]);
 		}));
@@ -67,9 +66,7 @@ describe("processImminentRecurringRuns", () => {
 				clientCodecApplied: false,
 				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
 			});
-			const { createdAt } = schedule;
-			expect(createdAt).toBeGreaterThan(0);
-			const occurrence = createdAt + 120_000;
+			const occurrence = schedule.nextRunAt;
 
 			await withFakeClock(occurrence, () =>
 				processImminentRecurringRuns(
@@ -88,5 +85,36 @@ describe("processImminentRecurringRuns", () => {
 					referenceId: getReferenceId(schedule.id, occurrence),
 				})
 			).toEqual(expect.objectContaining({ run: expect.objectContaining({ clientHasherApplied: true }) }));
+		}));
+
+	test("an allow schedule owes every occurrence from its next run, oldest first", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "allow" },
+			});
+
+			await withFakeClock(schedule.nextRunAt + 120_000, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller() },
+					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
+				)
+			);
+
+			// computeRank(occurrence, default priority) = occurrence * 10 + 5.
+			expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
+				expect.objectContaining({ rank: schedule.nextRunAt * 10 + 5 }),
+				expect.objectContaining({ rank: (schedule.nextRunAt + 60_000) * 10 + 5 }),
+				expect.objectContaining({ rank: (schedule.nextRunAt + 120_000) * 10 + 5 }),
+			]);
 		}));
 });

--- a/sdk/server/src/infra/db/pg/migration/0038_wet_gorgon.sql
+++ b/sdk/server/src/infra/db/pg/migration/0038_wet_gorgon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "schedule" ALTER COLUMN "next_run_at" SET NOT NULL;

--- a/sdk/server/src/infra/db/pg/migration/meta/0038_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0038_snapshot.json
@@ -1,0 +1,1823 @@
+{
+	"id": "9e337477-8eef-4a54-9859-f543edbf068d",
+	"prevId": "9fd53e89-04fc-4c58-85c4-60351fe56f44",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_signal_sequence_id": {
+					"name": "idx_event_wait_workflow_run_signal_sequence_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "signal_sequence",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				},
+				"chk_event_wait_timeout_not_codec_applied": {
+					"name": "chk_event_wait_timeout_not_codec_applied",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"client_codec_applied\" = false"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_due_active": {
+					"name": "idx_schedule_due_active",
+					"columns": [
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"schedule\".\"status\" = 'active'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"workflow_run\".\"reference_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"schedule_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"parent_workflow_run_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_scheduled": {
+					"name": "idx_workflow_run_due_scheduled",
+					"columns": [
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'scheduled'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_sleeping": {
+					"name": "idx_workflow_run_due_sleeping",
+					"columns": [
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_event": {
+					"name": "idx_workflow_run_due_awaiting_event",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_event'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_child_workflow": {
+					"name": "idx_workflow_run_due_awaiting_child_workflow",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_child_workflow'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_retry": {
+					"name": "idx_workflow_run_due_awaiting_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_task_retry": {
+					"name": "idx_workflow_run_due_awaiting_task_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_task_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_task_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -260,6 +260,13 @@
 			"when": 1788676737416,
 			"tag": "0037_freezing_stranger",
 			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1788783986246,
+			"tag": "0038_wet_gorgon",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -16,20 +16,12 @@ type ScheduleRowUpdate = Partial<
 	Pick<
 		ScheduleRowInsert,
 		| "status"
-		| "clientHasherApplied"
-		| "clientCodecApplied"
-		| "type"
-		| "cronExpression"
-		| "intervalMs"
-		| "overlapPolicy"
+		| "referenceId"
 		| "workflowRunInput"
 		| "workflowRunInputHash"
+		| "clientHasherApplied"
+		| "clientCodecApplied"
 		| "definitionHash"
-		| "referenceId"
-		| "workflowRunOptions"
-		| "lastOccurrence"
-		| "nextRunAt"
-		| "workflowId"
 	>
 >;
 export interface ScheduleOccurrenceUpdate {

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -98,7 +98,7 @@ export const schedule = pgTable(
 		workflowRunOptions: jsonb("workflow_run_options").$type<WorkflowRunOptions>(),
 
 		lastOccurrence: timestampMs("last_occurrence"),
-		nextRunAt: timestampMs("next_run_at"),
+		nextRunAt: timestampMs("next_run_at").notNull(),
 
 		createdAt: timestampMs("created_at").notNull().default(sql`now()`),
 		updatedAt: timestampMs("updated_at").notNull().default(sql`now()`),

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -3,6 +3,7 @@ import { asOpaquePayload } from "@aikirun/testing/payload";
 
 import { createScheduleService } from "./schedule";
 import { describe, expect, test } from "bun:test";
+import { withFakeClock } from "../testing/clock";
 import { createServiceHarness } from "../testing/harness";
 
 const withHarness = createServiceHarness();
@@ -537,6 +538,72 @@ describe("ScheduleService activateSchedule under an announced key", () => {
 					workflowRunInput: aheadInput,
 					workflowRunInputHash: announcedHash,
 					clientCodecApplied: true,
+				})
+			);
+		}));
+});
+
+describe("ScheduleService activateSchedule and the next run", () => {
+	const spec = { type: "interval" as const, everyMs: 60_000 };
+
+	test("reactivating a paused schedule leaves its next run untouched", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const request = {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec,
+			};
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+			await scheduleService.pauseSchedule(context.namespaceId, schedule.id);
+
+			// Two periods on
+			const { schedule: reactivated } = await withFakeClock(schedule.nextRunAt + 120_000, () =>
+				scheduleService.activateSchedule(context.namespaceId, request)
+			);
+
+			expect(reactivated.id).toBe(schedule.id);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ id: schedule.id, status: "active", nextRunAt: schedule.nextRunAt })
+			);
+		}));
+
+	test("adopting a reference id onto an unreferenced schedule leaves its next run untouched", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const request = {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec,
+			};
+
+			const { schedule: unreferenced } = await scheduleService.activateSchedule(context.namespaceId, request);
+
+			// Two periods on
+			const { schedule: referenced } = await withFakeClock(unreferenced.nextRunAt + 120_000, () =>
+				scheduleService.activateSchedule(context.namespaceId, {
+					...request,
+					options: { reference: { id: "invoices-eu-west" } },
+				})
+			);
+
+			expect(referenced.id).toBe(unreferenced.id);
+			expect(await repos.schedule.get(context.namespaceId, { id: unreferenced.id })).toEqual(
+				expect.objectContaining({
+					id: unreferenced.id,
+					referenceId: "invoices-eu-west",
+					nextRunAt: unreferenced.nextRunAt,
 				})
 			);
 		}));

--- a/sdk/server/src/service/schedule.test.ts
+++ b/sdk/server/src/service/schedule.test.ts
@@ -4,13 +4,17 @@ import { describe, expect, test } from "bun:test";
 describe("getDueOccurrences", () => {
 	const timestampMs = (iso: string) => new Date(iso).getTime();
 
-	// Hourly on the hour. Created at 00:30, so 01:00 is the first occurrence that can become due.
-	const createdAt = timestampMs("2026-01-01T00:30:00Z");
+	// Hourly on the hour, with 01:00 the next run still owed.
+	const nextRunAt = timestampMs("2026-01-01T01:00:00Z");
 	const hourlyCron = { type: "cron", expression: "0 * * * *", timezone: "UTC" } as const;
 	const hourlyInterval = { type: "interval", everyMs: 60 * 60 * 1_000 } as const;
 
 	test("skip policy: only the most recent missed occurrence is due, and nextRunAt is the one after it", () => {
-		expect(getDueOccurrences({ spec: hourlyCron, createdAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
+		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
+			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
+			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
+		});
+		expect(getDueOccurrences({ spec: hourlyInterval, nextRunAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
 			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
@@ -19,7 +23,7 @@ describe("getDueOccurrences", () => {
 	test("cancel_previous policy: same as skip, only the most recent missed occurrence is due", () => {
 		expect(
 			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "cancel_previous" }, createdAt },
+				{ spec: { ...hourlyCron, overlapPolicy: "cancel_previous" }, nextRunAt },
 				timestampMs("2026-01-01T03:15:00Z")
 			)
 		).toEqual({
@@ -28,19 +32,32 @@ describe("getDueOccurrences", () => {
 		});
 		expect(
 			getDueOccurrences(
-				{ spec: { ...hourlyInterval, overlapPolicy: "cancel_previous" }, createdAt },
+				{ spec: { ...hourlyInterval, overlapPolicy: "cancel_previous" }, nextRunAt },
 				timestampMs("2026-01-01T03:15:00Z")
 			)
 		).toEqual({
-			occurrences: [timestampMs("2026-01-01T02:30:00Z")],
-			nextRunAt: timestampMs("2026-01-01T03:30:00Z"),
+			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
+			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
 	});
 
-	test("allow policy: every missed occurrence is due, oldest first, and nextRunAt follows the last", () => {
+	test("allow policy: every occurrence from the next run is due, oldest first, and nextRunAt follows the last", () => {
 		expect(
 			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, createdAt },
+				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
+				timestampMs("2026-01-01T03:15:00Z")
+			)
+		).toEqual({
+			occurrences: [
+				timestampMs("2026-01-01T01:00:00Z"),
+				timestampMs("2026-01-01T02:00:00Z"),
+				timestampMs("2026-01-01T03:00:00Z"),
+			],
+			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
+		});
+		expect(
+			getDueOccurrences(
+				{ spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
 				timestampMs("2026-01-01T03:15:00Z")
 			)
 		).toEqual({
@@ -53,38 +70,34 @@ describe("getDueOccurrences", () => {
 		});
 	});
 
-	test("returns null when no occurrence has passed since the schedule was created", () => {
-		expect(getDueOccurrences({ spec: hourlyCron, createdAt }, timestampMs("2026-01-01T00:45:00Z"))).toBeNull();
+	test("the next run itself is due when now equals it exactly", () => {
+		const exactNextRunAt = timestampMs("2026-01-01T03:00:00Z");
+		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt: exactNextRunAt }, exactNextRunAt)).toEqual({
+			occurrences: [exactNextRunAt],
+			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
+		});
+		expect(
+			getDueOccurrences({ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt: exactNextRunAt }, exactNextRunAt)
+		).toEqual({
+			occurrences: [exactNextRunAt],
+			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
+		});
+	});
+
+	test("returns null while the next run is still ahead", () => {
+		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt }, timestampMs("2026-01-01T00:45:00Z"))).toBeNull();
 		expect(
 			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, createdAt },
+				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
 				timestampMs("2026-01-01T00:45:00Z")
 			)
 		).toBeNull();
-	});
-
-	test("returns null when the most recent occurrence has already fired", () => {
+		expect(getDueOccurrences({ spec: hourlyInterval, nextRunAt }, timestampMs("2026-01-01T00:45:00Z"))).toBeNull();
 		expect(
 			getDueOccurrences(
-				{ spec: hourlyCron, createdAt, lastOccurrence: timestampMs("2026-01-01T03:00:00Z") },
-				timestampMs("2026-01-01T03:15:00Z")
+				{ spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
+				timestampMs("2026-01-01T00:45:00Z")
 			)
 		).toBeNull();
-	});
-
-	test("interval specs: occurrences fall every everyMs after the anchor", () => {
-		expect(getDueOccurrences({ spec: hourlyInterval, createdAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
-			occurrences: [timestampMs("2026-01-01T02:30:00Z")],
-			nextRunAt: timestampMs("2026-01-01T03:30:00Z"),
-		});
-		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyInterval, overlapPolicy: "allow" }, createdAt },
-				timestampMs("2026-01-01T03:15:00Z")
-			)
-		).toEqual({
-			occurrences: [timestampMs("2026-01-01T01:30:00Z"), timestampMs("2026-01-01T02:30:00Z")],
-			nextRunAt: timestampMs("2026-01-01T03:30:00Z"),
-		});
 	});
 });

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -6,7 +6,7 @@ import type { ScheduleActivateRequestV1, ScheduleListRequestV1 } from "@aikirun/
 import type { Hash } from "@aikirun/types/infra/hasher";
 import type { NamespaceId } from "@aikirun/types/namespace";
 import type { OpaquePayload } from "@aikirun/types/payload";
-import type { Schedule, ScheduleSpec, ScheduleStatus } from "@aikirun/types/schedule";
+import type { Schedule, ScheduleSpec } from "@aikirun/types/schedule";
 import type { WorkflowName, WorkflowSource, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 import CronExpressionParser from "cron-parser";
@@ -29,86 +29,90 @@ export interface DueOccurrences {
 	nextRunAt: number;
 }
 
+interface OccurrenceRange {
+	/** Occurrences in the range, oldest first. */
+	occurrences: NonEmptyArray<number>;
+	/** The first occurrence after the range. */
+	next: number;
+}
+
 /**
- * Returns every occurrence due between `anchor` and `now` (inclusive).
- * Also returns the first non-due occurrence i.e. `nextRunAt`.
- * Used for the allow policy.
+ * Every occurrence of `spec` between `from` and `to`, both inclusive. Interval occurrences fall
+ * every `everyMs` starting at `from`; cron occurrences are the times the expression matches.
+ * Returns null when the range holds no occurrence.
  */
-function getAllDueOccurrencesBetween(spec: ScheduleSpec, anchor: number, now: number): DueOccurrences | null {
+function getOccurrencesBetween(spec: ScheduleSpec, from: number, to: number): OccurrenceRange | null {
 	const occurrences: number[] = [];
-	let nextRunAt: number;
+	let next: number;
 
 	if (spec.type === "cron") {
+		// next() is strict, so the cursor starts one millisecond before `from` to count an occurrence at `from` itself.
 		const parsed = CronExpressionParser.parse(spec.expression, {
-			currentDate: new Date(anchor),
+			currentDate: new Date(from - 1),
 			tz: spec.timezone,
 		});
-
-		let next = parsed.next().getTime();
-		while (next <= now) {
+		next = parsed.next().getTime();
+		while (next <= to) {
 			occurrences.push(next);
 			next = parsed.next().getTime();
 		}
-		nextRunAt = next;
 	} else {
-		let cursor = anchor + spec.everyMs;
-		while (cursor <= now) {
-			occurrences.push(cursor);
-			cursor += spec.everyMs;
+		next = from;
+		while (next <= to) {
+			occurrences.push(next);
+			next += spec.everyMs;
 		}
-		nextRunAt = cursor;
 	}
 
 	if (!isNonEmptyArray(occurrences)) {
 		return null;
 	}
-	return { occurrences, nextRunAt };
+	return { occurrences, next };
 }
 
 /**
- * Returns the last occurrence due between `anchor` and `now` (inclusive).
- * Also returns the first non-due occurrence i.e. `nextRunAt`.
- * Used for the skip and cancel_previous policies.
+ * The last occurrence of `spec` between `from` and `to`, both inclusive. Interval occurrences fall
+ * every `everyMs` starting at `from`; cron occurrences are the times the expression matches.
+ * Returns null when the range holds no occurrence.
  */
-function getLastDueOccurrenceBetween(spec: ScheduleSpec, anchor: number, now: number): DueOccurrences | null {
+function getLastOccurrenceBetween(spec: ScheduleSpec, from: number, to: number): OccurrenceRange | null {
 	if (spec.type === "cron") {
+		// prev() is strict, so the cursor starts one millisecond past `to` to count an occurrence at `to` itself.
 		const parsed = CronExpressionParser.parse(spec.expression, {
-			currentDate: new Date(now),
+			currentDate: new Date(to + 1),
 			tz: spec.timezone,
 		});
-		const previous = parsed.prev().getTime();
-		if (previous <= anchor) {
+		const last = parsed.prev().getTime();
+		if (last < from) {
 			return null;
 		}
-		// The parser's cursor now sits on `previous`, so next() is the occurrence after it.
-		return { occurrences: [previous], nextRunAt: parsed.next().getTime() };
+		// The parser's cursor now sits on `last`, so next() is the occurrence after it.
+		return { occurrences: [last], next: parsed.next().getTime() };
 	}
 
-	const elapsed = now - anchor;
-	if (elapsed < spec.everyMs) {
+	if (from > to) {
 		return null;
 	}
-	const intervalsPassed = Math.floor(elapsed / spec.everyMs);
-	const last = anchor + intervalsPassed * spec.everyMs;
-	return { occurrences: [last], nextRunAt: last + spec.everyMs };
+	const intervalsPassed = Math.floor((to - from) / spec.everyMs);
+	const last = from + intervalsPassed * spec.everyMs;
+	return { occurrences: [last], next: last + spec.everyMs };
 }
 
 /**
- * What a schedule owes as of `now`, and when it runs next.
- * Returns null when nothing is due.
+ * What a schedule owes as of `now`, counted from its next run, and when it runs after that.
+ * Returns null while the next run is still ahead.
  */
-export function getDueOccurrences(
-	schedule: Pick<Schedule, "spec" | "lastOccurrence" | "createdAt">,
-	now: number
-): DueOccurrences | null {
-	const { spec } = schedule;
-	const anchor = schedule.lastOccurrence ?? schedule.createdAt;
+export function getDueOccurrences(schedule: Pick<Schedule, "spec" | "nextRunAt">, now: number): DueOccurrences | null {
+	const { spec, nextRunAt } = schedule;
 	const overlapPolicy = spec.overlapPolicy ?? "skip";
-
-	if (overlapPolicy === "allow") {
-		return getAllDueOccurrencesBetween(spec, anchor, now);
+	const range =
+		overlapPolicy === "allow"
+			? getOccurrencesBetween(spec, nextRunAt, now)
+			: getLastOccurrenceBetween(spec, nextRunAt, now);
+	if (!range) {
+		return null;
 	}
-	return getLastDueOccurrenceBetween(spec, anchor, now);
+	return { occurrences: range.occurrences, nextRunAt: range.next };
 }
 
 export function getNextOccurrence(spec: ScheduleSpec, anchor: number): number {
@@ -128,21 +132,6 @@ export interface ScheduleServiceDeps {
 }
 
 export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
-	async updateSchedule(
-		namespaceId: NamespaceId,
-		id: string,
-		updates: Partial<{
-			status: ScheduleStatus;
-			lastOccurrence: TimestampMs | null;
-			nextRunAt: TimestampMs | null;
-		}>
-	): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, { id }, updates);
-		if (!schedule) {
-			throw new NotFoundError(`Schedule not found: ${id}`);
-		}
-	},
-
 	async activateSchedule(
 		namespaceId: NamespaceId,
 		request: ScheduleActivateRequestV1
@@ -312,7 +301,6 @@ async function activateScheduleInTx(
 					existing: existingScheduleByDefinition,
 					payload,
 					nextDefinitionHash: definitionHashes.nextValue,
-					nextRunAt,
 				})
 			: await createSchedule(txRepos.schedule, {
 					namespaceId,
@@ -342,7 +330,6 @@ async function activateScheduleInTx(
 			existing: existingScheduleByReference,
 			payload,
 			nextDefinitionHash: definitionHashes.nextValue,
-			nextRunAt,
 		});
 
 		return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
@@ -355,10 +342,9 @@ async function activateScheduleInTx(
 	});
 
 	if (existingNonReferencedSchedule) {
-		const updates: Partial<SchedulePayload> & { referenceId: string; status: "active"; nextRunAt: TimestampMs } = {
+		const updates: Partial<SchedulePayload> & { referenceId: string; status: "active" } = {
 			referenceId,
 			status: "active",
-			nextRunAt,
 		};
 		// Matching the request's next hash means the stored schedule was written by a client that
 		// has already switched to the rotation this request has only been told about. The stored
@@ -401,7 +387,6 @@ async function reuseSchedule(
 		existing: ScheduleRow;
 		payload: SchedulePayload;
 		nextDefinitionHash: string | undefined;
-		nextRunAt: TimestampMs;
 	}
 ): Promise<ScheduleRow> {
 	const { existing, payload } = params;
@@ -422,11 +407,10 @@ async function reuseSchedule(
 		return existing;
 	}
 
-	const updates: Partial<SchedulePayload> & { status?: "active"; nextRunAt?: TimestampMs } = {};
+	const updates: Partial<SchedulePayload> & { status?: "active" } = {};
 
 	if (needsActivation) {
 		updates.status = "active";
-		updates.nextRunAt = params.nextRunAt;
 	}
 
 	if (payloadChanged) {
@@ -501,7 +485,7 @@ export function scheduleRowToDomain(
 		createdAt: schedule.createdAt,
 		updatedAt: schedule.updatedAt,
 		lastOccurrence: schedule.lastOccurrence ?? undefined,
-		nextRunAt: schedule.nextRunAt ?? 0,
+		nextRunAt: schedule.nextRunAt,
 	};
 }
 


### PR DESCRIPTION
A schedule row stores `nextRunAt`, the occurrence it owes next, and `lastOccurrence`, the one it fired last. A timer wakes the recurring-runs daemon at `nextRunAt`; a poll every ten seconds is the backstop. Once woken, the daemon worked out what the schedule owed by counting occurrences forward from `lastOccurrence`, or from the row's `createdAt` before the first fire. `nextRunAt` only decided whether the schedule was picked up. On a fresh schedule the two starting points come from different clocks: `nextRunAt` from the server at activation, `createdAt` from the database's `now()` default. When the database clock runs ahead, the first occurrence goes wrong.

An interval schedule every 60 seconds, server clock 12:00:00.000, database clock one second ahead.

**1. Activate.**

```
nextRunAt  12:01:00.000   server clock + 60s
createdAt  12:00:01.000   database clock
```

**2. The timer fires at 12:01:00.** Counting from `createdAt`, the first occurrence is 12:01:01, still ahead. Nothing is due, nothing is written, and `nextRunAt` stays in the past.

```
count from createdAt    first occurrence 12:01:01.000 > now    nothing due
```

**3. The first poll after 12:01:01** finds the schedule past due, counts again, and fires it. The poll runs on its own cadence, so that is anywhere from a moment to about ten seconds late. Every later occurrence is counted from this one, so the schedule runs at one second past the minute from then on, not on the minute as the activation reported.

A cron schedule has fixed occurrence times, so it cannot drift, but it can lose an occurrence. Cron every minute, server clock 12:00:59.500, database clock 12:01:00.500:

```
nextRunAt  12:01:00.000   the next whole minute after the server clock
count from createdAt      first occurrence 12:02:00.000    12:01:00 never fires
```

The daemon now counts from `nextRunAt` instead. `nextRunAt` is the next occurrence the schedule owes, so it is the first one counted, and the count continues up to now:

```
count from nextRunAt    12:01:00.000 <= now    due, fires on time
```

After a fire, `nextRunAt` is written as the occurrence after the last one fired, which is where the old count started too: the first occurrence after `lastOccurrence`. So the two counts agree from then on. Only the first fire differed, and that special case is gone. `createdAt` is no longer read. `lastOccurrence` keeps one job: naming the run the skip and cancel_previous overlap policies look up.

Now that counting starts from `nextRunAt`, anything that rewrites it decides which occurrences a schedule replays. Activation also recomputed it from the clock when it reactivated a paused schedule or attached a reference id to an anonymous one. That would now silently drop the occurrences missed while paused, so both writes are removed: reactivation flips the status and nothing else. The repository's update type no longer accepts `nextRunAt` or `lastOccurrence`, so after creation the occurrence columns have one writer, the daemon's compare-and-swap occurrence update.

## Breaking changes

- `schedule.next_run_at` is `NOT NULL`.