### PR TITLE
Cap the occurrences a schedule fires per pass

### DIFF
--- a/app/website/content/docs/core-concepts/schedules.md
+++ b/app/website/content/docs/core-concepts/schedules.md
@@ -100,6 +100,8 @@ const syncSchedule = schedule({
 | `"skip"` (default) | Skip this occurrence if a run is still active |
 | `"cancel_previous"` | Cancel the active run and start a new one |
 
+The policy also decides what happens to the occurrences a schedule missed, whether because the server was down or because the schedule was paused. `"allow"` runs every missed occurrence, oldest first, working through a large backlog in batches rather than all at once. `"skip"` and `"cancel_previous"` run only the most recent one.
+
 Overlap policies are evaluated per schedule instance, not globally. If you activate the same schedule for multiple tenants with different inputs, each tenant has independent overlap handling.
 
 ## Run Options

--- a/sdk/server/src/config/runtime.ts
+++ b/sdk/server/src/config/runtime.ts
@@ -25,7 +25,9 @@ export interface ServerRuntimeConfig {
 		imminentTaskRetryableRuns: ImminentPollingDaemonConfig;
 		imminentEventWaitTimedOutRuns: ImminentPollingDaemonConfig;
 		imminentChildRunWaitTimedOutRuns: ImminentPollingDaemonConfig;
-		imminentRecurringRuns: ImminentPollingDaemonConfig;
+		imminentRecurringRuns: ImminentPollingDaemonConfig & {
+			maxOccurrencesPerSchedule: number;
+		};
 		publishPendingOutboxEntries: PollingDaemonConfig & {
 			leaseDurationMs: number;
 			republishBackoff: {
@@ -110,6 +112,7 @@ export const defaultServerRuntimeConfig: ServerRuntimeConfig = {
 			intervalMs: 10_000,
 			pageSize: 1_000,
 			lookaheadWindowMs: 30_000,
+			maxOccurrencesPerSchedule: 3,
 			chunk: {
 				size: 100,
 				maxConcurrency: 10,

--- a/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
@@ -48,6 +48,7 @@ describe("processDueTimers", () => {
 							pageSize: 100,
 							overshootMs: 0,
 							republishBackoff,
+							maxOccurrencesPerSchedule: daemonConfig.imminentRecurringRuns.maxOccurrencesPerSchedule,
 							chunkByTimerType: chunkConfigByTimerType,
 						})),
 					},

--- a/sdk/server/src/daemon/due-timers-consumer.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.test.ts
@@ -51,6 +51,7 @@ describe("startDueTimersConsumer", () => {
 				pageSize: 1,
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+				maxOccurrencesPerSchedule: 3,
 				chunkByTimerType: chunkConfigByTimerType,
 			})),
 		}).then(() => {
@@ -97,6 +98,7 @@ describe("startDueTimersConsumer", () => {
 				pageSize: 1_000,
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
+				maxOccurrencesPerSchedule: 3,
 				chunkByTimerType: chunkConfigByTimerType,
 			})),
 		});

--- a/sdk/server/src/daemon/due-timers-consumer.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.ts
@@ -29,6 +29,7 @@ interface DueTimerConsumerConfig {
 	pageSize: number;
 	overshootMs: number;
 	republishBackoff: RepublishBackoff;
+	maxOccurrencesPerSchedule: number;
 	chunkByTimerType: Record<TimerType, PageProcessingConfig["chunk"]>;
 }
 
@@ -174,7 +175,10 @@ export async function processDueTimers(
 				continue;
 			}
 			promises.push(
-				queueRecurringRuns(context, deps, schedules, configProvider.config.republishBackoff, { chunk: chunkConfig })
+				queueRecurringRuns(context, deps, schedules, configProvider.config.republishBackoff, {
+					maxOccurrencesPerSchedule: configProvider.config.maxOccurrencesPerSchedule,
+					chunk: chunkConfig,
+				})
 			);
 		} else {
 			const rankById = new Map(timers.map((timer) => [timer.id, timer.rank]));

--- a/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
@@ -16,6 +16,16 @@ const namespaceRequestContext = namespaceRequestContextFactory.build();
 
 const { republishBackoff } = defaultServerRuntimeConfig.daemons.publishPendingOutboxEntries;
 
+const NO_CAP = Number.MAX_SAFE_INTEGER;
+
+const config = {
+	pageSize: 100,
+	lookaheadWindowMs: 0,
+	maxOccurrencesPerSchedule: NO_CAP,
+	republishBackoff,
+	chunk: { size: 100, maxConcurrency: 10 },
+};
+
 describe("processImminentRecurringRuns", () => {
 	test("the occurrence's outbox rank carries the schedule's run priority", () =>
 		withHarness(async ({ context, repos }) => {
@@ -35,11 +45,7 @@ describe("processImminentRecurringRuns", () => {
 			const occurrence = schedule.nextRunAt + 60_000;
 
 			await withFakeClock(occurrence, () =>
-				processImminentRecurringRuns(
-					context,
-					{ repos, childRunCanceller: createChildRunCanceller() },
-					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
-				)
+				processImminentRecurringRuns(context, { repos, childRunCanceller: createChildRunCanceller() }, config)
 			);
 
 			// computeRank(occurrence, priority 2) = occurrence * 10 + 2.
@@ -69,11 +75,7 @@ describe("processImminentRecurringRuns", () => {
 			const occurrence = schedule.nextRunAt;
 
 			await withFakeClock(occurrence, () =>
-				processImminentRecurringRuns(
-					context,
-					{ repos, childRunCanceller: createChildRunCanceller() },
-					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
-				)
+				processImminentRecurringRuns(context, { repos, childRunCanceller: createChildRunCanceller() }, config)
 			);
 
 			expect(
@@ -103,11 +105,7 @@ describe("processImminentRecurringRuns", () => {
 			});
 
 			await withFakeClock(schedule.nextRunAt + 120_000, () =>
-				processImminentRecurringRuns(
-					context,
-					{ repos, childRunCanceller: createChildRunCanceller() },
-					{ pageSize: 100, lookaheadWindowMs: 0, republishBackoff, chunk: { size: 100, maxConcurrency: 10 } }
-				)
+				processImminentRecurringRuns(context, { repos, childRunCanceller: createChildRunCanceller() }, config)
 			);
 
 			// computeRank(occurrence, default priority) = occurrence * 10 + 5.
@@ -116,5 +114,84 @@ describe("processImminentRecurringRuns", () => {
 				expect.objectContaining({ rank: (schedule.nextRunAt + 60_000) * 10 + 5 }),
 				expect.objectContaining({ rank: (schedule.nextRunAt + 120_000) * 10 + 5 }),
 			]);
+		}));
+
+	test("an allow schedule fires at most the cap's worth of occurrences and stays due at the first one left over", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "allow" },
+			});
+
+			// Three occurrences are due under a cap of two.
+			await withFakeClock(schedule.nextRunAt + 120_000, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller() },
+					{ ...config, maxOccurrencesPerSchedule: 2 }
+				)
+			);
+
+			expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
+				expect.objectContaining({ rank: schedule.nextRunAt * 10 + 5 }),
+				expect.objectContaining({ rank: (schedule.nextRunAt + 60_000) * 10 + 5 }),
+			]);
+			expect(await repos.schedule.get(namespaceRequestContext.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({
+					lastOccurrence: schedule.nextRunAt + 60_000,
+					nextRunAt: schedule.nextRunAt + 120_000,
+				})
+			);
+		}));
+
+	test("a capped allow schedule fires the rest on the next pass", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "allow" },
+			});
+
+			// Three occurrences are due under a cap of two, so the second pass owes one.
+			await withFakeClock(schedule.nextRunAt + 120_000, async () => {
+				const cappedConfig = { ...config, maxOccurrencesPerSchedule: 2 };
+				await processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller() },
+					cappedConfig
+				);
+				await processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller() },
+					cappedConfig
+				);
+			});
+
+			expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
+				expect.objectContaining({ rank: schedule.nextRunAt * 10 + 5 }),
+				expect.objectContaining({ rank: (schedule.nextRunAt + 60_000) * 10 + 5 }),
+				expect.objectContaining({ rank: (schedule.nextRunAt + 120_000) * 10 + 5 }),
+			]);
+			expect(await repos.schedule.get(namespaceRequestContext.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({
+					lastOccurrence: schedule.nextRunAt + 120_000,
+					nextRunAt: schedule.nextRunAt + 180_000,
+				})
+			);
 		}));
 });

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -53,9 +53,13 @@ const advanceScheduleCursor = createKeysetStreamCursorAdvancer<{ schedule: { id:
 export async function processImminentRecurringRuns(
 	context: DaemonContext,
 	deps: ProcessImminentRecurringRunsDeps,
-	config: PageProcessingConfig & { lookaheadWindowMs: number; republishBackoff: RepublishBackoff }
+	config: PageProcessingConfig & {
+		lookaheadWindowMs: number;
+		maxOccurrencesPerSchedule: number;
+		republishBackoff: RepublishBackoff;
+	}
 ) {
-	const { pageSize, lookaheadWindowMs, republishBackoff, chunk } = config;
+	const { pageSize, lookaheadWindowMs, maxOccurrencesPerSchedule, republishBackoff, chunk } = config;
 	const dueBefore = (Date.now() + (deps.timerPriorityQueue ? lookaheadWindowMs : 0)) as TimestampMs;
 
 	for await (const rows of streamChunks(
@@ -79,7 +83,7 @@ export async function processImminentRecurringRuns(
 		}));
 
 		if (isNonEmptyArray(schedulesDueNow)) {
-			await queueRecurringRuns(context, deps, schedulesDueNow, republishBackoff, { chunk });
+			await queueRecurringRuns(context, deps, schedulesDueNow, republishBackoff, { maxOccurrencesPerSchedule, chunk });
 		}
 
 		const { timerPriorityQueue } = deps;
@@ -102,15 +106,17 @@ export async function queueRecurringRuns(
 	deps: ProcessImminentRecurringRunsDeps,
 	schedules: NonEmptyArray<DueSchedule>,
 	republishBackoff: RepublishBackoff,
-	options?: { chunk?: { size?: number; maxConcurrency?: number } }
+	options: { maxOccurrencesPerSchedule: number; chunk?: { size?: number; maxConcurrency?: number } }
 ) {
-	const { size: chunkSize = schedules.length, maxConcurrency } = options?.chunk ?? {};
+	const { size: chunkSize = schedules.length, maxConcurrency } = options.chunk ?? {};
+	const { maxOccurrencesPerSchedule } = options;
 	const now = Date.now();
 
 	await runConcurrently(
 		context,
 		chunkLazy(schedules, chunkSize),
-		(chunk, spanCtx) => processChunk(spanCtx, deps, chunk, now, republishBackoff),
+		(chunk, spanCtx) =>
+			processChunk(spanCtx, deps, { schedules: chunk, now, maxOccurrencesPerSchedule, republishBackoff }),
 		maxConcurrency ? { concurrency: maxConcurrency } : undefined
 	);
 }
@@ -118,10 +124,15 @@ export async function queueRecurringRuns(
 async function processChunk(
 	context: DaemonContext,
 	deps: ProcessImminentRecurringRunsDeps,
-	schedules: NonEmptyArray<DueSchedule>,
-	now: number,
-	republishBackoff: RepublishBackoff
+	params: {
+		schedules: NonEmptyArray<DueSchedule>;
+		now: number;
+		maxOccurrencesPerSchedule: number;
+		republishBackoff: RepublishBackoff;
+	}
 ) {
+	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+
 	const allowSchedules: DueSchedule[] = [];
 	const skipSchedules: DueSchedule[] = [];
 	const cancelPreviousSchedules: DueSchedule[] = [];
@@ -140,13 +151,28 @@ async function processChunk(
 
 	const results = await Promise.allSettled([
 		isNonEmptyArray(allowSchedules)
-			? processOverlapAllowSchedules(context, deps.repos, allowSchedules, now, deps.publisher, republishBackoff)
+			? processOverlapAllowSchedules(context, deps, {
+					schedules: allowSchedules,
+					now,
+					maxOccurrencesPerSchedule,
+					republishBackoff,
+				})
 			: undefined,
 		isNonEmptyArray(skipSchedules)
-			? processOverlapSkipSchedules(context, deps.repos, skipSchedules, now, deps.publisher, republishBackoff)
+			? processOverlapSkipSchedules(context, deps, {
+					schedules: skipSchedules,
+					now,
+					maxOccurrencesPerSchedule,
+					republishBackoff,
+				})
 			: undefined,
 		isNonEmptyArray(cancelPreviousSchedules)
-			? processOverlapCancelPreviousSchedules(context, deps, cancelPreviousSchedules, now, republishBackoff)
+			? processOverlapCancelPreviousSchedules(context, deps, {
+					schedules: cancelPreviousSchedules,
+					now,
+					maxOccurrencesPerSchedule,
+					republishBackoff,
+				})
 			: undefined,
 	]);
 
@@ -159,21 +185,31 @@ async function processChunk(
 
 async function processOverlapAllowSchedules(
 	context: DaemonContext,
-	repos: Repositories,
-	schedules: NonEmptyArray<DueSchedule>,
-	now: number,
-	publisher: Publisher | undefined,
-	republishBackoff: RepublishBackoff
+	{ repos, publisher }: ProcessImminentRecurringRunsDeps,
+	params: {
+		schedules: NonEmptyArray<DueSchedule>;
+		now: number;
+		maxOccurrencesPerSchedule: number;
+		republishBackoff: RepublishBackoff;
+	}
 ) {
+	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
-		const due = getDueOccurrences(schedule, now);
+		const due = getDueOccurrences({ schedule, now, maxOccurrences: maxOccurrencesPerSchedule });
 		if (!due) {
 			continue;
+		}
+		if (due.nextRunAt <= now) {
+			context.logger.debug("Schedule reached the occurrence cap, the rest stays due", {
+				"aiki.scheduleId": schedule.id,
+				"aiki.count": due.occurrences.length,
+			});
 		}
 
 		for (const occurrence of due.occurrences) {
@@ -264,12 +300,15 @@ async function insertRecurringRunsInTx(
 
 async function processOverlapSkipSchedules(
 	context: DaemonContext,
-	repos: Repositories,
-	schedules: NonEmptyArray<DueSchedule>,
-	now: number,
-	publisher: Publisher | undefined,
-	republishBackoff: RepublishBackoff
+	{ repos, publisher }: ProcessImminentRecurringRunsDeps,
+	params: {
+		schedules: NonEmptyArray<DueSchedule>;
+		now: number;
+		maxOccurrencesPerSchedule: number;
+		republishBackoff: RepublishBackoff;
+	}
 ) {
+	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
 	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(repos, schedules);
 
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
@@ -278,7 +317,7 @@ async function processOverlapSkipSchedules(
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
-		const due = getDueOccurrences(schedule, now);
+		const due = getDueOccurrences({ schedule, now, maxOccurrences: maxOccurrencesPerSchedule });
 		if (!due) {
 			continue;
 		}
@@ -381,10 +420,15 @@ async function insertRunsAndAdvanceSchedulesInTx(
 async function processOverlapCancelPreviousSchedules(
 	context: DaemonContext,
 	deps: ProcessImminentRecurringRunsDeps,
-	schedules: NonEmptyArray<DueSchedule>,
-	now: number,
-	republishBackoff: RepublishBackoff
+	params: {
+		schedules: NonEmptyArray<DueSchedule>;
+		now: number;
+		maxOccurrencesPerSchedule: number;
+		republishBackoff: RepublishBackoff;
+	}
 ) {
+	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+
 	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(deps.repos, schedules);
 
 	const runIdsToCancel: string[] = [];
@@ -402,7 +446,7 @@ async function processOverlapCancelPreviousSchedules(
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
 	for (const schedule of schedules) {
-		const due = getDueOccurrences(schedule, now);
+		const due = getDueOccurrences({ schedule, now, maxOccurrences: maxOccurrencesPerSchedule });
 		if (!due) {
 			continue;
 		}

--- a/sdk/server/src/daemon/index.ts
+++ b/sdk/server/src/daemon/index.ts
@@ -196,6 +196,7 @@ export async function startDaemons(logger: Logger, deps: StartDaemonsDeps): Prom
 					return {
 						...config.dueTimersConsumer,
 						republishBackoff: config.publishPendingOutboxEntries.republishBackoff,
+						maxOccurrencesPerSchedule: config.imminentRecurringRuns.maxOccurrencesPerSchedule,
 						chunkByTimerType: {
 							scheduled: config.imminentScheduledRuns.chunk,
 							sleep: config.imminentSleepElapsedRuns.chunk,

--- a/sdk/server/src/service/schedule.test.ts
+++ b/sdk/server/src/service/schedule.test.ts
@@ -4,17 +4,31 @@ import { describe, expect, test } from "bun:test";
 describe("getDueOccurrences", () => {
 	const timestampMs = (iso: string) => new Date(iso).getTime();
 
+	const NoCap = Number.MAX_SAFE_INTEGER;
+
 	// Hourly on the hour, with 01:00 the next run still owed.
 	const nextRunAt = timestampMs("2026-01-01T01:00:00Z");
 	const hourlyCron = { type: "cron", expression: "0 * * * *", timezone: "UTC" } as const;
 	const hourlyInterval = { type: "interval", everyMs: 60 * 60 * 1_000 } as const;
 
 	test("skip policy: only the most recent missed occurrence is due, and nextRunAt is the one after it", () => {
-		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
+		expect(
+			getDueOccurrences({
+				schedule: { spec: hourlyCron, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
+		).toEqual({
 			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
-		expect(getDueOccurrences({ spec: hourlyInterval, nextRunAt }, timestampMs("2026-01-01T03:15:00Z"))).toEqual({
+		expect(
+			getDueOccurrences({
+				schedule: { spec: hourlyInterval, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
+		).toEqual({
 			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
@@ -22,19 +36,21 @@ describe("getDueOccurrences", () => {
 
 	test("cancel_previous policy: same as skip, only the most recent missed occurrence is due", () => {
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "cancel_previous" }, nextRunAt },
-				timestampMs("2026-01-01T03:15:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyCron, overlapPolicy: "cancel_previous" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toEqual({
 			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyInterval, overlapPolicy: "cancel_previous" }, nextRunAt },
-				timestampMs("2026-01-01T03:15:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyInterval, overlapPolicy: "cancel_previous" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toEqual({
 			occurrences: [timestampMs("2026-01-01T03:00:00Z")],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
@@ -43,10 +59,11 @@ describe("getDueOccurrences", () => {
 
 	test("allow policy: every occurrence from the next run is due, oldest first, and nextRunAt follows the last", () => {
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
-				timestampMs("2026-01-01T03:15:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toEqual({
 			occurrences: [
 				timestampMs("2026-01-01T01:00:00Z"),
@@ -56,10 +73,11 @@ describe("getDueOccurrences", () => {
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
-				timestampMs("2026-01-01T03:15:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toEqual({
 			occurrences: [
 				timestampMs("2026-01-01T01:00:00Z"),
@@ -70,14 +88,47 @@ describe("getDueOccurrences", () => {
 		});
 	});
 
+	test("allow policy: at most the cap's worth of occurrences are due, and nextRunAt is the first one left over", () => {
+		expect(
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: 2,
+			})
+		).toEqual({
+			occurrences: [timestampMs("2026-01-01T01:00:00Z"), timestampMs("2026-01-01T02:00:00Z")],
+			nextRunAt: timestampMs("2026-01-01T03:00:00Z"),
+		});
+		expect(
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T03:15:00Z"),
+				maxOccurrences: 2,
+			})
+		).toEqual({
+			occurrences: [timestampMs("2026-01-01T01:00:00Z"), timestampMs("2026-01-01T02:00:00Z")],
+			nextRunAt: timestampMs("2026-01-01T03:00:00Z"),
+		});
+	});
+
 	test("the next run itself is due when now equals it exactly", () => {
 		const exactNextRunAt = timestampMs("2026-01-01T03:00:00Z");
-		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt: exactNextRunAt }, exactNextRunAt)).toEqual({
+		expect(
+			getDueOccurrences({
+				schedule: { spec: hourlyCron, nextRunAt: exactNextRunAt },
+				now: exactNextRunAt,
+				maxOccurrences: NoCap,
+			})
+		).toEqual({
 			occurrences: [exactNextRunAt],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
 		});
 		expect(
-			getDueOccurrences({ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt: exactNextRunAt }, exactNextRunAt)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt: exactNextRunAt },
+				now: exactNextRunAt,
+				maxOccurrences: NoCap,
+			})
 		).toEqual({
 			occurrences: [exactNextRunAt],
 			nextRunAt: timestampMs("2026-01-01T04:00:00Z"),
@@ -85,19 +136,33 @@ describe("getDueOccurrences", () => {
 	});
 
 	test("returns null while the next run is still ahead", () => {
-		expect(getDueOccurrences({ spec: hourlyCron, nextRunAt }, timestampMs("2026-01-01T00:45:00Z"))).toBeNull();
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
-				timestampMs("2026-01-01T00:45:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: hourlyCron, nextRunAt },
+				now: timestampMs("2026-01-01T00:45:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toBeNull();
-		expect(getDueOccurrences({ spec: hourlyInterval, nextRunAt }, timestampMs("2026-01-01T00:45:00Z"))).toBeNull();
 		expect(
-			getDueOccurrences(
-				{ spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
-				timestampMs("2026-01-01T00:45:00Z")
-			)
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyCron, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T00:45:00Z"),
+				maxOccurrences: NoCap,
+			})
+		).toBeNull();
+		expect(
+			getDueOccurrences({
+				schedule: { spec: hourlyInterval, nextRunAt },
+				now: timestampMs("2026-01-01T00:45:00Z"),
+				maxOccurrences: NoCap,
+			})
+		).toBeNull();
+		expect(
+			getDueOccurrences({
+				schedule: { spec: { ...hourlyInterval, overlapPolicy: "allow" }, nextRunAt },
+				now: timestampMs("2026-01-01T00:45:00Z"),
+				maxOccurrences: NoCap,
+			})
 		).toBeNull();
 	});
 });

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -25,23 +25,30 @@ export function getReferenceId(scheduleId: string, occurrence: number) {
 export interface DueOccurrences {
 	/** Occurrences due at or before `now`, oldest first. */
 	occurrences: NonEmptyArray<number>;
-	/** The occurrence after the last due one. */
+	/** The occurrence after the last one returned. Still due when the cap cut the count short. */
 	nextRunAt: number;
 }
 
 interface OccurrenceRange {
 	/** Occurrences in the range, oldest first. */
 	occurrences: NonEmptyArray<number>;
-	/** The first occurrence after the range. */
+	/** The first occurrence after the last one returned. */
 	next: number;
 }
 
 /**
- * Every occurrence of `spec` between `from` and `to`, both inclusive. Interval occurrences fall
- * every `everyMs` starting at `from`; cron occurrences are the times the expression matches.
+ * Every occurrence of `spec` between `from` and `to`, both inclusive, up to `limit` of them. Interval
+ * occurrences fall every `everyMs` starting at `from`; cron occurrences are the times the expression matches.
  * Returns null when the range holds no occurrence.
  */
-function getOccurrencesBetween(spec: ScheduleSpec, from: number, to: number): OccurrenceRange | null {
+function getOccurrencesBetween(params: {
+	spec: ScheduleSpec;
+	from: number;
+	to: number;
+	limit: number;
+}): OccurrenceRange | null {
+	const { spec, from, to, limit } = params;
+
 	const occurrences: number[] = [];
 	let next: number;
 
@@ -52,13 +59,13 @@ function getOccurrencesBetween(spec: ScheduleSpec, from: number, to: number): Oc
 			tz: spec.timezone,
 		});
 		next = parsed.next().getTime();
-		while (next <= to) {
+		while (next <= to && occurrences.length < limit) {
 			occurrences.push(next);
 			next = parsed.next().getTime();
 		}
 	} else {
 		next = from;
-		while (next <= to) {
+		while (next <= to && occurrences.length < limit) {
 			occurrences.push(next);
 			next += spec.everyMs;
 		}
@@ -75,7 +82,9 @@ function getOccurrencesBetween(spec: ScheduleSpec, from: number, to: number): Oc
  * every `everyMs` starting at `from`; cron occurrences are the times the expression matches.
  * Returns null when the range holds no occurrence.
  */
-function getLastOccurrenceBetween(spec: ScheduleSpec, from: number, to: number): OccurrenceRange | null {
+function getLastOccurrenceBetween(params: { spec: ScheduleSpec; from: number; to: number }): OccurrenceRange | null {
+	const { spec, from, to } = params;
+
 	if (spec.type === "cron") {
 		// prev() is strict, so the cursor starts one millisecond past `to` to count an occurrence at `to` itself.
 		const parsed = CronExpressionParser.parse(spec.expression, {
@@ -99,16 +108,22 @@ function getLastOccurrenceBetween(spec: ScheduleSpec, from: number, to: number):
 }
 
 /**
- * What a schedule owes as of `now`, counted from its next run, and when it runs after that.
- * Returns null while the next run is still ahead.
+ * What a schedule owes as of `now`, counted from its next run and at most `maxOccurrences` of it,
+ * and when it runs after that. Returns null while the next run is still ahead.
  */
-export function getDueOccurrences(schedule: Pick<Schedule, "spec" | "nextRunAt">, now: number): DueOccurrences | null {
+export function getDueOccurrences(params: {
+	schedule: Pick<Schedule, "spec" | "nextRunAt">;
+	now: number;
+	maxOccurrences: number;
+}): DueOccurrences | null {
+	const { schedule, now, maxOccurrences } = params;
+
 	const { spec, nextRunAt } = schedule;
 	const overlapPolicy = spec.overlapPolicy ?? "skip";
 	const range =
 		overlapPolicy === "allow"
-			? getOccurrencesBetween(spec, nextRunAt, now)
-			: getLastOccurrenceBetween(spec, nextRunAt, now);
+			? getOccurrencesBetween({ spec, from: nextRunAt, to: now, limit: maxOccurrences })
+			: getLastOccurrenceBetween({ spec, from: nextRunAt, to: now });
 	if (!range) {
 		return null;
 	}


### PR DESCRIPTION
Since #203 the recurring-runs daemon counts a schedule's owed occurrences from its next run, and under the allow policy it fires every one of them. It did that in one go. The daemon works through due schedules in chunks, and for each chunk it built a run, a state transition, and an outbox entry for every owed occurrence of every allow schedule, all in memory, and inserted them in one transaction. Nothing bounded that, so a schedule that fell far enough behind, through downtime or a long pause, could not catch up at all:

```
a few thousand due    one insert per table exceeds the driver's 65,534-parameter limit
                      the transaction rolls back, next run unchanged
next pass             the same occurrences plus the new ones, the same failure, forever
```

Every allow schedule in that chunk rolled back with it, and a backlog large enough to exhaust memory failed before the insert.

The daemon now fires at most a configured number of occurrences per schedule per pass, `maxOccurrencesPerSchedule` on the recurring-runs daemon config, and writes the first occurrence left over as the schedule's next run. That next run is still in the past, so the schedule stays due and the following pass continues from it. An interval schedule every minute, five occurrences behind, cap 3:

```
due       12:01 12:02 12:03 12:04 12:05     next run 12:01
pass 1    fires 12:01 12:02 12:03           next run 12:04   still due
pass 2    fires 12:04 12:05                 next run 12:06
```

Both entry points apply the cap, the poll and the timer consumer. A chunk's transaction is now bounded by the chunk size times the cap, and a schedule with a large backlog drains one cap per pass without holding up the others. The daemon logs at debug when a schedule hits the cap.

The docs now say what the overlap policy means for missed occurrences: allow runs every one of them, oldest first, in batches; skip and cancel_previous run only the most recent.