### PR TITLE
Sleep takes a duration object

### DIFF
--- a/app/website/content/docs/core-concepts/sleeps.md
+++ b/app/website/content/docs/core-concepts/sleeps.md
@@ -23,19 +23,16 @@ const orderWorkflowV1 = orderWorkflow.v("1.0.0", {
 
 ### Duration Formats
 
-Durations can be specified as an object or milliseconds:
+A duration is an object naming its units:
 
 ```typescript
-// Object format (recommended for readability)
 await run.sleep("reminder", { days: 7 });
 await run.sleep("cooldown", { hours: 1, minutes: 30 });
 await run.sleep("delay", { seconds: 30 });
-
-// Milliseconds
-await run.sleep("short-delay", 5000);
+await run.sleep("short-delay", { milliseconds: 5000 });
 ```
 
-Available fields: `days`, `hours`, `minutes`, `seconds`, `milliseconds`.
+Available fields: `days`, `hours`, `minutes`, `seconds`, `milliseconds`. Set at least one.
 
 ## How Sleeps Work
 

--- a/sdk/workflow/src/index.ts
+++ b/sdk/workflow/src/index.ts
@@ -1,4 +1,4 @@
-export type { Duration, DurationObject } from "@aikirun/lib/duration";
+export type { DurationObject } from "@aikirun/lib/duration";
 export type {
 	ExponentialRetryStrategy,
 	FixedRetryStrategy,

--- a/sdk/workflow/src/run/index.ts
+++ b/sdk/workflow/src/run/index.ts
@@ -1,5 +1,5 @@
 import type { ConfigProvider } from "@aikirun/lib/config";
-import type { Duration } from "@aikirun/lib/duration";
+import type { DurationObject } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
 import type { BoundHasher } from "@aikirun/types/infra/hasher";
 import { INTERNAL } from "@aikirun/types/symbols";
@@ -17,7 +17,7 @@ export interface WorkflowRun<Context, TEvents extends EventsDefinition = EventsD
 	versionId: WorkflowVersionId;
 	options: WorkflowRunOptions;
 	logger: Logger;
-	sleep: (name: string, duration: Duration) => Promise<SleepResult>;
+	sleep: (name: string, duration: DurationObject) => Promise<SleepResult>;
 	events: EventWaiters<TEvents>;
 	context: Context;
 	[INTERNAL]: {

--- a/sdk/workflow/src/run/sleeper.ts
+++ b/sdk/workflow/src/run/sleeper.ts
@@ -1,4 +1,4 @@
-import type { Duration } from "@aikirun/lib/duration";
+import type { DurationObject } from "@aikirun/lib/duration";
 import { toMilliseconds } from "@aikirun/lib/duration";
 import type { Logger } from "@aikirun/lib/logger";
 import { INTERNAL } from "@aikirun/types/symbols";
@@ -13,7 +13,7 @@ const MAX_SLEEP_MS = MAX_SLEEP_YEARS * 365 * 24 * 60 * 60 * 1_000;
 export function createSleeper(handle: WorkflowRunHandle<unknown, unknown>, logger: Logger) {
 	const nextIndexBySleepName: Record<SleepName, number> = {};
 
-	return async (name: string, duration: Duration): Promise<SleepResult> => {
+	return async (name: string, duration: DurationObject): Promise<SleepResult> => {
 		const sleepName = name as SleepName;
 		const durationMs = toMilliseconds(duration);
 


### PR DESCRIPTION
`run.sleep()` accepts a bare number in milliseconds or a duration object. Now it only accepts the duration object which helps with clarifying units.

```ts
// before
await run.sleep("short-delay", 5000);

// after
await run.sleep("short-delay", { milliseconds: 5000 });
```

## Breaking changes

- `run.sleep()` takes a `DurationObject`. A bare number no longer compiles.
- `Duration` is no longer exported from `@aikirun/workflow` — nothing in the public API accepts it.