### PR TITLE
Arm the next timer when a schedule fires

### DIFF
--- a/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.integration.test.ts
@@ -1,12 +1,15 @@
 import { asConfigProvider } from "@aikirun/lib/config";
+import { hashInput } from "@aikirun/lib/crypto";
 import { noopLogger } from "@aikirun/lib/logger";
 import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+import { asOpaquePayload } from "@aikirun/testing/payload";
 
 import { processDueTimers } from "./due-timers-consumer";
 import { describe, expect, test } from "bun:test";
 import { defaultServerRuntimeConfig } from "../config/runtime";
 import { computeRank } from "../lib/rank";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
+import { createScheduleService } from "../service/schedule";
 import { withFakeClock } from "../testing/clock";
 import { namespaceRequestContextFactory } from "../testing/data-factory/middleware/context";
 import { createDaemonHarness } from "../testing/harness";
@@ -49,6 +52,7 @@ describe("processDueTimers", () => {
 							overshootMs: 0,
 							republishBackoff,
 							maxOccurrencesPerSchedule: daemonConfig.imminentRecurringRuns.maxOccurrencesPerSchedule,
+							lookaheadWindowMs: daemonConfig.imminentRecurringRuns.lookaheadWindowMs,
 							chunkByTimerType: chunkConfigByTimerType,
 						})),
 					},
@@ -69,5 +73,52 @@ describe("processDueTimers", () => {
 					})
 				);
 			});
+		}));
+
+	test("a recurring timer arms the timer for the schedule's next run when due soon", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
+				workflowRunOptions: { priority: 2 },
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// The next run lands one period on, exactly at the edge of the lookahead.
+			await withFakeClock(schedule.nextRunAt, () =>
+				processDueTimers(
+					context,
+					{
+						repos,
+						signal: new AbortController().signal,
+						timerPriorityQueue,
+						childRunCanceller: createChildRunCanceller(),
+						configProvider: asConfigProvider(() => ({
+							pageSize: 100,
+							overshootMs: 0,
+							republishBackoff,
+							maxOccurrencesPerSchedule: daemonConfig.imminentRecurringRuns.maxOccurrencesPerSchedule,
+							lookaheadWindowMs: 60_000,
+							chunkByTimerType: chunkConfigByTimerType,
+						})),
+					},
+					[{ type: "recurring", id: schedule.id, rank: computeRank({ dueAt: schedule.nextRunAt, priority: 2 }) }]
+				)
+			);
+
+			// The timer fired the occurrence it was set for.
+			expect(await repos.workflowRunOutbox.listPending(context, 100)).toEqual([
+				expect.objectContaining({ rank: computeRank({ dueAt: schedule.nextRunAt, priority: 2 }) }),
+			]);
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "recurring", id: schedule.id, rank: computeRank({ dueAt: schedule.nextRunAt + 60_000, priority: 2 }) },
+			]);
 		}));
 });

--- a/sdk/server/src/daemon/due-timers-consumer.test.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.test.ts
@@ -52,6 +52,7 @@ describe("startDueTimersConsumer", () => {
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
 				maxOccurrencesPerSchedule: 3,
+				lookaheadWindowMs: 0,
 				chunkByTimerType: chunkConfigByTimerType,
 			})),
 		}).then(() => {
@@ -99,6 +100,7 @@ describe("startDueTimersConsumer", () => {
 				overshootMs: 10,
 				republishBackoff: { baseDelayMs: 5_000, maxDelayMs: 300_000, declinedBackoffMs: 30_000 },
 				maxOccurrencesPerSchedule: 3,
+				lookaheadWindowMs: 0,
 				chunkByTimerType: chunkConfigByTimerType,
 			})),
 		});

--- a/sdk/server/src/daemon/due-timers-consumer.ts
+++ b/sdk/server/src/daemon/due-timers-consumer.ts
@@ -30,6 +30,7 @@ interface DueTimerConsumerConfig {
 	overshootMs: number;
 	republishBackoff: RepublishBackoff;
 	maxOccurrencesPerSchedule: number;
+	lookaheadWindowMs: number;
 	chunkByTimerType: Record<TimerType, PageProcessingConfig["chunk"]>;
 }
 
@@ -177,6 +178,7 @@ export async function processDueTimers(
 			promises.push(
 				queueRecurringRuns(context, deps, schedules, configProvider.config.republishBackoff, {
 					maxOccurrencesPerSchedule: configProvider.config.maxOccurrencesPerSchedule,
+					lookaheadWindowMs: configProvider.config.lookaheadWindowMs,
 					chunk: chunkConfig,
 				})
 			);

--- a/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.integration.test.ts
@@ -1,9 +1,12 @@
 import { hashInput } from "@aikirun/lib/crypto";
+import { noopLogger } from "@aikirun/lib/logger";
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
 import { asOpaquePayload } from "@aikirun/testing/payload";
 
 import { processImminentRecurringRuns } from "./imminent-recurring-runs";
 import { describe, expect, test } from "bun:test";
 import { defaultServerRuntimeConfig } from "../config/runtime";
+import { computeRank, PRIORITY_LEVELS } from "../lib/rank";
 import { createChildRunCanceller } from "../service/cancel-child-runs";
 import { createScheduleService, getReferenceId } from "../service/schedule";
 import { withFakeClock } from "../testing/clock";
@@ -193,5 +196,98 @@ describe("processImminentRecurringRuns", () => {
 					nextRunAt: schedule.nextRunAt + 180_000,
 				})
 			);
+		}));
+
+	test("firing a schedule arms a timer for its next run when it falls within the lookahead", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
+				workflowRunOptions: { priority: 2 },
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// The next run lands one period on, exactly at the edge of the lookahead.
+			await withFakeClock(schedule.nextRunAt, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller(), timerPriorityQueue },
+					{ ...config, lookaheadWindowMs: 60_000 }
+				)
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "recurring", id: schedule.id, rank: computeRank({ dueAt: schedule.nextRunAt + 60_000, priority: 2 }) },
+			]);
+		}));
+
+	test("firing a schedule arms no timer when its next run falls beyond the lookahead", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "skip" },
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// The next run lands one period on, one millisecond past the lookahead.
+			await withFakeClock(schedule.nextRunAt, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller(), timerPriorityQueue },
+					{ ...config, lookaheadWindowMs: 59_999 }
+				)
+			);
+
+			expect(await timerPriorityQueue.peekNext()).toBeNull();
+		}));
+
+	test("a capped allow schedule arms a timer that is due at once for the occurrences left over", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const workflowRunInput = { region: "eu-west" };
+
+			const { schedule } = await scheduleService.activateSchedule(namespaceRequestContext.namespaceId, {
+				workflowName: "send-invoices",
+				workflowVersionId: "v1",
+				workflowRunInput: asOpaquePayload(workflowRunInput),
+				workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+				clientHasherApplied: false,
+				clientCodecApplied: false,
+				spec: { type: "interval", everyMs: 60_000, overlapPolicy: "allow" },
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			// Three occurrences are due under a cap of two, so the leftover is already past and the lookahead is moot.
+			const now = schedule.nextRunAt + 120_000;
+			await withFakeClock(now, () =>
+				processImminentRecurringRuns(
+					context,
+					{ repos, childRunCanceller: createChildRunCanceller(), timerPriorityQueue },
+					{ ...config, maxOccurrencesPerSchedule: 2, lookaheadWindowMs: 0 }
+				)
+			);
+
+			expect(
+				await timerPriorityQueue.popDue({
+					maxRank: computeRank({ dueAt: now, priority: PRIORITY_LEVELS - 1 }),
+					limit: 10,
+				})
+			).toEqual([{ type: "recurring", id: schedule.id, rank: computeRank({ dueAt: now }) }]);
 		}));
 });

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -1,4 +1,4 @@
-import { streamChunks } from "@aikirun/lib/async";
+import { fireAndForget, streamChunks } from "@aikirun/lib/async";
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import { asNonEmptyArray, chunkLazy, isNonEmptyArray, partitionArray } from "@aikirun/lib/collection/array";
 import type { TimestampMs } from "@aikirun/lib/timestamp";
@@ -83,7 +83,11 @@ export async function processImminentRecurringRuns(
 		}));
 
 		if (isNonEmptyArray(schedulesDueNow)) {
-			await queueRecurringRuns(context, deps, schedulesDueNow, republishBackoff, { maxOccurrencesPerSchedule, chunk });
+			await queueRecurringRuns(context, deps, schedulesDueNow, republishBackoff, {
+				maxOccurrencesPerSchedule,
+				lookaheadWindowMs,
+				chunk,
+			});
 		}
 
 		const { timerPriorityQueue } = deps;
@@ -106,17 +110,27 @@ export async function queueRecurringRuns(
 	deps: ProcessImminentRecurringRunsDeps,
 	schedules: NonEmptyArray<DueSchedule>,
 	republishBackoff: RepublishBackoff,
-	options: { maxOccurrencesPerSchedule: number; chunk?: { size?: number; maxConcurrency?: number } }
+	options: {
+		maxOccurrencesPerSchedule: number;
+		lookaheadWindowMs: number;
+		chunk?: { size?: number; maxConcurrency?: number };
+	}
 ) {
 	const { size: chunkSize = schedules.length, maxConcurrency } = options.chunk ?? {};
-	const { maxOccurrencesPerSchedule } = options;
+	const { maxOccurrencesPerSchedule, lookaheadWindowMs } = options;
 	const now = Date.now();
 
 	await runConcurrently(
 		context,
 		chunkLazy(schedules, chunkSize),
 		(chunk, spanCtx) =>
-			processChunk(spanCtx, deps, { schedules: chunk, now, maxOccurrencesPerSchedule, republishBackoff }),
+			processChunk(spanCtx, deps, {
+				schedules: chunk,
+				now,
+				maxOccurrencesPerSchedule,
+				lookaheadWindowMs,
+				republishBackoff,
+			}),
 		maxConcurrency ? { concurrency: maxConcurrency } : undefined
 	);
 }
@@ -128,10 +142,11 @@ async function processChunk(
 		schedules: NonEmptyArray<DueSchedule>;
 		now: number;
 		maxOccurrencesPerSchedule: number;
+		lookaheadWindowMs: number;
 		republishBackoff: RepublishBackoff;
 	}
 ) {
-	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+	const { schedules, now, maxOccurrencesPerSchedule, lookaheadWindowMs, republishBackoff } = params;
 
 	const allowSchedules: DueSchedule[] = [];
 	const skipSchedules: DueSchedule[] = [];
@@ -155,6 +170,7 @@ async function processChunk(
 					schedules: allowSchedules,
 					now,
 					maxOccurrencesPerSchedule,
+					lookaheadWindowMs,
 					republishBackoff,
 				})
 			: undefined,
@@ -163,6 +179,7 @@ async function processChunk(
 					schedules: skipSchedules,
 					now,
 					maxOccurrencesPerSchedule,
+					lookaheadWindowMs,
 					republishBackoff,
 				})
 			: undefined,
@@ -171,6 +188,7 @@ async function processChunk(
 					schedules: cancelPreviousSchedules,
 					now,
 					maxOccurrencesPerSchedule,
+					lookaheadWindowMs,
 					republishBackoff,
 				})
 			: undefined,
@@ -185,16 +203,18 @@ async function processChunk(
 
 async function processOverlapAllowSchedules(
 	context: DaemonContext,
-	{ repos, publisher }: ProcessImminentRecurringRunsDeps,
+	{ repos, publisher, timerPriorityQueue }: ProcessImminentRecurringRunsDeps,
 	params: {
 		schedules: NonEmptyArray<DueSchedule>;
 		now: number;
 		maxOccurrencesPerSchedule: number;
+		lookaheadWindowMs: number;
 		republishBackoff: RepublishBackoff;
 	}
 ) {
-	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+	const { schedules, now, maxOccurrencesPerSchedule, lookaheadWindowMs, republishBackoff } = params;
 
+	const timersDueSoon: TimerEntry[] = [];
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -209,6 +229,13 @@ async function processOverlapAllowSchedules(
 			context.logger.debug("Schedule reached the occurrence cap, the rest stays due", {
 				"aiki.scheduleId": schedule.id,
 				"aiki.count": due.occurrences.length,
+			});
+		}
+		if (timerPriorityQueue && due.nextRunAt <= now + lookaheadWindowMs) {
+			timersDueSoon.push({
+				type: "recurring",
+				id: schedule.id,
+				rank: computeRank({ dueAt: due.nextRunAt, priority: schedule.workflowRunOptions?.priority }),
 			});
 		}
 
@@ -274,9 +301,15 @@ async function processOverlapAllowSchedules(
 		return;
 	}
 
-	await repos.transaction(async (txRepos) =>
-		insertRecurringRunsInTx({ workflowRunEntries, stateTransitionEntries, scheduleUpdates, outboxEntries }, txRepos)
-	);
+	await repos.transaction(async (txRepos) => {
+		await insertRecurringRunsInTx(
+			{ workflowRunEntries, stateTransitionEntries, scheduleUpdates, outboxEntries },
+			txRepos
+		);
+		if (timerPriorityQueue && isNonEmptyArray(timersDueSoon)) {
+			txRepos.onCommit(() => queueTimers(context, timerPriorityQueue, timersDueSoon));
+		}
+	});
 
 	if (publisher) {
 		await publishOutboxEntries(context, repos, publisher, outboxEntries, republishBackoff);
@@ -300,17 +333,19 @@ async function insertRecurringRunsInTx(
 
 async function processOverlapSkipSchedules(
 	context: DaemonContext,
-	{ repos, publisher }: ProcessImminentRecurringRunsDeps,
+	{ repos, publisher, timerPriorityQueue }: ProcessImminentRecurringRunsDeps,
 	params: {
 		schedules: NonEmptyArray<DueSchedule>;
 		now: number;
 		maxOccurrencesPerSchedule: number;
+		lookaheadWindowMs: number;
 		republishBackoff: RepublishBackoff;
 	}
 ) {
-	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+	const { schedules, now, maxOccurrencesPerSchedule, lookaheadWindowMs, republishBackoff } = params;
 	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(repos, schedules);
 
+	const timersDueSoon: TimerEntry[] = [];
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
 	const stateTransitionEntries: StateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -322,6 +357,13 @@ async function processOverlapSkipSchedules(
 			continue;
 		}
 		const occurrence = due.occurrences[0];
+		if (timerPriorityQueue && due.nextRunAt <= now + lookaheadWindowMs) {
+			timersDueSoon.push({
+				type: "recurring",
+				id: schedule.id,
+				rank: computeRank({ dueAt: due.nextRunAt, priority: schedule.workflowRunOptions?.priority }),
+			});
+		}
 
 		if (activeRunsByScheduleId.has(schedule.id)) {
 			scheduleUpdates.push({
@@ -383,12 +425,16 @@ async function processOverlapSkipSchedules(
 		return;
 	}
 
-	const insertedOutboxEntries = await repos.transaction(async (txRepos) =>
-		insertRunsAndAdvanceSchedulesInTx(
+	const insertedOutboxEntries = await repos.transaction(async (txRepos) => {
+		const inserted = await insertRunsAndAdvanceSchedulesInTx(
 			{ workflowRunEntries, stateTransitionEntries, scheduleUpdates, outboxEntries },
 			txRepos
-		)
-	);
+		);
+		if (timerPriorityQueue && isNonEmptyArray(timersDueSoon)) {
+			txRepos.onCommit(() => queueTimers(context, timerPriorityQueue, timersDueSoon));
+		}
+		return inserted;
+	});
 
 	if (publisher && isNonEmptyArray(insertedOutboxEntries)) {
 		await publishOutboxEntries(context, repos, publisher, insertedOutboxEntries, republishBackoff);
@@ -424,12 +470,14 @@ async function processOverlapCancelPreviousSchedules(
 		schedules: NonEmptyArray<DueSchedule>;
 		now: number;
 		maxOccurrencesPerSchedule: number;
+		lookaheadWindowMs: number;
 		republishBackoff: RepublishBackoff;
 	}
 ) {
-	const { schedules, now, maxOccurrencesPerSchedule, republishBackoff } = params;
+	const { repos, childRunCanceller, timerPriorityQueue, publisher } = deps;
+	const { schedules, now, maxOccurrencesPerSchedule, lookaheadWindowMs, republishBackoff } = params;
 
-	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(deps.repos, schedules);
+	const { activeRunsByScheduleId } = await fetchActiveRunsBySchedule(repos, schedules);
 
 	const runIdsToCancel: string[] = [];
 	const runsToCancel: Array<{
@@ -440,6 +488,7 @@ async function processOverlapCancelPreviousSchedules(
 		priority?: number;
 	}> = [];
 
+	const timersDueSoon: TimerEntry[] = [];
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
 	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
 	const newOutboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -451,6 +500,13 @@ async function processOverlapCancelPreviousSchedules(
 			continue;
 		}
 		const occurrence = due.occurrences[0];
+		if (timerPriorityQueue && due.nextRunAt <= now + lookaheadWindowMs) {
+			timersDueSoon.push({
+				type: "recurring",
+				id: schedule.id,
+				rank: computeRank({ dueAt: due.nextRunAt, priority: schedule.workflowRunOptions?.priority }),
+			});
+		}
 
 		const activeRun = activeRunsByScheduleId.get(schedule.id);
 		if (activeRun) {
@@ -517,10 +573,10 @@ async function processOverlapCancelPreviousSchedules(
 		return;
 	}
 
-	const insertedOutboxEntries = await deps.repos.transaction(async (txRepos) =>
-		cancelPreviousAndInsertRunsInTx(
+	const insertedOutboxEntries = await repos.transaction(async (txRepos) => {
+		const inserted = await cancelPreviousAndInsertRunsInTx(
 			context,
-			deps.childRunCanceller,
+			childRunCanceller,
 			now as TimestampMs,
 			{
 				runIdsToCancel,
@@ -531,11 +587,15 @@ async function processOverlapCancelPreviousSchedules(
 				newOutboxEntries,
 			},
 			txRepos
-		)
-	);
+		);
+		if (timerPriorityQueue && isNonEmptyArray(timersDueSoon)) {
+			txRepos.onCommit(() => queueTimers(context, timerPriorityQueue, timersDueSoon));
+		}
+		return inserted;
+	});
 
-	if (deps.publisher && isNonEmptyArray(insertedOutboxEntries)) {
-		await publishOutboxEntries(context, deps.repos, deps.publisher, insertedOutboxEntries, republishBackoff);
+	if (publisher && isNonEmptyArray(insertedOutboxEntries)) {
+		await publishOutboxEntries(context, repos, publisher, insertedOutboxEntries, republishBackoff);
 	}
 }
 
@@ -690,4 +750,19 @@ async function fetchActiveRunsBySchedule(repos: Repositories, schedules: NonEmpt
 	}
 
 	return { activeRunsByScheduleId };
+}
+
+function queueTimers(
+	context: DaemonContext,
+	timerPriorityQueue: TimerPriorityQueue,
+	timers: NonEmptyArray<TimerEntry>
+): void {
+	fireAndForget(
+		timerPriorityQueue.add(timers).then((result) => {
+			if (result.status === "failed") {
+				context.logger.debug("Failed to add recurring timers", { "aiki.count": timers.length });
+			}
+		}),
+		(err) => context.logger.debug("Failed to add recurring timers", { err, "aiki.count": timers.length })
+	);
 }

--- a/sdk/server/src/daemon/index.ts
+++ b/sdk/server/src/daemon/index.ts
@@ -197,6 +197,7 @@ export async function startDaemons(logger: Logger, deps: StartDaemonsDeps): Prom
 						...config.dueTimersConsumer,
 						republishBackoff: config.publishPendingOutboxEntries.republishBackoff,
 						maxOccurrencesPerSchedule: config.imminentRecurringRuns.maxOccurrencesPerSchedule,
+						lookaheadWindowMs: config.imminentRecurringRuns.lookaheadWindowMs,
 						chunkByTimerType: {
 							scheduled: config.imminentScheduledRuns.chunk,
 							sleep: config.imminentSleepElapsedRuns.chunk,


### PR DESCRIPTION
The recurring-runs daemon polls every ten seconds for schedules whose next run falls within the next thirty seconds (its lookahead window). A schedule already due is fired on the spot. One due later in the window gets a timer, and the timer consumer fires it at the exact time instead of at the next poll.

That poll was the only place a timer was created. A fire writes the schedule's new next run and creates nothing for it, so the schedule waits for the next poll to notice it, and if the new next run is already past by then it fires late. A schedule whose period is shorter than the poll interval is therefore late after its first occurrence. An every-five-seconds schedule with `skip` overlap policy, with polls at :03, :13, :23:

```
:03  poll    next run :05, inside the lookahead   timer created for :05
:05  timer   fires :05, next run :10              nothing created
:13  poll    :10 already past                     fires :10 three seconds late, next run :15, nothing created
:23  poll    :15 and :20 already past             fires :20 three seconds late, :15 never fires
```

With `allow` overlap policy, :15 fires as well, eight seconds late.

### Solution

A fire now creates the timer for the new next run when it falls inside the lookahead, whether the poll or the timer consumer did the firing:

```
:03  poll    timer created for :05
:05  timer   fires :05, next run :10              timer created for :10
:10  timer   fires :10, next run :15              timer created for :15
```

The timer is created once the pass's transaction commits, so a rolled-back pass creates nothing. A failed add is logged at debug and the schedule waits for the next poll instead.

Since #204 a capped schedule leaves its next run in the past. The timer created for it is due at once, so a backlog drains as fast as the consumer works through it, one cap per pass, instead of one cap per poll.

The timer consumer's config carries the recurring daemon's lookahead, so a fire uses the same window from either path.