### PR TITLE
Add schedule state transition history

### DIFF
--- a/app/website/content/docs/core-concepts/schedules.md
+++ b/app/website/content/docs/core-concepts/schedules.md
@@ -162,7 +162,7 @@ const handle = await dailyReport
 | `"error"` (default) | Throw a `ScheduleConflictError` if the reference ID already identifies a schedule with a different definition |
 | `"return_existing"` | Return the existing schedule unchanged |
 
-The definition is immutable, so a reference ID that already points at a different definition is a conflict, not an update. With `"error"` the activation throws a `ScheduleConflictError`; with `"return_existing"` it returns the existing schedule as-is. Re-activating with the *same* definition is idempotent, and reactivates the schedule if it was paused.
+The definition is immutable, so a reference ID that already points at a different definition is a conflict, not an update. With `"error"` the activation throws a `ScheduleConflictError`; with `"return_existing"` it returns the existing schedule as-is. Re-activating with the *same* definition is idempotent: it returns the existing schedule. If that schedule is paused, re-activating does not resume it; only `resume()` does. If the schedule was deactivated, re-activating brings it back.
 
 For more on reference IDs in workflows and events, see the [Reference IDs guide](../guides/reference-ids.md).
 
@@ -173,16 +173,16 @@ The handle returned from `activate()` lets you manage the schedule:
 ```typescript
 const handle = await mySchedule.activate(aikiClient, workflowV1);
 
-await handle.pause();      // Stop triggering
-await handle.resume();     // Resume triggering
+await handle.pause();      // Stop triggering until resumed
+await handle.resume();     // Resume a paused schedule
 await handle.deactivate(); // Deactivate schedule
 ```
 
 | Property/Method | Description |
 |-----------------|-------------|
 | `id` | Unique identifier for this schedule |
-| `pause()` | Stop triggering |
-| `resume()` | Resume triggering |
+| `pause()` | Stop triggering until resumed. Rejected on a deactivated schedule |
+| `resume()` | Resume a paused schedule. Rejected on a deactivated schedule; `activate()` brings it back |
 | `deactivate()` | Deactivate schedule |
 
 ## Multi-Tenant Schedules

--- a/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-child-run-wait-timed-out-runs.ts
@@ -10,7 +10,7 @@ import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-o
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ChildWorkflowRunWaitRowInsert } from "../infra/db/types/child-workflow-run-wait";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -106,7 +106,7 @@ async function processChunk(
 	const timedOutAt = Date.now() as TimestampMs;
 
 	const childRunWaitEntries: ChildWorkflowRunWaitRowInsert[] = [];
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -140,7 +140,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts,
 			state: toState,
 		});
@@ -192,7 +191,7 @@ async function transitionToQueuedInTx(
 			update: { stateTransitionId: string };
 		}>;
 		childRunWaitEntries: ChildWorkflowRunWaitRowInsert[];
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	txRepos: TxRepositories

--- a/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
+++ b/sdk/server/src/daemon/imminent-event-wait-timed-out-runs.ts
@@ -11,7 +11,7 @@ import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-o
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { EventWaitRowInsert } from "../infra/db/types/event-wait";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -107,7 +107,7 @@ async function processChunk(
 	const timedOutAt = Date.now() as TimestampMs;
 
 	const eventWaitEntries: Omit<EventWaitRowInsert, "signalSequence">[] = [];
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -142,7 +142,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts,
 			state: toState,
 		});
@@ -195,7 +194,7 @@ async function transitionToQueuedInTx(
 			update: { stateTransitionId: string };
 		}>;
 		eventWaitEntries: Omit<EventWaitRowInsert, "signalSequence">[];
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	txRepos: TxRepositories

--- a/sdk/server/src/daemon/imminent-recurring-runs.ts
+++ b/sdk/server/src/daemon/imminent-recurring-runs.ts
@@ -18,7 +18,7 @@ import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-o
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ScheduleOccurrenceUpdate } from "../infra/db/types/schedule";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
 import { runConcurrently } from "../lib/concurrency";
@@ -216,7 +216,7 @@ async function processOverlapAllowSchedules(
 
 	const timersDueSoon: TimerEntry[] = [];
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
@@ -262,7 +262,6 @@ async function processOverlapAllowSchedules(
 				id: stateTransitionId,
 				workflowRunId: runId,
 				type: "workflow_run",
-				status: "queued",
 				attempt: 1,
 				state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 			});
@@ -319,7 +318,7 @@ async function processOverlapAllowSchedules(
 async function insertRecurringRunsInTx(
 	entries: {
 		workflowRunEntries: NonEmptyArray<WorkflowRunRowInsert>;
-		stateTransitionEntries: NonEmptyArray<StateTransitionRowInsert>;
+		stateTransitionEntries: NonEmptyArray<WorkflowRunStateTransitionRowInsert>;
 		scheduleUpdates: NonEmptyArray<ScheduleOccurrenceUpdate>;
 		outboxEntries: NonEmptyArray<WorkflowRunOutboxRowInsertPending>;
 	},
@@ -347,7 +346,7 @@ async function processOverlapSkipSchedules(
 
 	const timersDueSoon: TimerEntry[] = [];
 	const workflowRunEntries: WorkflowRunRowInsert[] = [];
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
@@ -395,7 +394,6 @@ async function processOverlapSkipSchedules(
 			id: stateTransitionId,
 			workflowRunId: runId,
 			type: "workflow_run",
-			status: "queued",
 			attempt: 1,
 			state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 		});
@@ -444,7 +442,7 @@ async function processOverlapSkipSchedules(
 async function insertRunsAndAdvanceSchedulesInTx(
 	entries: {
 		workflowRunEntries: WorkflowRunRowInsert[];
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		scheduleUpdates: NonEmptyArray<ScheduleOccurrenceUpdate>;
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
@@ -490,7 +488,7 @@ async function processOverlapCancelPreviousSchedules(
 
 	const timersDueSoon: TimerEntry[] = [];
 	const newWorkflowRunEntries: WorkflowRunRowInsert[] = [];
-	const newRunStateTransitionEntries: StateTransitionRowInsert[] = [];
+	const newRunStateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const newOutboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
 	const scheduleUpdates: ScheduleOccurrenceUpdate[] = [];
 
@@ -539,7 +537,6 @@ async function processOverlapCancelPreviousSchedules(
 			id: stateTransitionId,
 			workflowRunId: runId,
 			type: "workflow_run",
-			status: "queued",
 			attempt: 1,
 			state: { status: "queued", reason: "new" } satisfies WorkflowRunStateQueued,
 		});
@@ -607,7 +604,7 @@ async function cancelPreviousAndInsertRunsInTx(
 		runIdsToCancel: string[];
 		runsToCancel: Array<{ id: string; attempts: number; namespaceId: NamespaceId; pool?: string; priority?: number }>;
 		newWorkflowRunEntries: NonEmptyArray<WorkflowRunRowInsert>;
-		newRunStateTransitionEntries: NonEmptyArray<StateTransitionRowInsert>;
+		newRunStateTransitionEntries: NonEmptyArray<WorkflowRunStateTransitionRowInsert>;
 		scheduleUpdates: NonEmptyArray<ScheduleOccurrenceUpdate>;
 		newOutboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
@@ -638,7 +635,7 @@ async function cancelPreviousAndInsertRunsInTx(
 		await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now);
 		await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
-		const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
+		const cancelStateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 		const cancelledRunStateTransitionIdUpdates: {
 			filter: { namespaceId: NamespaceId; id: string };
 			update: { stateTransitionId: string };
@@ -657,7 +654,6 @@ async function cancelPreviousAndInsertRunsInTx(
 				id: stateTransitionId,
 				workflowRunId: run.id,
 				type: "workflow_run",
-				status: "cancelled",
 				attempt: run.attempts,
 				state: { status: "cancelled", explanation: "Schedule overlap policy" } satisfies WorkflowRunStateCancelled,
 			});

--- a/sdk/server/src/daemon/imminent-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-retryable-runs.ts
@@ -9,7 +9,7 @@ import { ulid } from "ulidx";
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -91,7 +91,7 @@ async function processChunk(
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -108,7 +108,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts + 1,
 			state,
 		});
@@ -156,7 +155,7 @@ async function transitionToQueuedInTx(
 			filter: { id: string; revision: number };
 			update: { stateTransitionId: string };
 		}>;
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	txRepos: TxRepositories

--- a/sdk/server/src/daemon/imminent-scheduled-runs.ts
+++ b/sdk/server/src/daemon/imminent-scheduled-runs.ts
@@ -9,7 +9,7 @@ import { ulid } from "ulidx";
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -102,7 +102,7 @@ async function processChunk(
 	stateTransitionsById: Map<string, { id: string; state: unknown }>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -128,7 +128,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts,
 			state: toState,
 		});
@@ -175,7 +174,7 @@ async function transitionToQueuedInTx(
 			filter: { id: string; revision: number };
 			update: { stateTransitionId: string };
 		}>;
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	txRepos: TxRepositories

--- a/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
+++ b/sdk/server/src/daemon/imminent-sleep-elapsed-runs.ts
@@ -8,7 +8,7 @@ import { ulid } from "ulidx";
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -91,7 +91,7 @@ async function processChunk(
 ): Promise<void> {
 	const completedAt = Date.now() as TimestampMs;
 
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -108,7 +108,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts,
 			state,
 		});
@@ -155,7 +154,7 @@ async function transitionToQueuedInTx(
 			filter: { id: string; revision: number };
 			update: { stateTransitionId: string };
 		}>;
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	completedAt: TimestampMs,

--- a/sdk/server/src/daemon/imminent-task-retryable-runs.ts
+++ b/sdk/server/src/daemon/imminent-task-retryable-runs.ts
@@ -9,7 +9,7 @@ import { ulid } from "ulidx";
 import { publishOutboxEntries, type RepublishBackoff } from "./publish-pending-outbox-entries";
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowRow } from "../infra/db/types/workflow";
 import type { WorkflowRunMeta } from "../infra/db/types/workflow-run";
 import type { WorkflowRunOutboxRowInsertPending } from "../infra/db/types/workflow-run-outbox";
@@ -90,7 +90,7 @@ async function processChunk(
 	runs: NonEmptyArray<Ranked<WorkflowRunMeta>>,
 	workflowsById: Map<string, WorkflowRow>
 ): Promise<void> {
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const workflowRunUpdates: Array<{ filter: { id: string; revision: number }; update: { stateTransitionId: string } }> =
 		[];
 	const outboxEntries: WorkflowRunOutboxRowInsertPending[] = [];
@@ -107,7 +107,6 @@ async function processChunk(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "queued",
 			attempt: run.attempts,
 			state,
 		});
@@ -155,7 +154,7 @@ async function transitionToQueuedInTx(
 			filter: { id: string; revision: number };
 			update: { stateTransitionId: string };
 		}>;
-		stateTransitionEntries: StateTransitionRowInsert[];
+		stateTransitionEntries: WorkflowRunStateTransitionRowInsert[];
 		outboxEntries: WorkflowRunOutboxRowInsertPending[];
 	},
 	txRepos: TxRepositories

--- a/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
+++ b/sdk/server/src/daemon/recover-overdue-outbox-entries.ts
@@ -7,7 +7,7 @@ import { ulid } from "ulidx";
 
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import { runConcurrently } from "../lib/concurrency";
 import { createKeysetStreamCursorAdvancer } from "../lib/keyset-stream";
 import type { DaemonContext } from "../middleware/context";
@@ -100,7 +100,7 @@ async function releaseStaleClaimsInTx(
 	const releasedRuns = await txRepos.workflowRun.bulkReleaseToQueued(context, params.runIds);
 
 	if (isNonEmptyArray(releasedRuns)) {
-		const stateTransitionEntries: StateTransitionRowInsert[] = [];
+		const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 		const stateTransitionUpdates: {
 			filter: { namespaceId: NamespaceId; id: string };
 			update: { stateTransitionId: string };
@@ -112,7 +112,6 @@ async function releaseStaleClaimsInTx(
 				id: stateTransitionId,
 				workflowRunId: run.id,
 				type: "workflow_run",
-				status: "queued",
 				attempt: run.attempts,
 				state: { status: "queued", reason: "recovery" } satisfies WorkflowRunStateQueued,
 			});

--- a/sdk/server/src/daemon/stall-undeliverable-runs.ts
+++ b/sdk/server/src/daemon/stall-undeliverable-runs.ts
@@ -6,7 +6,7 @@ import { ulid } from "ulidx";
 
 import type { PageProcessingConfig } from "../config/runtime";
 import type { Repositories, TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import { runConcurrently } from "../lib/concurrency";
 import { ulidUpperBound } from "../lib/ulid";
 import type { DaemonContext } from "../middleware/context";
@@ -59,7 +59,7 @@ async function stallByRunIdsInTx(context: DaemonContext, runIds: NonEmptyArray<s
 
 	await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(stalledRunIds);
 
-	const stallStateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stallStateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const stalledRunStateTransitionUpdates: {
 		filter: { namespaceId: NamespaceId; id: string };
 		update: { stateTransitionId: string };
@@ -71,7 +71,6 @@ async function stallByRunIdsInTx(context: DaemonContext, runIds: NonEmptyArray<s
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "stalled",
 			attempt: run.attempts,
 			state: { status: "stalled" } satisfies WorkflowRunStateStalled,
 		});

--- a/sdk/server/src/errors.ts
+++ b/sdk/server/src/errors.ts
@@ -1,4 +1,5 @@
 import { AikiError } from "@aikirun/lib/error";
+import type { ScheduleStatus } from "@aikirun/types/schedule";
 import type { WorkflowName, WorkflowVersionId } from "@aikirun/types/workflow";
 import type { TerminalWorkflowRunStatus, WorkflowRunId, WorkflowRunStatus } from "@aikirun/types/workflow/run";
 import type { TaskId, TaskName, TaskStatus } from "@aikirun/types/workflow/task";
@@ -36,6 +37,23 @@ export class InvalidWorkflowRunStateTransitionError extends AikiError {
 		this.from = from;
 		this.to = to;
 		this.reason = reason;
+	}
+}
+
+export class InvalidScheduleStateTransitionError extends AikiError {
+	readonly code = "BAD_REQUEST";
+	readonly status = 400;
+
+	public readonly scheduleId: string;
+	public readonly from: ScheduleStatus;
+	public readonly to: ScheduleStatus;
+
+	constructor(scheduleId: string, from: ScheduleStatus, to: ScheduleStatus) {
+		super(`Cannot transition schedule ${scheduleId} from ${from} to ${to}`);
+		this.name = "InvalidScheduleStateTransitionError";
+		this.scheduleId = scheduleId;
+		this.from = from;
+		this.to = to;
 	}
 }
 

--- a/sdk/server/src/infra/db/constants/state-transition.ts
+++ b/sdk/server/src/infra/db/constants/state-transition.ts
@@ -1,2 +1,2 @@
-export const STATE_TRANSITION_TYPES = ["workflow_run", "task"] as const;
+export const STATE_TRANSITION_TYPES = ["workflow_run", "task", "schedule"] as const;
 export type StateTransitionType = (typeof STATE_TRANSITION_TYPES)[number];

--- a/sdk/server/src/infra/db/pg/migration/0039_rare_wrecker.sql
+++ b/sdk/server/src/infra/db/pg/migration/0039_rare_wrecker.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."state_transition_type" ADD VALUE 'schedule';

--- a/sdk/server/src/infra/db/pg/migration/0040_lazy_mordo.sql
+++ b/sdk/server/src/infra/db/pg/migration/0040_lazy_mordo.sql
@@ -1,0 +1,49 @@
+ALTER TABLE "state_transition" DROP CONSTRAINT "chk_task_state_transition_requires_task_id";--> statement-breakpoint
+ALTER TABLE "state_transition" DROP CONSTRAINT "chk_state_transition_status_matches_type";--> statement-breakpoint
+DROP INDEX "idx_state_transition_workflow_run_id";--> statement-breakpoint
+ALTER TABLE "state_transition" ALTER COLUMN "workflow_run_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "state_transition" drop column "status";--> statement-breakpoint
+ALTER TABLE "state_transition" ADD COLUMN "status" text GENERATED ALWAYS AS ("state_transition"."state"->>'status') STORED NOT NULL;--> statement-breakpoint
+ALTER TABLE "state_transition" ALTER COLUMN "attempt" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "schedule" ADD COLUMN "latest_state_transition_id" text;--> statement-breakpoint
+ALTER TABLE "state_transition" ADD COLUMN "schedule_id" text;--> statement-breakpoint
+ALTER TABLE "state_transition" ADD CONSTRAINT "fk_state_transition_schedule" FOREIGN KEY ("schedule_id") REFERENCES "public"."schedule"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_state_transition_schedule_id" ON "state_transition" USING btree ("schedule_id","id") WHERE "state_transition"."schedule_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_state_transition_workflow_run_id" ON "state_transition" USING btree ("workflow_run_id","id") WHERE "state_transition"."workflow_run_id" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "state_transition" ADD CONSTRAINT "chk_state_transition_columns_match_type" CHECK (("state_transition"."type" = 'workflow_run' AND "state_transition"."workflow_run_id" IS NOT NULL AND "state_transition"."attempt" IS NOT NULL AND "state_transition"."task_id" IS NULL AND "state_transition"."schedule_id" IS NULL) OR ("state_transition"."type" = 'task' AND "state_transition"."workflow_run_id" IS NOT NULL AND "state_transition"."attempt" IS NOT NULL AND "state_transition"."task_id" IS NOT NULL AND "state_transition"."schedule_id" IS NULL) OR ("state_transition"."type" = 'schedule' AND "state_transition"."schedule_id" IS NOT NULL AND "state_transition"."workflow_run_id" IS NULL AND "state_transition"."attempt" IS NULL AND "state_transition"."task_id" IS NULL));--> statement-breakpoint
+ALTER TABLE "state_transition" ADD CONSTRAINT "chk_state_transition_status_matches_type" CHECK (("state_transition"."type" = 'workflow_run' AND "state_transition"."status" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR ("state_transition"."type" = 'task' AND "state_transition"."status" = ANY(enum_range(NULL::task_status)::text[])) OR ("state_transition"."type" = 'schedule' AND "state_transition"."status" = ANY(enum_range(NULL::schedule_status)::text[])));--> statement-breakpoint
+CREATE FUNCTION pg_temp.ulid_at(ts timestamptz) RETURNS text AS $$
+DECLARE
+	alphabet text := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+	ms bigint := floor(extract(epoch from ts) * 1000)::bigint;
+	result text := '';
+	i int;
+BEGIN
+	FOR i IN REVERSE 9..0 LOOP
+		result := result || substr(alphabet, ((ms >> (5 * i)) & 31)::int + 1, 1);
+	END LOOP;
+	FOR i IN 1..16 LOOP
+		result := result || substr(alphabet, floor(random() * 32)::int + 1, 1);
+	END LOOP;
+	RETURN result;
+END $$ LANGUAGE plpgsql VOLATILE;--> statement-breakpoint
+WITH minted AS (
+	SELECT id AS schedule_id, status, updated_at, pg_temp.ulid_at(updated_at) AS transition_id
+	FROM "schedule"
+	WHERE latest_state_transition_id IS NULL
+), inserted AS (
+	INSERT INTO "state_transition" (id, type, schedule_id, state, created_at)
+	SELECT
+		transition_id,
+		'schedule',
+		schedule_id,
+		CASE status
+			WHEN 'active' THEN jsonb_build_object('status', 'active', 'reason', 'activated')
+			ELSE jsonb_build_object('status', status::text)
+		END,
+		updated_at
+	FROM minted
+	RETURNING id
+)
+UPDATE "schedule" SET latest_state_transition_id = minted.transition_id FROM minted WHERE "schedule".id = minted.schedule_id;--> statement-breakpoint
+ALTER TABLE "schedule" ALTER COLUMN "latest_state_transition_id" SET NOT NULL;

--- a/sdk/server/src/infra/db/pg/migration/meta/0039_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0039_snapshot.json
@@ -1,0 +1,1823 @@
+{
+	"id": "bf23c9af-d0bf-4305-b14e-983a17a07e1e",
+	"prevId": "9e337477-8eef-4a54-9859-f543edbf068d",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_signal_sequence_id": {
+					"name": "idx_event_wait_workflow_run_signal_sequence_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "signal_sequence",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				},
+				"chk_event_wait_timeout_not_codec_applied": {
+					"name": "chk_event_wait_timeout_not_codec_applied",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"client_codec_applied\" = false"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_due_active": {
+					"name": "idx_schedule_due_active",
+					"columns": [
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"schedule\".\"status\" = 'active'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_task_state_transition_requires_task_id": {
+					"name": "chk_task_state_transition_requires_task_id",
+					"value": "(\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"task_id\" IS NOT NULL) OR (\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"workflow_run\".\"reference_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"schedule_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"parent_workflow_run_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_scheduled": {
+					"name": "idx_workflow_run_due_scheduled",
+					"columns": [
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'scheduled'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_sleeping": {
+					"name": "idx_workflow_run_due_sleeping",
+					"columns": [
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_event": {
+					"name": "idx_workflow_run_due_awaiting_event",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_event'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_child_workflow": {
+					"name": "idx_workflow_run_due_awaiting_child_workflow",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_child_workflow'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_retry": {
+					"name": "idx_workflow_run_due_awaiting_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_task_retry": {
+					"name": "idx_workflow_run_due_awaiting_task_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_task_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task", "schedule"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_task_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/0040_snapshot.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/0040_snapshot.json
@@ -1,0 +1,1871 @@
+{
+	"id": "01bc9666-1423-45d2-a877-972b4db1a1c5",
+	"prevId": "bf23c9af-d0bf-4305-b14e-983a17a07e1e",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.child_workflow_run_wait": {
+			"name": "child_workflow_run_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_id": {
+					"name": "child_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"child_workflow_run_status": {
+					"name": "child_workflow_run_status",
+					"type": "terminal_workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "child_workflow_run_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"child_workflow_run_state_transition_id": {
+					"name": "child_workflow_run_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_child_workflow_run_wait_parent_id": {
+					"name": "idx_child_workflow_run_wait_parent_id",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_child_workflow_run_wait_parent": {
+					"name": "fk_child_workflow_run_wait_parent",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_child": {
+					"name": "fk_child_workflow_run_wait_child",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["child_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_child_workflow_run_wait_state_transition": {
+					"name": "fk_child_workflow_run_wait_state_transition",
+					"tableFrom": "child_workflow_run_wait",
+					"tableTo": "state_transition",
+					"columnsFrom": ["child_workflow_run_state_transition_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_child_workflow_run_wait_completed_invariants": {
+					"name": "chk_child_workflow_run_wait_completed_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'completed' OR (\"child_workflow_run_wait\".\"completed_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NOT NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NOT NULL)"
+				},
+				"chk_child_workflow_run_wait_timeout_invariants": {
+					"name": "chk_child_workflow_run_wait_timeout_invariants",
+					"value": "\"child_workflow_run_wait\".\"status\" != 'timeout' OR (\"child_workflow_run_wait\".\"timed_out_at\" IS NOT NULL AND \"child_workflow_run_wait\".\"child_workflow_run_status\" IS NULL AND \"child_workflow_run_wait\".\"child_workflow_run_state_transition_id\" IS NULL AND \"child_workflow_run_wait\".\"signal_sequence\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.event_wait": {
+			"name": "event_wait",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "event_wait_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timed_out_at": {
+					"name": "timed_out_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_event_wait_workflow_run_name_reference": {
+					"name": "uqidx_event_wait_workflow_run_name_reference",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_event_wait_workflow_run_signal_sequence_id": {
+					"name": "idx_event_wait_workflow_run_signal_sequence_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "signal_sequence",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_event_wait_workflow_run": {
+					"name": "fk_event_wait_workflow_run",
+					"tableFrom": "event_wait",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_event_wait_timeout_requires_timed_out_at": {
+					"name": "chk_event_wait_timeout_requires_timed_out_at",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"timed_out_at\" IS NOT NULL"
+				},
+				"chk_event_wait_timeout_not_codec_applied": {
+					"name": "chk_event_wait_timeout_not_codec_applied",
+					"value": "\"event_wait\".\"status\" != 'timeout' OR \"event_wait\".\"client_codec_applied\" = false"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.schedule": {
+			"name": "schedule",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "schedule_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "schedule_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cron_expression": {
+					"name": "cron_expression",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cron_timezone": {
+					"name": "cron_timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_ms": {
+					"name": "interval_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overlap_policy": {
+					"name": "overlap_policy",
+					"type": "schedule_overlap_policy",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input": {
+					"name": "workflow_run_input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_input_hash": {
+					"name": "workflow_run_input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"definition_hash": {
+					"name": "definition_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workflow_run_options": {
+					"name": "workflow_run_options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_occurrence": {
+					"name": "last_occurrence",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_run_at": {
+					"name": "next_run_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_schedule_namespace_definition": {
+					"name": "uqidx_schedule_namespace_definition",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "definition_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"uqidx_schedule_namespace_reference": {
+					"name": "uqidx_schedule_namespace_reference",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_namespace_workflow": {
+					"name": "idx_schedule_namespace_workflow",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_schedule_due_active": {
+					"name": "idx_schedule_due_active",
+					"columns": [
+						{
+							"expression": "next_run_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"schedule\".\"status\" = 'active'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_schedule_workflow_id": {
+					"name": "fk_schedule_workflow_id",
+					"tableFrom": "schedule",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_schedule_spec_matches_type": {
+					"name": "chk_schedule_spec_matches_type",
+					"value": "(\"schedule\".\"type\" = 'cron' AND \"schedule\".\"cron_expression\" IS NOT NULL AND \"schedule\".\"interval_ms\" IS NULL) OR (\"schedule\".\"type\" = 'interval' AND \"schedule\".\"interval_ms\" > 0 AND \"schedule\".\"cron_expression\" IS NULL AND \"schedule\".\"cron_timezone\" IS NULL)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.sleep": {
+			"name": "sleep",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "sleep_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_sleep_one_active_per_run": {
+					"name": "uqidx_sleep_one_active_per_run",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"sleep\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_sleep_workflow_run_id": {
+					"name": "idx_sleep_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_sleep_workflow_run": {
+					"name": "fk_sleep_workflow_run",
+					"tableFrom": "sleep",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_sleep_completed_requires_completed_at": {
+					"name": "chk_sleep_completed_requires_completed_at",
+					"value": "\"sleep\".\"status\" != 'completed' OR \"sleep\".\"completed_at\" IS NOT NULL"
+				},
+				"chk_sleep_cancelled_requires_cancelled_at": {
+					"name": "chk_sleep_cancelled_requires_cancelled_at",
+					"value": "\"sleep\".\"status\" != 'cancelled' OR \"sleep\".\"cancelled_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.state_transition": {
+			"name": "state_transition",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "state_transition_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"task_id": {
+					"name": "task_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"generated": {
+						"as": "\"state_transition\".\"state\"->>'status'",
+						"type": "stored"
+					}
+				},
+				"attempt": {
+					"name": "attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_state_transition_workflow_run_id": {
+					"name": "idx_state_transition_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"state_transition\".\"workflow_run_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_state_transition_schedule_id": {
+					"name": "idx_state_transition_schedule_id",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"state_transition\".\"schedule_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_state_transition_workflow_run": {
+					"name": "fk_state_transition_workflow_run",
+					"tableFrom": "state_transition",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_task": {
+					"name": "fk_state_transition_task",
+					"tableFrom": "state_transition",
+					"tableTo": "task",
+					"columnsFrom": ["task_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_state_transition_schedule": {
+					"name": "fk_state_transition_schedule",
+					"tableFrom": "state_transition",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_state_transition_columns_match_type": {
+					"name": "chk_state_transition_columns_match_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"workflow_run_id\" IS NOT NULL AND \"state_transition\".\"attempt\" IS NOT NULL AND \"state_transition\".\"task_id\" IS NULL AND \"state_transition\".\"schedule_id\" IS NULL) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"workflow_run_id\" IS NOT NULL AND \"state_transition\".\"attempt\" IS NOT NULL AND \"state_transition\".\"task_id\" IS NOT NULL AND \"state_transition\".\"schedule_id\" IS NULL) OR (\"state_transition\".\"type\" = 'schedule' AND \"state_transition\".\"schedule_id\" IS NOT NULL AND \"state_transition\".\"workflow_run_id\" IS NULL AND \"state_transition\".\"attempt\" IS NULL AND \"state_transition\".\"task_id\" IS NULL)"
+				},
+				"chk_state_transition_status_matches_type": {
+					"name": "chk_state_transition_status_matches_type",
+					"value": "(\"state_transition\".\"type\" = 'workflow_run' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (\"state_transition\".\"type\" = 'task' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::task_status)::text[])) OR (\"state_transition\".\"type\" = 'schedule' AND \"state_transition\".\"status\" = ANY(enum_range(NULL::schedule_status)::text[]))"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.task": {
+			"name": "task",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "task_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"idx_task_workflow_run_id": {
+					"name": "idx_task_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_task_workflow_run_status": {
+					"name": "idx_task_workflow_run_status",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_task_workflow_run": {
+					"name": "fk_task_workflow_run",
+					"tableFrom": "task",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow": {
+			"name": "workflow",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version_id": {
+					"name": "version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_namespace_source_name_version": {
+					"name": "uqidx_workflow_namespace_source_name_version",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run": {
+			"name": "workflow_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_id": {
+					"name": "workflow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_workflow_run_id": {
+					"name": "parent_workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_hasher_applied": {
+					"name": "client_hasher_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_codec_applied": {
+					"name": "client_codec_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revision": {
+					"name": "revision",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"signal_sequence": {
+					"name": "signal_sequence",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempts": {
+					"name": "attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"input": {
+					"name": "input",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"input_hash": {
+					"name": "input_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"latest_state_transition_id": {
+					"name": "latest_state_transition_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scheduled_at": {
+					"name": "scheduled_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"wakeup_at": {
+					"name": "wakeup_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timeout_at": {
+					"name": "timeout_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_attempt_at": {
+					"name": "next_attempt_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_workflow_reference": {
+					"name": "uqidx_workflow_run_workflow_reference",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reference_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"workflow_run\".\"reference_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_id": {
+					"name": "idx_workflow_run_namespace_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_namespace_status_id": {
+					"name": "idx_workflow_run_namespace_status_id",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_id": {
+					"name": "idx_workflow_run_workflow_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_workflow_status_id": {
+					"name": "idx_workflow_run_workflow_status_id",
+					"columns": [
+						{
+							"expression": "workflow_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_schedule_namespace": {
+					"name": "idx_workflow_run_schedule_namespace",
+					"columns": [
+						{
+							"expression": "schedule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"schedule_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_parent_workflow_run_status": {
+					"name": "idx_workflow_run_parent_workflow_run_status",
+					"columns": [
+						{
+							"expression": "parent_workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"parent_workflow_run_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_scheduled": {
+					"name": "idx_workflow_run_due_scheduled",
+					"columns": [
+						{
+							"expression": "scheduled_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'scheduled'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_sleeping": {
+					"name": "idx_workflow_run_due_sleeping",
+					"columns": [
+						{
+							"expression": "wakeup_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'sleeping'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_event": {
+					"name": "idx_workflow_run_due_awaiting_event",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_event'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_child_workflow": {
+					"name": "idx_workflow_run_due_awaiting_child_workflow",
+					"columns": [
+						{
+							"expression": "timeout_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_child_workflow'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_retry": {
+					"name": "idx_workflow_run_due_awaiting_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_due_awaiting_task_retry": {
+					"name": "idx_workflow_run_due_awaiting_task_retry",
+					"columns": [
+						{
+							"expression": "next_attempt_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run\".\"status\" = 'awaiting_task_retry'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"fk_workflow_run_workflow_id": {
+					"name": "fk_workflow_run_workflow_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow",
+					"columnsFrom": ["workflow_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_schedule_id": {
+					"name": "fk_workflow_run_schedule_id",
+					"tableFrom": "workflow_run",
+					"tableTo": "schedule",
+					"columnsFrom": ["schedule_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"fk_workflow_run_parent_workflow_run": {
+					"name": "fk_workflow_run_parent_workflow_run",
+					"tableFrom": "workflow_run",
+					"tableTo": "workflow_run",
+					"columnsFrom": ["parent_workflow_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workflow_run_outbox": {
+			"name": "workflow_run_outbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"namespace_id": {
+					"name": "namespace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_run_id": {
+					"name": "workflow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_source": {
+					"name": "workflow_source",
+					"type": "workflow_source",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_name": {
+					"name": "workflow_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workflow_version_id": {
+					"name": "workflow_version_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pool": {
+					"name": "pool",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "workflow_run_outbox_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_published_at": {
+					"name": "first_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_published_at": {
+					"name": "last_published_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_publish_attempt_rank": {
+					"name": "next_publish_attempt_rank",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dispatch_attempts": {
+					"name": "dispatch_attempts",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"uqidx_workflow_run_outbox_workflow_run_id": {
+					"name": "uqidx_workflow_run_outbox_workflow_run_id",
+					"columns": [
+						{
+							"expression": "workflow_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_claim_pending": {
+					"name": "idx_workflow_run_outbox_claim_pending",
+					"columns": [
+						{
+							"expression": "namespace_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_source",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "workflow_version_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "pool",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_pending": {
+					"name": "idx_workflow_run_outbox_list_pending",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'pending'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_published": {
+					"name": "idx_workflow_run_outbox_list_published",
+					"columns": [
+						{
+							"expression": "next_publish_attempt_rank",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'published'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_list_claimed": {
+					"name": "idx_workflow_run_outbox_list_claimed",
+					"columns": [
+						{
+							"expression": "claimed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" = 'claimed'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_workflow_run_outbox_stall_undeliverable": {
+					"name": "idx_workflow_run_outbox_stall_undeliverable",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"workflow_run_outbox\".\"status\" IN ('pending', 'published')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {
+				"chk_workflow_run_outbox_published_requires_first_published_at": {
+					"name": "chk_workflow_run_outbox_published_requires_first_published_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'published' OR \"workflow_run_outbox\".\"first_published_at\" IS NOT NULL"
+				},
+				"chk_workflow_run_outbox_claimed_requires_claimed_at": {
+					"name": "chk_workflow_run_outbox_claimed_requires_claimed_at",
+					"value": "\"workflow_run_outbox\".\"status\" != 'claimed' OR \"workflow_run_outbox\".\"claimed_at\" IS NOT NULL"
+				}
+			},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.child_workflow_run_wait_status": {
+			"name": "child_workflow_run_wait_status",
+			"schema": "public",
+			"values": ["completed", "timeout"]
+		},
+		"public.event_wait_status": {
+			"name": "event_wait_status",
+			"schema": "public",
+			"values": ["received", "timeout"]
+		},
+		"public.schedule_overlap_policy": {
+			"name": "schedule_overlap_policy",
+			"schema": "public",
+			"values": ["allow", "skip", "cancel_previous"]
+		},
+		"public.schedule_status": {
+			"name": "schedule_status",
+			"schema": "public",
+			"values": ["active", "paused", "inactive"]
+		},
+		"public.schedule_type": {
+			"name": "schedule_type",
+			"schema": "public",
+			"values": ["cron", "interval"]
+		},
+		"public.sleep_status": {
+			"name": "sleep_status",
+			"schema": "public",
+			"values": ["sleeping", "completed", "cancelled"]
+		},
+		"public.state_transition_type": {
+			"name": "state_transition_type",
+			"schema": "public",
+			"values": ["workflow_run", "task", "schedule"]
+		},
+		"public.task_status": {
+			"name": "task_status",
+			"schema": "public",
+			"values": ["running", "awaiting_retry", "completed", "failed", "discarded"]
+		},
+		"public.terminal_workflow_run_status": {
+			"name": "terminal_workflow_run_status",
+			"schema": "public",
+			"values": ["cancelled", "completed", "failed"]
+		},
+		"public.workflow_run_outbox_status": {
+			"name": "workflow_run_outbox_status",
+			"schema": "public",
+			"values": ["pending", "published", "claimed"]
+		},
+		"public.workflow_run_status": {
+			"name": "workflow_run_status",
+			"schema": "public",
+			"values": [
+				"scheduled",
+				"queued",
+				"running",
+				"paused",
+				"sleeping",
+				"awaiting_event",
+				"awaiting_retry",
+				"awaiting_task_retry",
+				"awaiting_child_workflow",
+				"stalled",
+				"cancelled",
+				"completed",
+				"failed"
+			]
+		},
+		"public.workflow_source": {
+			"name": "workflow_source",
+			"schema": "public",
+			"values": ["user", "system"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/sdk/server/src/infra/db/pg/migration/meta/_journal.json
+++ b/sdk/server/src/infra/db/pg/migration/meta/_journal.json
@@ -267,6 +267,20 @@
 			"when": 1788783986246,
 			"tag": "0038_wet_gorgon",
 			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1788821221790,
+			"tag": "0039_rare_wrecker",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1788821222107,
+			"tag": "0040_lazy_mordo",
+			"breakpoints": true
 		}
 	]
 }

--- a/sdk/server/src/infra/db/pg/repository/schedule.ts
+++ b/sdk/server/src/infra/db/pg/repository/schedule.ts
@@ -12,10 +12,11 @@ import { schedule, workflow } from "../schema";
 
 export type ScheduleRow = typeof schedule.$inferSelect;
 type ScheduleRowInsert = typeof schedule.$inferInsert;
-type ScheduleRowUpdate = Partial<
+export type ScheduleRowUpdate = Partial<
 	Pick<
 		ScheduleRowInsert,
 		| "status"
+		| "latestStateTransitionId"
 		| "referenceId"
 		| "workflowRunInput"
 		| "workflowRunInputHash"
@@ -95,7 +96,8 @@ export const createScheduleRepository = (db: PgDb) => ({
 
 	async get(
 		namespaceId: NamespaceId,
-		filter: { id?: string; definitionHashes?: string[]; referenceId?: string | null }
+		filter: { id?: string; definitionHashes?: string[]; referenceId?: string | null },
+		options?: { lock?: "update" }
 	): Promise<ScheduleRow | null> {
 		const conditions = [eq(schedule.namespaceId, namespaceId)];
 
@@ -113,12 +115,13 @@ export const createScheduleRepository = (db: PgDb) => ({
 			}
 		}
 
-		const result = await db
+		const query = db
 			.select()
 			.from(schedule)
 			.where(and(...conditions))
 			.limit(1);
 
+		const result = options?.lock ? await query.for(options.lock) : await query;
 		return result[0] ?? null;
 	},
 

--- a/sdk/server/src/infra/db/pg/repository/state-transition.ts
+++ b/sdk/server/src/infra/db/pg/repository/state-transition.ts
@@ -1,5 +1,6 @@
 import type { NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { NamespaceId } from "@aikirun/types/namespace";
+import type { ScheduleState } from "@aikirun/types/schedule";
 import { TERMINAL_WORKFLOW_RUN_STATUSES, type WorkflowRunState } from "@aikirun/types/workflow/run";
 import type { TaskState } from "@aikirun/types/workflow/task";
 import { and, count, eq, gt, inArray, sql } from "drizzle-orm";
@@ -8,10 +9,57 @@ import type { PgDb } from "../provider";
 import { stateTransition, workflowRun } from "../schema";
 
 type _StateTransitionRow = typeof stateTransition.$inferSelect;
-export type StateTransitionRow = Omit<_StateTransitionRow, "state"> & {
-	state: WorkflowRunState | TaskState;
+type _StateTransitionRowInsert = typeof stateTransition.$inferInsert;
+type EntityColumn = "type" | "workflowRunId" | "attempt" | "taskId" | "scheduleId" | "state";
+
+export type WorkflowRunStateTransitionRow = Omit<_StateTransitionRow, EntityColumn> & {
+	type: "workflow_run";
+	workflowRunId: string;
+	attempt: number;
+	taskId: null;
+	scheduleId: null;
+	state: WorkflowRunState;
 };
-export type StateTransitionRowInsert = typeof stateTransition.$inferInsert;
+export type TaskStateTransitionRow = Omit<_StateTransitionRow, EntityColumn> & {
+	type: "task";
+	workflowRunId: string;
+	attempt: number;
+	taskId: string;
+	scheduleId: null;
+	state: TaskState;
+};
+export type ScheduleStateTransitionRow = Omit<_StateTransitionRow, EntityColumn> & {
+	type: "schedule";
+	workflowRunId: null;
+	attempt: null;
+	taskId: null;
+	scheduleId: string;
+	state: ScheduleState;
+};
+export type StateTransitionRow = WorkflowRunStateTransitionRow | TaskStateTransitionRow | ScheduleStateTransitionRow;
+
+export type WorkflowRunStateTransitionRowInsert = Omit<_StateTransitionRowInsert, EntityColumn> & {
+	type: "workflow_run";
+	workflowRunId: string;
+	attempt: number;
+	state: WorkflowRunState;
+};
+export type TaskStateTransitionRowInsert = Omit<_StateTransitionRowInsert, EntityColumn> & {
+	type: "task";
+	workflowRunId: string;
+	attempt: number;
+	taskId: string;
+	state: TaskState;
+};
+export type ScheduleStateTransitionRowInsert = Omit<_StateTransitionRowInsert, EntityColumn> & {
+	type: "schedule";
+	scheduleId: string;
+	state: ScheduleState;
+};
+export type StateTransitionRowInsert =
+	| WorkflowRunStateTransitionRowInsert
+	| TaskStateTransitionRowInsert
+	| ScheduleStateTransitionRowInsert;
 
 export const createStateTransitionRepository = (db: PgDb) => ({
 	async append(input: StateTransitionRowInsert): Promise<void> {
@@ -25,12 +73,12 @@ export const createStateTransitionRepository = (db: PgDb) => ({
 	async getById(id: string): Promise<StateTransitionRow | null> {
 		const result = await db.select().from(stateTransition).where(eq(stateTransition.id, id)).limit(1);
 		const row = result[0];
-		return row ? normalizeRow(row) : null;
+		return row ? toStateTransitionRow(row) : null;
 	},
 
 	async getByIds(ids: NonEmptyArray<string>): Promise<StateTransitionRow[]> {
 		const rows = await db.select().from(stateTransition).where(inArray(stateTransition.id, ids));
-		return rows.map(normalizeRow);
+		return rows.map(toStateTransitionRow);
 	},
 
 	async listByRunId(
@@ -38,7 +86,7 @@ export const createStateTransitionRepository = (db: PgDb) => ({
 		limit = 50,
 		offset = 0,
 		sort?: { order: "asc" | "desc" }
-	): Promise<{ rows: StateTransitionRow[]; total: number }> {
+	): Promise<{ rows: Array<WorkflowRunStateTransitionRow | TaskStateTransitionRow>; total: number }> {
 		const sortOrder = sort?.order ?? "desc";
 		const orderBy = sql`${stateTransition.id} ${sql.raw(sortOrder)}`;
 
@@ -53,7 +101,30 @@ export const createStateTransitionRepository = (db: PgDb) => ({
 			db.select({ count: count() }).from(stateTransition).where(eq(stateTransition.workflowRunId, runId)),
 		]);
 
-		return { rows: rows.map(normalizeRow), total: countResult[0]?.count ?? 0 };
+		return { rows: rows.map(toRunOwnedStateTransitionRow), total: countResult[0]?.count ?? 0 };
+	},
+
+	async listByScheduleId(
+		scheduleId: string,
+		limit = 50,
+		offset = 0,
+		sort?: { order: "asc" | "desc" }
+	): Promise<{ rows: ScheduleStateTransitionRow[]; total: number }> {
+		const sortOrder = sort?.order ?? "desc";
+		const orderBy = sql`${stateTransition.id} ${sql.raw(sortOrder)}`;
+
+		const [rows, countResult] = await Promise.all([
+			db
+				.select()
+				.from(stateTransition)
+				.where(eq(stateTransition.scheduleId, scheduleId))
+				.orderBy(orderBy)
+				.limit(limit)
+				.offset(offset),
+			db.select({ count: count() }).from(stateTransition).where(eq(stateTransition.scheduleId, scheduleId)),
+		]);
+
+		return { rows: rows.map(toScheduleStateTransitionRow), total: countResult[0]?.count ?? 0 };
 	},
 
 	async hasTerminated(
@@ -116,7 +187,77 @@ export function toTaskState(raw: unknown): TaskState {
 	return state as unknown as TaskState;
 }
 
-function normalizeRow(row: _StateTransitionRow): StateTransitionRow {
-	(row as Record<string, unknown>).state = row.type === "task" ? toTaskState(row.state) : toWorkflowRunState(row.state);
-	return row as unknown as StateTransitionRow;
+function toStateTransitionRow(row: _StateTransitionRow): StateTransitionRow {
+	const { id, status, createdAt } = row;
+	switch (row.type) {
+		case "workflow_run": {
+			if (row.workflowRunId === null || row.attempt === null || row.taskId !== null || row.scheduleId !== null) {
+				throw new Error(`State transition ${id} has columns that do not match type 'workflow_run'`);
+			}
+			return {
+				id,
+				status,
+				createdAt,
+				type: "workflow_run",
+				workflowRunId: row.workflowRunId,
+				attempt: row.attempt,
+				taskId: null,
+				scheduleId: null,
+				state: toWorkflowRunState(row.state),
+			};
+		}
+		case "task": {
+			if (row.workflowRunId === null || row.attempt === null || row.taskId === null || row.scheduleId !== null) {
+				throw new Error(`State transition ${id} has columns that do not match type 'task'`);
+			}
+			return {
+				id,
+				status,
+				createdAt,
+				type: "task",
+				workflowRunId: row.workflowRunId,
+				attempt: row.attempt,
+				taskId: row.taskId,
+				scheduleId: null,
+				state: toTaskState(row.state),
+			};
+		}
+		case "schedule": {
+			if (row.scheduleId === null || row.workflowRunId !== null || row.attempt !== null || row.taskId !== null) {
+				throw new Error(`State transition ${id} has columns that do not match type 'schedule'`);
+			}
+			return {
+				id,
+				status,
+				createdAt,
+				type: "schedule",
+				workflowRunId: null,
+				attempt: null,
+				taskId: null,
+				scheduleId: row.scheduleId,
+				state: row.state as ScheduleState,
+			};
+		}
+		default: {
+			return row.type satisfies never;
+		}
+	}
+}
+
+function toRunOwnedStateTransitionRow(
+	row: _StateTransitionRow
+): WorkflowRunStateTransitionRow | TaskStateTransitionRow {
+	const narrowed = toStateTransitionRow(row);
+	if (narrowed.type !== "workflow_run" && narrowed.type !== "task") {
+		throw new Error(`State transition ${row.id} doesn't belong to a run`);
+	}
+	return narrowed;
+}
+
+function toScheduleStateTransitionRow(row: _StateTransitionRow): ScheduleStateTransitionRow {
+	const narrowed = toStateTransitionRow(row);
+	if (narrowed.type !== "schedule") {
+		throw new Error(`State transition ${row.id} doesn't belong to a schedule`);
+	}
+	return narrowed;
 }

--- a/sdk/server/src/infra/db/pg/schema.ts
+++ b/sdk/server/src/infra/db/pg/schema.ts
@@ -9,7 +9,7 @@ import {
 	type WorkflowRunOptions,
 } from "@aikirun/types/workflow/run";
 import { TASK_STATUSES, type TaskStartOptions } from "@aikirun/types/workflow/task";
-import { relations, sql } from "drizzle-orm";
+import { relations, type SQL, sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
@@ -99,6 +99,7 @@ export const schedule = pgTable(
 
 		lastOccurrence: timestampMs("last_occurrence"),
 		nextRunAt: timestampMs("next_run_at").notNull(),
+		latestStateTransitionId: text("latest_state_transition_id").notNull(),
 
 		createdAt: timestampMs("created_at").notNull().default(sql`now()`),
 		updatedAt: timestampMs("updated_at").notNull().default(sql`now()`),
@@ -240,11 +241,14 @@ export const stateTransition = pgTable(
 	"state_transition",
 	{
 		id: text("id").primaryKey(),
-		workflowRunId: text("workflow_run_id").notNull(),
+		workflowRunId: text("workflow_run_id"),
 		type: stateTransitionTypeEnum("type").notNull(),
 		taskId: text("task_id"),
-		status: text("status").notNull(),
-		attempt: integer("attempt").notNull(),
+		scheduleId: text("schedule_id"),
+		status: text("status")
+			.notNull()
+			.generatedAlwaysAs((): SQL => sql`${stateTransition.state}->>'status'`),
+		attempt: integer("attempt"),
 		state: jsonb("state").notNull(),
 		createdAt: timestampMs("created_at").notNull().default(sql`now()`),
 	},
@@ -259,14 +263,24 @@ export const stateTransition = pgTable(
 			columns: [table.taskId],
 			foreignColumns: [task.id],
 		}),
-		index("idx_state_transition_workflow_run_id").on(table.workflowRunId, table.id),
+		foreignKey({
+			name: "fk_state_transition_schedule",
+			columns: [table.scheduleId],
+			foreignColumns: [schedule.id],
+		}),
+		index("idx_state_transition_workflow_run_id")
+			.on(table.workflowRunId, table.id)
+			.where(sql`${table.workflowRunId} IS NOT NULL`),
+		index("idx_state_transition_schedule_id")
+			.on(table.scheduleId, table.id)
+			.where(sql`${table.scheduleId} IS NOT NULL`),
 		check(
-			"chk_task_state_transition_requires_task_id",
-			sql`(${table.type} = 'task' AND ${table.taskId} IS NOT NULL) OR (${table.type} = 'workflow_run' AND ${table.taskId} IS NULL)`
+			"chk_state_transition_columns_match_type",
+			sql`(${table.type} = 'workflow_run' AND ${table.workflowRunId} IS NOT NULL AND ${table.attempt} IS NOT NULL AND ${table.taskId} IS NULL AND ${table.scheduleId} IS NULL) OR (${table.type} = 'task' AND ${table.workflowRunId} IS NOT NULL AND ${table.attempt} IS NOT NULL AND ${table.taskId} IS NOT NULL AND ${table.scheduleId} IS NULL) OR (${table.type} = 'schedule' AND ${table.scheduleId} IS NOT NULL AND ${table.workflowRunId} IS NULL AND ${table.attempt} IS NULL AND ${table.taskId} IS NULL)`
 		),
 		check(
 			"chk_state_transition_status_matches_type",
-			sql`(${table.type} = 'workflow_run' AND ${table.status} = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (${table.type} = 'task' AND ${table.status} = ANY(enum_range(NULL::task_status)::text[]))`
+			sql`(${table.type} = 'workflow_run' AND ${table.status} = ANY(enum_range(NULL::workflow_run_status)::text[])) OR (${table.type} = 'task' AND ${table.status} = ANY(enum_range(NULL::task_status)::text[])) OR (${table.type} = 'schedule' AND ${table.status} = ANY(enum_range(NULL::schedule_status)::text[]))`
 		),
 	]
 );

--- a/sdk/server/src/infra/db/types/schedule.ts
+++ b/sdk/server/src/infra/db/types/schedule.ts
@@ -1,1 +1,6 @@
-export type { ScheduleOccurrenceUpdate, ScheduleRepository, ScheduleRow } from "../pg/repository/schedule";
+export type {
+	ScheduleOccurrenceUpdate,
+	ScheduleRepository,
+	ScheduleRow,
+	ScheduleRowUpdate,
+} from "../pg/repository/schedule";

--- a/sdk/server/src/infra/db/types/state-transition.ts
+++ b/sdk/server/src/infra/db/types/state-transition.ts
@@ -1,5 +1,11 @@
 export type {
+	ScheduleStateTransitionRow,
+	ScheduleStateTransitionRowInsert,
 	StateTransitionRepository,
 	StateTransitionRow,
 	StateTransitionRowInsert,
+	TaskStateTransitionRow,
+	TaskStateTransitionRowInsert,
+	WorkflowRunStateTransitionRow,
+	WorkflowRunStateTransitionRowInsert,
 } from "../pg/repository/state-transition";

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -15,7 +15,7 @@ import { ulid } from "ulidx";
 
 import { bulkGetOrCreateWorkflowsInTx } from "./workflow";
 import type { TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { WorkflowIdentity } from "../infra/db/types/workflow";
 import type { WorkflowRunRowInsert } from "../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
@@ -72,7 +72,7 @@ export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimer
 		const inputHashes = await Promise.all(inputHashPromises);
 
 		const workflowRunEntries: WorkflowRunRowInsert[] = [];
-		const stateTransitionEntries: StateTransitionRowInsert[] = [];
+		const stateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 
 		for (const [i, parentRun] of runsHavingChildren.entries()) {
 			const workflow = workflowsByNamespaceId.get(parentRun.namespaceId);
@@ -111,7 +111,6 @@ export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimer
 				id: cancellationRunStateTransitionId,
 				workflowRunId: childrenCancellationRunId,
 				type: "workflow_run",
-				status: "scheduled",
 				attempt: 1,
 				state: {
 					status: "scheduled",

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -11,7 +11,7 @@ import type {
 import { ulid } from "ulidx";
 
 import type { TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 
 export interface TerminatedChildRun {
@@ -83,7 +83,7 @@ export async function deliverTerminatedSignalToParentRun(
 	);
 
 	const childRunIds = new Set<string>(runs.map((childRun) => childRun.id));
-	const parentRunStateTransitionEntries: StateTransitionRowInsert[] = [];
+	const parentRunStateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const parentRunUpdates: {
 		filter: { namespaceId: NamespaceId; id: string; revision: number };
 		update: { stateTransitionId: string };
@@ -104,7 +104,6 @@ export async function deliverTerminatedSignalToParentRun(
 			id: stateTransitionId,
 			workflowRunId: parentRun.id,
 			type: "workflow_run",
-			status: "scheduled",
 			attempt: parentRun.attempts,
 			state: {
 				status: "scheduled",

--- a/sdk/server/src/service/discard-stale-tasks.ts
+++ b/sdk/server/src/service/discard-stale-tasks.ts
@@ -4,7 +4,7 @@ import type { DiscardableTaskStatus, TaskStateDiscarded } from "@aikirun/types/w
 import { ulid } from "ulidx";
 
 import type { TxRepositories } from "../infra/db/types";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { TaskStateTransitionRowInsert } from "../infra/db/types/state-transition";
 
 export async function discardStaleTasks(
 	workflowRunIds: string | NonEmptyArray<string>,
@@ -36,7 +36,7 @@ export async function discardStaleTasks(
 		return;
 	}
 
-	const stateTransitionEntries: StateTransitionRowInsert[] = [];
+	const stateTransitionEntries: TaskStateTransitionRowInsert[] = [];
 
 	for (const discardedTaskId of discardedTaskIds) {
 		const taskUpdate = taskUpdatesById.get(discardedTaskId);
@@ -48,7 +48,6 @@ export async function discardStaleTasks(
 			workflowRunId: taskUpdate.filter.workflowRunId,
 			type: "task",
 			taskId: discardedTaskId,
-			status: "discarded",
 			attempt: taskUpdate.filter.attempts,
 			state: { status: "discarded" } satisfies TaskStateDiscarded,
 		});

--- a/sdk/server/src/service/schedule.integration.test.ts
+++ b/sdk/server/src/service/schedule.integration.test.ts
@@ -1,10 +1,13 @@
+import { createBinaryLatch } from "@aikirun/lib/async";
 import { hashInput } from "@aikirun/lib/crypto";
 import { asOpaquePayload } from "@aikirun/testing/payload";
 
-import { createScheduleService } from "./schedule";
+import { createScheduleService, type ScheduleService } from "./schedule";
 import { describe, expect, test } from "bun:test";
+import { InvalidScheduleStateTransitionError } from "../errors";
+import type { Repositories } from "../infra/db/types";
 import { withFakeClock } from "../testing/clock";
-import { createServiceHarness } from "../testing/harness";
+import { createServiceHarness, withRepos } from "../testing/harness";
 
 const withHarness = createServiceHarness();
 
@@ -546,7 +549,7 @@ describe("ScheduleService activateSchedule under an announced key", () => {
 describe("ScheduleService activateSchedule and the next run", () => {
 	const spec = { type: "interval" as const, everyMs: 60_000 };
 
-	test("reactivating a paused schedule leaves its next run untouched", () =>
+	test("activating a paused schedule again leaves it paused with its next run untouched", () =>
 		withHarness(async ({ context, repos }) => {
 			const scheduleService = createScheduleService({ repos });
 			const workflowRunInput = { region: "eu-west" };
@@ -570,7 +573,7 @@ describe("ScheduleService activateSchedule and the next run", () => {
 
 			expect(reactivated.id).toBe(schedule.id);
 			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
-				expect.objectContaining({ id: schedule.id, status: "active", nextRunAt: schedule.nextRunAt })
+				expect.objectContaining({ id: schedule.id, status: "paused", nextRunAt: schedule.nextRunAt })
 			);
 		}));
 
@@ -608,3 +611,432 @@ describe("ScheduleService activateSchedule and the next run", () => {
 			);
 		}));
 });
+
+describe("ScheduleService status transitions", () => {
+	const spec = { type: "interval" as const, everyMs: 60_000 };
+
+	async function activationRequest() {
+		const workflowRunInput = { region: "eu-west" };
+		return {
+			workflowName: "send-invoices",
+			workflowVersionId: "v1",
+			workflowRunInput: asOpaquePayload(workflowRunInput),
+			workflowRunInputHash: { value: await hashInput(workflowRunInput) },
+			clientHasherApplied: false,
+			clientCodecApplied: false,
+			spec,
+		};
+	}
+
+	test("activating a new schedule writes an activated transition the schedule points at", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, await activationRequest());
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({
+					type: "schedule",
+					scheduleId: schedule.id,
+					status: "active",
+					state: { status: "active", reason: "activated" },
+				}),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ status: "active", latestStateTransitionId: rows[0]?.id })
+			);
+		}));
+
+	test("resuming a paused schedule writes a resumed transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, await activationRequest());
+			await scheduleService.pauseSchedule(context.namespaceId, schedule.id);
+
+			await scheduleService.resumeSchedule(context.namespaceId, schedule.id);
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "resumed" } }),
+				expect.objectContaining({ status: "paused", state: { status: "paused" } }),
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ status: "active", latestStateTransitionId: rows[0]?.id })
+			);
+		}));
+
+	test("deactivating writes an inactive transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, await activationRequest());
+
+			await scheduleService.deactivateSchedule(context.namespaceId, schedule.id);
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({ status: "inactive", state: { status: "inactive" } }),
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ status: "inactive", latestStateTransitionId: rows[0]?.id })
+			);
+		}));
+
+	test("activating a paused schedule again writes nothing", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const request = await activationRequest();
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+			await scheduleService.pauseSchedule(context.namespaceId, schedule.id);
+
+			const { schedule: returned } = await scheduleService.activateSchedule(context.namespaceId, request);
+
+			expect(returned.id).toBe(schedule.id);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+				rows: [
+					expect.objectContaining({ status: "paused", state: { status: "paused" } }),
+					expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+				],
+				total: 2,
+			});
+		}));
+
+	test("activating a deactivated schedule again writes a reactivated transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const request = await activationRequest();
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+			await scheduleService.deactivateSchedule(context.namespaceId, schedule.id);
+
+			const { schedule: reactivated } = await scheduleService.activateSchedule(context.namespaceId, request);
+
+			expect(reactivated.id).toBe(schedule.id);
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "reactivated" } }),
+				expect.objectContaining({ status: "inactive", state: { status: "inactive" } }),
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ status: "active", latestStateTransitionId: rows[0]?.id })
+			);
+		}));
+
+	test("resuming a deactivated schedule is refused", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, await activationRequest());
+			await scheduleService.deactivateSchedule(context.namespaceId, schedule.id);
+
+			expect(scheduleService.resumeSchedule(context.namespaceId, schedule.id)).rejects.toThrow(
+				InvalidScheduleStateTransitionError
+			);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+				rows: [expect.objectContaining({ status: "inactive" }), expect.objectContaining({ status: "active" })],
+				total: 2,
+			});
+		}));
+
+	test("pausing a deactivated schedule is refused", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, await activationRequest());
+			await scheduleService.deactivateSchedule(context.namespaceId, schedule.id);
+
+			expect(scheduleService.pauseSchedule(context.namespaceId, schedule.id)).rejects.toThrow(
+				InvalidScheduleStateTransitionError
+			);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+				rows: [expect.objectContaining({ status: "inactive" }), expect.objectContaining({ status: "active" })],
+				total: 2,
+			});
+		}));
+
+	test("adopting a reference id onto an active schedule writes no transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const request = await activationRequest();
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+
+			await scheduleService.activateSchedule(context.namespaceId, {
+				...request,
+				options: { reference: { id: "invoices-eu-west" } },
+			});
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([expect.objectContaining({ state: { status: "active", reason: "activated" } })]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({ referenceId: "invoices-eu-west", latestStateTransitionId: rows[0]?.id })
+			);
+		}));
+
+	test("adopting a reference id onto a paused schedule renames it and writes nothing", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const request = await activationRequest();
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+			await scheduleService.pauseSchedule(context.namespaceId, schedule.id);
+
+			await scheduleService.activateSchedule(context.namespaceId, {
+				...request,
+				options: { reference: { id: "invoices-eu-west" } },
+			});
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({ status: "paused", state: { status: "paused" } }),
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({
+					status: "paused",
+					referenceId: "invoices-eu-west",
+					latestStateTransitionId: rows[0]?.id,
+				})
+			);
+		}));
+
+	test("adopting a reference id onto a deactivated schedule writes a reactivated transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const scheduleService = createScheduleService({ repos });
+			const request = await activationRequest();
+			const { schedule } = await scheduleService.activateSchedule(context.namespaceId, request);
+			await scheduleService.deactivateSchedule(context.namespaceId, schedule.id);
+
+			await scheduleService.activateSchedule(context.namespaceId, {
+				...request,
+				options: { reference: { id: "invoices-eu-west" } },
+			});
+
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows).toEqual([
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "reactivated" } }),
+				expect.objectContaining({ status: "inactive" }),
+				expect.objectContaining({ status: "active", state: { status: "active", reason: "activated" } }),
+			]);
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+				expect.objectContaining({
+					status: "active",
+					referenceId: "invoices-eu-west",
+					latestStateTransitionId: rows[0]?.id,
+				})
+			);
+		}));
+
+	test("two concurrent pauses write one transition", () =>
+		withHarness(async ({ context, repos }) =>
+			withRepos(async (secondaryRepos) => {
+				const service = createScheduleService({ repos });
+				const { schedule } = await service.activateSchedule(context.namespaceId, await activationRequest());
+
+				await runConcurrentScheduleOperations(
+					repos,
+					secondaryRepos,
+					(primary) => primary.pauseSchedule(context.namespaceId, schedule.id),
+					(secondary) => secondary.pauseSchedule(context.namespaceId, schedule.id)
+				);
+
+				expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+					rows: [
+						expect.objectContaining({ state: { status: "paused" } }),
+						expect.objectContaining({ state: { status: "active", reason: "activated" } }),
+					],
+					total: 2,
+				});
+			})
+		));
+
+	test("a concurrent resume after a repeated pause leaves the schedule active", () =>
+		withHarness(async ({ context, repos }) =>
+			withRepos(async (secondaryRepos) => {
+				const service = createScheduleService({ repos });
+				const { schedule } = await service.activateSchedule(context.namespaceId, await activationRequest());
+				await service.pauseSchedule(context.namespaceId, schedule.id);
+
+				await runConcurrentScheduleOperations(
+					repos,
+					secondaryRepos,
+					(primary) => primary.pauseSchedule(context.namespaceId, schedule.id),
+					(secondary) => secondary.resumeSchedule(context.namespaceId, schedule.id)
+				);
+
+				expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+					expect.objectContaining({ status: "active" })
+				);
+				expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+					rows: [
+						expect.objectContaining({ state: { status: "active", reason: "resumed" } }),
+						expect.objectContaining({ state: { status: "paused" } }),
+						expect.objectContaining({ state: { status: "active", reason: "activated" } }),
+					],
+					total: 3,
+				});
+			})
+		));
+
+	test("reference adoption racing with reactivation returns the same schedule", () =>
+		withHarness(async ({ context, repos }) =>
+			withRepos(async (secondaryRepos) => {
+				const service = createScheduleService({ repos });
+				const request = await activationRequest();
+				const { schedule } = await service.activateSchedule(context.namespaceId, request);
+				await service.deactivateSchedule(context.namespaceId, schedule.id);
+
+				const { schedule: adopted } = await runConcurrentScheduleOperations(
+					repos,
+					secondaryRepos,
+					(primary) => primary.activateSchedule(context.namespaceId, request),
+					(secondary) =>
+						secondary.activateSchedule(context.namespaceId, {
+							...request,
+							options: { reference: { id: "invoices-eu-west" } },
+						})
+				);
+
+				expect(adopted).toEqual(
+					expect.objectContaining({
+						id: schedule.id,
+						status: "active",
+						referenceId: "invoices-eu-west",
+						nextRunAt: schedule.nextRunAt,
+					})
+				);
+				expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual({
+					rows: [
+						expect.objectContaining({ state: { status: "active", reason: "reactivated" } }),
+						expect.objectContaining({ state: { status: "inactive" } }),
+						expect.objectContaining({ state: { status: "active", reason: "activated" } }),
+					],
+					total: 3,
+				});
+			})
+		));
+
+	test("a payload upgrade survives a concurrent reactivation", () =>
+		withHarness(async ({ context, repos }) =>
+			withRepos(async (secondaryRepos) => {
+				const service = createScheduleService({ repos });
+				const request = await activationRequest();
+				const { schedule } = await service.activateSchedule(context.namespaceId, request);
+				await service.deactivateSchedule(context.namespaceId, schedule.id);
+				const nextInput = asOpaquePayload({ encrypted: "rotated-invoices" });
+
+				await runConcurrentScheduleOperations(
+					repos,
+					secondaryRepos,
+					(primary) => primary.activateSchedule(context.namespaceId, request),
+					(secondary) =>
+						secondary.activateSchedule(context.namespaceId, {
+							...request,
+							workflowRunInput: nextInput,
+							workflowRunInputHash: { value: "rotated-hash", deprecatedValues: [request.workflowRunInputHash.value] },
+							clientHasherApplied: true,
+							clientCodecApplied: true,
+						})
+				);
+
+				expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+					expect.objectContaining({
+						status: "active",
+						workflowRunInput: nextInput,
+						workflowRunInputHash: "rotated-hash",
+						clientHasherApplied: true,
+						clientCodecApplied: true,
+					})
+				);
+			})
+		));
+
+	test("an older activation preserves a concurrently upgraded payload", () =>
+		withHarness(async ({ context, repos }) =>
+			withRepos(async (secondaryRepos) => {
+				const service = createScheduleService({ repos });
+				const request = await activationRequest();
+				const { schedule } = await service.activateSchedule(context.namespaceId, request);
+				const nextInput = asOpaquePayload({ encrypted: "rotated-invoices" });
+
+				await runConcurrentScheduleOperations(
+					repos,
+					secondaryRepos,
+					(primary) =>
+						primary.activateSchedule(context.namespaceId, {
+							...request,
+							workflowRunInput: nextInput,
+							workflowRunInputHash: { value: "rotated-hash", deprecatedValues: [request.workflowRunInputHash.value] },
+							clientHasherApplied: true,
+							clientCodecApplied: true,
+						}),
+					(secondary) =>
+						secondary.activateSchedule(context.namespaceId, {
+							...request,
+							workflowRunInput: asOpaquePayload({ encrypted: "older-invoices" }),
+							workflowRunInputHash: { ...request.workflowRunInputHash, nextValue: "rotated-hash" },
+							clientCodecApplied: true,
+						})
+				);
+
+				expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(
+					expect.objectContaining({
+						workflowRunInput: nextInput,
+						workflowRunInputHash: "rotated-hash",
+						clientHasherApplied: true,
+						clientCodecApplied: true,
+					})
+				);
+			})
+		));
+});
+
+async function runConcurrentScheduleOperations<T>(
+	primaryRepos: Repositories,
+	secondaryRepos: Repositories,
+	primaryOperation: (service: ScheduleService) => Promise<unknown>,
+	secondaryOperation: (service: ScheduleService) => Promise<T>
+): Promise<T> {
+	const primaryWritten = createBinaryLatch();
+	const commitPrimary = createBinaryLatch();
+	const secondaryReadStarted = createBinaryLatch();
+	const primaryService = createScheduleService({
+		repos: {
+			...primaryRepos,
+			transaction: (fn) =>
+				primaryRepos.transaction(async (txRepos) => {
+					const result = await fn(txRepos);
+					primaryWritten.signal();
+					await commitPrimary.wait();
+					return result;
+				}),
+		},
+	});
+	const secondaryService = createScheduleService({
+		repos: {
+			...secondaryRepos,
+			transaction: (fn) =>
+				secondaryRepos.transaction((txRepos) =>
+					fn({
+						...txRepos,
+						schedule: {
+							...txRepos.schedule,
+							get: (namespaceId, filter, options) => {
+								const result = txRepos.schedule.get(namespaceId, filter, options);
+								if (filter.id || filter.definitionHashes) {
+									secondaryReadStarted.signal();
+								}
+								return result;
+							},
+						},
+					})
+				),
+		},
+	});
+
+	const primaryPromise = primaryOperation(primaryService);
+	await primaryWritten.wait();
+	const secondaryPromise = secondaryOperation(secondaryService);
+	await secondaryReadStarted.wait();
+	commitPrimary.signal();
+	await primaryPromise;
+	return secondaryPromise;
+}

--- a/sdk/server/src/service/schedule.ts
+++ b/sdk/server/src/service/schedule.ts
@@ -12,6 +12,7 @@ import type { WorkflowRunOptions } from "@aikirun/types/workflow/run";
 import CronExpressionParser from "cron-parser";
 import { ulid } from "ulidx";
 
+import { transitionScheduleInTx, writeScheduleStateInTx } from "./state-machine/schedule";
 import { getOrCreateWorkflowInTx } from "./workflow";
 import { ScheduleConflictError } from "../errors";
 import type { Repositories, TxRepositories } from "../infra/db/types";
@@ -216,24 +217,25 @@ export const createScheduleService = ({ repos }: ScheduleServiceDeps) => ({
 	},
 
 	async pauseSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "paused" });
-		if (!schedule) {
-			throw new NotFoundError(`Schedule not found: ${id}`);
-		}
+		await repos.transaction((txRepos) =>
+			transitionScheduleInTx(txRepos, { namespaceId, id, state: { status: "paused" } })
+		);
 	},
 
 	async resumeSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "active" });
-		if (!schedule) {
-			throw new NotFoundError(`Schedule not found: ${id}`);
-		}
+		await repos.transaction((txRepos) =>
+			transitionScheduleInTx(txRepos, {
+				namespaceId,
+				id,
+				state: { status: "active", reason: "resumed" },
+			})
+		);
 	},
 
 	async deactivateSchedule(namespaceId: NamespaceId, id: string): Promise<void> {
-		const schedule = await repos.schedule.update(namespaceId, { id }, { status: "inactive" });
-		if (!schedule) {
-			throw new NotFoundError(`Schedule not found: ${id}`);
-		}
+		await repos.transaction((txRepos) =>
+			transitionScheduleInTx(txRepos, { namespaceId, id, state: { status: "inactive" } })
+		);
 	},
 });
 
@@ -306,18 +308,20 @@ async function activateScheduleInTx(
 	const nextRunAt = getNextOccurrence(spec, now) as TimestampMs;
 
 	if (!referenceId) {
-		const existingScheduleByDefinition = await txRepos.schedule.get(namespaceId, {
-			definitionHashes: candidateHashes(definitionHashes),
-		});
+		const existingScheduleByDefinition = await txRepos.schedule.get(
+			namespaceId,
+			{ definitionHashes: candidateHashes(definitionHashes) },
+			{ lock: "update" }
+		);
 
 		const schedule = existingScheduleByDefinition
-			? await reuseSchedule(txRepos.schedule, {
+			? await activateExistingSchedule(txRepos, {
 					namespaceId,
 					existing: existingScheduleByDefinition,
 					payload,
 					nextDefinitionHash: definitionHashes.nextValue,
 				})
-			: await createSchedule(txRepos.schedule, {
+			: await createSchedule(txRepos, {
 					namespaceId,
 					workflowId: workflowRow.id,
 					spec,
@@ -330,7 +334,7 @@ async function activateScheduleInTx(
 		return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 	}
 
-	const existingScheduleByReference = await txRepos.schedule.get(namespaceId, { referenceId });
+	const existingScheduleByReference = await txRepos.schedule.get(namespaceId, { referenceId }, { lock: "update" });
 	if (existingScheduleByReference) {
 		if (!candidateHashes(definitionHashes).includes(existingScheduleByReference.definitionHash)) {
 			if (conflictPolicy === "error") {
@@ -340,7 +344,7 @@ async function activateScheduleInTx(
 			return { schedule: scheduleRowToDomain(existingScheduleByReference, workflowInfo) };
 		}
 
-		const schedule = await reuseSchedule(txRepos.schedule, {
+		const schedule = await activateExistingSchedule(txRepos, {
 			namespaceId,
 			existing: existingScheduleByReference,
 			payload,
@@ -351,38 +355,24 @@ async function activateScheduleInTx(
 	}
 
 	// Reference id is free, but the definition may already exist.
-	const existingNonReferencedSchedule = await txRepos.schedule.get(namespaceId, {
-		definitionHashes: candidateHashes(definitionHashes),
-		referenceId: null,
-	});
+	const existingNonReferencedSchedule = await txRepos.schedule.get(
+		namespaceId,
+		{ definitionHashes: candidateHashes(definitionHashes), referenceId: null },
+		{ lock: "update" }
+	);
 
 	if (existingNonReferencedSchedule) {
-		const updates: Partial<SchedulePayload> & { referenceId: string; status: "active" } = {
-			referenceId,
-			status: "active",
-		};
-		// Matching the request's next hash means the stored schedule was written by a client that
-		// has already switched to the rotation this request has only been told about. The stored
-		// payload is the newer one, so it stays.
-		if (existingNonReferencedSchedule.definitionHash !== definitionHashes.nextValue) {
-			updates.workflowRunInput = payload.workflowRunInput;
-			updates.workflowRunInputHash = payload.workflowRunInputHash;
-			updates.clientHasherApplied = payload.clientHasherApplied;
-			updates.clientCodecApplied = payload.clientCodecApplied;
-			updates.definitionHash = payload.definitionHash;
-		}
-		const schedule = await txRepos.schedule.update(
+		const schedule = await activateExistingSchedule(txRepos, {
 			namespaceId,
-			{ id: existingNonReferencedSchedule.id, referenceId: null },
-			updates
-		);
-
-		if (schedule) {
-			return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
-		}
+			existing: existingNonReferencedSchedule,
+			payload,
+			nextDefinitionHash: definitionHashes.nextValue,
+			referenceIdToAttach: referenceId,
+		});
+		return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 	}
 
-	const schedule = await createSchedule(txRepos.schedule, {
+	const schedule = await createSchedule(txRepos, {
 		namespaceId,
 		workflowId: workflowRow.id,
 		spec,
@@ -395,40 +385,45 @@ async function activateScheduleInTx(
 	return { schedule: scheduleRowToDomain(schedule, workflowInfo) };
 }
 
-async function reuseSchedule(
-	repo: Repositories["schedule"],
+async function activateExistingSchedule(
+	txRepos: TxRepositories,
 	params: {
 		namespaceId: NamespaceId;
 		existing: ScheduleRow;
 		payload: SchedulePayload;
 		nextDefinitionHash: string | undefined;
+		referenceIdToAttach?: string;
 	}
 ): Promise<ScheduleRow> {
+	// Callers lock the matching schedule before entering this function. A reference is supplied
+	// only after the locked lookup confirmed the schedule has none, so attaching it cannot
+	// overwrite a reference assigned by another activation.
 	const { existing, payload } = params;
-	const needsActivation = existing.status !== "active";
-	// Matching the request's next hash means the stored schedule was written by a client that has
-	// already switched to the rotation this request has only been told about. The stored payload
-	// is the newer one, so it stays. The stored input itself is never compared: a codec may encode
-	// the same input differently each time, and an unchanged hash and declaration mean the stored
-	// value still decodes.
-	const payloadChanged =
+	// A paused schedule stays paused: only `resume` ends a pause.
+	const needsReactivation = existing.status === "inactive";
+
+	// The announced next hash identifies a newer stored payload that this client must preserve.
+	// Otherwise, attaching a reference records the activating client's payload. Repeated
+	// activation without attachment keeps equivalent input: a randomized codec can produce
+	// different bytes for the same input, so hashes and declarations decide whether to write.
+	const shouldWritePayload =
 		existing.definitionHash !== params.nextDefinitionHash &&
-		(existing.workflowRunInputHash !== payload.workflowRunInputHash ||
+		(params.referenceIdToAttach !== undefined ||
+			existing.workflowRunInputHash !== payload.workflowRunInputHash ||
 			existing.definitionHash !== payload.definitionHash ||
 			existing.clientHasherApplied !== payload.clientHasherApplied ||
 			existing.clientCodecApplied !== payload.clientCodecApplied);
 
-	if (!needsActivation && !payloadChanged) {
+	if (!needsReactivation && !shouldWritePayload && params.referenceIdToAttach === undefined) {
 		return existing;
 	}
 
-	const updates: Partial<SchedulePayload> & { status?: "active" } = {};
-
-	if (needsActivation) {
-		updates.status = "active";
+	const updates: Partial<SchedulePayload> & { referenceId?: string } = {};
+	if (params.referenceIdToAttach !== undefined) {
+		updates.referenceId = params.referenceIdToAttach;
 	}
 
-	if (payloadChanged) {
+	if (shouldWritePayload) {
 		updates.workflowRunInput = payload.workflowRunInput;
 		updates.workflowRunInputHash = payload.workflowRunInputHash;
 		updates.clientHasherApplied = payload.clientHasherApplied;
@@ -436,17 +431,24 @@ async function reuseSchedule(
 		updates.definitionHash = payload.definitionHash;
 	}
 
-	const updatedRow = await repo.update(params.namespaceId, { id: existing.id }, updates);
-
-	if (!updatedRow) {
-		throw new NotFoundError(`Schedule not found: ${existing.id}`);
+	if (!needsReactivation) {
+		const updatedRow = await txRepos.schedule.update(params.namespaceId, { id: existing.id }, updates);
+		if (!updatedRow) {
+			throw new NotFoundError(`Schedule not found: ${existing.id}`);
+		}
+		return updatedRow;
 	}
 
-	return updatedRow;
+	return writeScheduleStateInTx(txRepos, {
+		namespaceId: params.namespaceId,
+		id: existing.id,
+		state: { status: "active", reason: "reactivated" },
+		updates,
+	});
 }
 
 async function createSchedule(
-	repo: Repositories["schedule"],
+	txRepos: TxRepositories,
 	params: {
 		namespaceId: NamespaceId;
 		workflowId: string;
@@ -458,7 +460,8 @@ async function createSchedule(
 	}
 ): Promise<ScheduleRow> {
 	const { spec, payload } = params;
-	return repo.create({
+	const transitionId = ulid();
+	const created = await txRepos.schedule.create({
 		id: ulid(),
 		namespaceId: params.namespaceId,
 		workflowId: params.workflowId,
@@ -476,7 +479,15 @@ async function createSchedule(
 		referenceId: params.referenceId,
 		workflowRunOptions: params.workflowRunOptions,
 		nextRunAt: params.nextRunAt,
+		latestStateTransitionId: transitionId,
 	});
+	await txRepos.stateTransition.append({
+		id: transitionId,
+		type: "schedule",
+		scheduleId: created.id,
+		state: { status: "active", reason: "activated" },
+	});
+	return created;
 }
 
 export function scheduleRowToDomain(

--- a/sdk/server/src/service/state-machine/schedule.integration.test.ts
+++ b/sdk/server/src/service/state-machine/schedule.integration.test.ts
@@ -1,0 +1,160 @@
+import { NotFoundError } from "@aikirun/lib/error";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { ScheduleState, ScheduleStatus } from "@aikirun/types/schedule";
+
+import { transitionScheduleInTx } from "./schedule";
+import { describe, expect, test } from "bun:test";
+import { InvalidScheduleStateTransitionError } from "../../errors";
+import { createServiceHarness } from "../../testing/harness";
+import { seedActiveSchedule } from "../../testing/seed/schedule";
+import { createScheduleService, type ScheduleService } from "../schedule";
+
+const withHarness = createServiceHarness();
+
+describe("transitionScheduleInTx", () => {
+	test("rejects an unknown schedule", () =>
+		withHarness(async ({ context, repos }) => {
+			expect(
+				repos.transaction((txRepos) =>
+					transitionScheduleInTx(txRepos, {
+						namespaceId: context.namespaceId,
+						id: "schedule-missing",
+						state: { status: "paused" },
+					})
+				)
+			).rejects.toThrow(NotFoundError);
+		}));
+
+	test("does not transition a schedule belonging to another namespace", () =>
+		withHarness(async ({ context, repos }) => {
+			const { schedule } = await seedActiveSchedule({ repos, namespaceRequestContext: context });
+			const before = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			const historyBefore = await repos.stateTransition.listByScheduleId(schedule.id);
+
+			expect(
+				repos.transaction((txRepos) =>
+					transitionScheduleInTx(txRepos, {
+						namespaceId: "other-namespace" as NamespaceId,
+						id: schedule.id,
+						state: { status: "paused" },
+					})
+				)
+			).rejects.toThrow(NotFoundError);
+
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(before);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual(historyBefore);
+		}));
+
+	test("writes the new status and points at its transition", () =>
+		withHarness(async ({ context, repos }) => {
+			const { schedule } = await seedActiveSchedule({ repos, namespaceRequestContext: context });
+
+			await repos.transaction((txRepos) =>
+				transitionScheduleInTx(txRepos, {
+					namespaceId: context.namespaceId,
+					id: schedule.id,
+					state: { status: "paused" },
+				})
+			);
+
+			const row = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			expect(row).toEqual(expect.objectContaining({ status: "paused", nextRunAt: schedule.nextRunAt }));
+			if (!row) {
+				throw new Error("Schedule not found");
+			}
+			expect(await repos.stateTransition.getById(row.latestStateTransitionId)).toEqual(
+				expect.objectContaining({ type: "schedule", scheduleId: schedule.id, state: { status: "paused" } })
+			);
+			const { rows } = await repos.stateTransition.listByScheduleId(schedule.id);
+			expect(rows.sort((a, b) => a.status.localeCompare(b.status))).toEqual([
+				expect.objectContaining({ state: { status: "active", reason: "activated" } }),
+				expect.objectContaining({ state: { status: "paused" } }),
+			]);
+		}));
+
+	const noOpCases = {
+		active: { seed: async () => {}, state: { status: "active", reason: "resumed" } },
+		paused: {
+			seed: (service, namespaceId, id) => service.pauseSchedule(namespaceId, id),
+			state: { status: "paused" },
+		},
+		inactive: {
+			seed: (service, namespaceId, id) => service.deactivateSchedule(namespaceId, id),
+			state: { status: "inactive" },
+		},
+	} satisfies {
+		[Status in ScheduleStatus]: {
+			seed: (service: ScheduleService, namespaceId: NamespaceId, id: string) => Promise<void>;
+			state: Extract<ScheduleState, { status: Status }>;
+		};
+	};
+
+	for (const [status, { seed, state }] of Object.entries(noOpCases)) {
+		test(`leaves an already ${status} schedule and its history untouched`, () =>
+			withHarness(async ({ context, repos }) => {
+				const { schedule } = await seedActiveSchedule({ repos, namespaceRequestContext: context });
+				await seed(createScheduleService({ repos }), context.namespaceId, schedule.id);
+				const before = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+				const historyBefore = await repos.stateTransition.listByScheduleId(schedule.id);
+
+				await repos.transaction((txRepos) =>
+					transitionScheduleInTx(txRepos, {
+						namespaceId: context.namespaceId,
+						id: schedule.id,
+						state,
+					})
+				);
+
+				expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(before);
+				expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual(historyBefore);
+			}));
+	}
+
+	test("refuses reactivation of a paused schedule without changing its history", () =>
+		withHarness(async ({ context, repos }) => {
+			const { schedule } = await seedActiveSchedule({ repos, namespaceRequestContext: context });
+			await createScheduleService({ repos }).pauseSchedule(context.namespaceId, schedule.id);
+			const before = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			const historyBefore = await repos.stateTransition.listByScheduleId(schedule.id);
+
+			expect(
+				repos.transaction((txRepos) =>
+					transitionScheduleInTx(txRepos, {
+						namespaceId: context.namespaceId,
+						id: schedule.id,
+						state: { status: "active", reason: "reactivated" },
+					})
+				)
+			).rejects.toThrow(InvalidScheduleStateTransitionError);
+
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(before);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual(historyBefore);
+		}));
+
+	test("rolls back the status and pointer when appending history fails", () =>
+		withHarness(async ({ context, repos }) => {
+			const { schedule } = await seedActiveSchedule({ repos, namespaceRequestContext: context });
+			const before = await repos.schedule.get(context.namespaceId, { id: schedule.id });
+			const historyBefore = await repos.stateTransition.listByScheduleId(schedule.id);
+
+			expect(
+				repos.transaction((txRepos) =>
+					transitionScheduleInTx(
+						{
+							...txRepos,
+							stateTransition: {
+								...txRepos.stateTransition,
+								append: async () => {
+									throw new Error("history unavailable");
+								},
+							},
+						},
+						{ namespaceId: context.namespaceId, id: schedule.id, state: { status: "paused" } }
+					)
+				)
+			).rejects.toThrow("history unavailable");
+
+			expect(await repos.schedule.get(context.namespaceId, { id: schedule.id })).toEqual(before);
+			expect(await repos.stateTransition.listByScheduleId(schedule.id)).toEqual(historyBefore);
+		}));
+});

--- a/sdk/server/src/service/state-machine/schedule.test.ts
+++ b/sdk/server/src/service/state-machine/schedule.test.ts
@@ -1,0 +1,73 @@
+import type { NonEmptyArray } from "@aikirun/lib/collection/array";
+import {
+	SCHEDULE_ACTIVE_REASONS,
+	SCHEDULE_STATUSES,
+	type ScheduleActiveReason,
+	type ScheduleState,
+	type ScheduleStatus,
+} from "@aikirun/types/schedule";
+
+import { assertIsValidScheduleStateTransition } from "./schedule";
+import { describe, expect, test } from "bun:test";
+import { InvalidScheduleStateTransitionError } from "../../errors";
+
+describe("assertIsValidScheduleStateTransition", () => {
+	function attemptTransition(
+		fromStatus: ScheduleStatus,
+		to: { status: ScheduleStatus; reason?: ScheduleActiveReason }
+	): void {
+		assertIsValidScheduleStateTransition("schedule-1", fromStatus, to as ScheduleState);
+	}
+
+	const validTransitions: Record<
+		ScheduleStatus,
+		Partial<Record<ScheduleStatus, { reasons?: NonEmptyArray<ScheduleActiveReason> }>>
+	> = {
+		active: { paused: {}, inactive: {} },
+		paused: { active: { reasons: ["resumed"] }, inactive: {} },
+		inactive: { active: { reasons: ["reactivated"] } },
+	};
+
+	for (const fromStatus of SCHEDULE_STATUSES) {
+		describe(`from ${fromStatus}`, () => {
+			const validDestinations = validTransitions[fromStatus];
+
+			for (const toStatus of SCHEDULE_STATUSES) {
+				const validDestination = validDestinations[toStatus];
+
+				if (validDestination === undefined) {
+					test(`declines to ${toStatus}`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus })).toThrow(
+							InvalidScheduleStateTransitionError
+						);
+					});
+					continue;
+				}
+
+				const validReasons = validDestination.reasons;
+				if (validReasons === undefined) {
+					test(`accepts to ${toStatus}`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus })).not.toThrow();
+					});
+					continue;
+				}
+
+				for (const reason of validReasons) {
+					test(`accepts to ${toStatus} (${reason})`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus, reason })).not.toThrow();
+					});
+				}
+				for (const reason of SCHEDULE_ACTIVE_REASONS) {
+					if (validReasons.includes(reason)) {
+						continue;
+					}
+					test(`declines to ${toStatus} (${reason})`, () => {
+						expect(() => attemptTransition(fromStatus, { status: toStatus, reason })).toThrow(
+							InvalidScheduleStateTransitionError
+						);
+					});
+				}
+			}
+		});
+	}
+});

--- a/sdk/server/src/service/state-machine/schedule.ts
+++ b/sdk/server/src/service/state-machine/schedule.ts
@@ -1,0 +1,86 @@
+import { NotFoundError } from "@aikirun/lib/error";
+import type { NamespaceId } from "@aikirun/types/namespace";
+import type { ScheduleActiveReason, ScheduleState, ScheduleStatus } from "@aikirun/types/schedule";
+import { ulid } from "ulidx";
+
+import { InvalidScheduleStateTransitionError } from "../../errors";
+import type { TxRepositories } from "../../infra/db/types";
+import type { ScheduleRow, ScheduleRowUpdate } from "../../infra/db/types/schedule";
+
+const scheduleStateTransitionValidator: Record<
+	ScheduleStatus,
+	Partial<{ active: ScheduleActiveReason; paused: true; inactive: true }>
+> = {
+	active: { paused: true, inactive: true },
+	paused: { active: "resumed", inactive: true },
+	inactive: { active: "reactivated" },
+};
+
+export function assertIsValidScheduleStateTransition(id: string, from: ScheduleStatus, to: ScheduleState) {
+	const validator = scheduleStateTransitionValidator[from][to.status];
+	if (validator === undefined) {
+		throw new InvalidScheduleStateTransitionError(id, from, to.status);
+	}
+	if (validator === true) {
+		return;
+	}
+	if (to.status === "active" && validator === to.reason) {
+		return;
+	}
+	throw new InvalidScheduleStateTransitionError(id, from, to.status);
+}
+
+export async function writeScheduleStateInTx(
+	txRepos: TxRepositories,
+	params: {
+		namespaceId: NamespaceId;
+		id: string;
+		state: ScheduleState;
+		updates?: Pick<
+			ScheduleRowUpdate,
+			| "workflowRunInput"
+			| "workflowRunInputHash"
+			| "clientHasherApplied"
+			| "clientCodecApplied"
+			| "definitionHash"
+			| "referenceId"
+		>;
+	}
+): Promise<ScheduleRow> {
+	const transitionId = ulid();
+	const row = await txRepos.schedule.update(
+		params.namespaceId,
+		{ id: params.id },
+		{
+			...params.updates,
+			status: params.state.status,
+			latestStateTransitionId: transitionId,
+		}
+	);
+	if (!row) {
+		throw new NotFoundError(`Schedule not found: ${params.id}`);
+	}
+	await txRepos.stateTransition.append({
+		id: transitionId,
+		type: "schedule",
+		scheduleId: row.id,
+		state: params.state,
+	});
+	return row;
+}
+
+export async function transitionScheduleInTx(
+	txRepos: TxRepositories,
+	params: { namespaceId: NamespaceId; id: string; state: ScheduleState }
+): Promise<void> {
+	const { namespaceId, id, state } = params;
+	const existing = await txRepos.schedule.get(namespaceId, { id }, { lock: "update" });
+	if (!existing) {
+		throw new NotFoundError(`Schedule not found: ${id}`);
+	}
+	if (existing.status === state.status) {
+		return;
+	}
+	assertIsValidScheduleStateTransition(id, existing.status, state);
+	await writeScheduleStateInTx(txRepos, params);
+}

--- a/sdk/server/src/service/state-machine/task.ts
+++ b/sdk/server/src/service/state-machine/task.ts
@@ -115,7 +115,6 @@ async function transitionStateInTx(
 			workflowRunId: runId,
 			type: "task",
 			taskId,
-			status: taskState.status,
 			attempt: attempts,
 			state: taskState,
 		});
@@ -169,7 +168,6 @@ async function transitionStateInTx(
 		workflowRunId: runId,
 		type: "task",
 		taskId,
-		status: taskState.status,
 		attempt: attempts,
 		state: taskState,
 	});

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -257,7 +257,6 @@ async function transitionStateInTx(
 		id: stateTransitionId,
 		workflowRunId: runId,
 		type: "workflow_run",
-		status: toState.status,
 		attempt: attempts,
 		state: toState,
 	});

--- a/sdk/server/src/service/task.ts
+++ b/sdk/server/src/service/task.ts
@@ -84,7 +84,6 @@ async function setTaskStateInTx(
 		workflowRunId: runId,
 		type: "task",
 		taskId: existingTaskRow.id,
-		status: state.status,
 		attempt: attempts,
 		state: state,
 	});

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -41,7 +41,7 @@ import type { Repositories, TxRepositories } from "../infra/db/types";
 import type { ChildRunWaitWithState } from "../infra/db/types/child-workflow-run-wait";
 import type { EventWaitRow } from "../infra/db/types/event-wait";
 import type { SleepRow } from "../infra/db/types/sleep";
-import type { StateTransitionRowInsert } from "../infra/db/types/state-transition";
+import type { WorkflowRunStateTransitionRowInsert } from "../infra/db/types/state-transition";
 import type { ChildRunWithWorkflow, WorkflowRunWithWorkflowAndState } from "../infra/db/types/workflow-run";
 import type { ImminentRunTimerQueue } from "../infra/timer/imminent-run-timer-queue";
 import { candidateHashes } from "../lib/hash";
@@ -395,7 +395,6 @@ async function createWorkflowRunInTx(
 		id: transitionId,
 		workflowRunId: runId,
 		type: "workflow_run",
-		status: "scheduled",
 		attempt: 1,
 		state,
 	});
@@ -434,7 +433,7 @@ async function cancelByIdsInTx(
 	await txRepos.sleep.bulkCancelByWorkflowRunIds(cancelledRunIds, now);
 	await txRepos.workflowRunOutbox.deleteByWorkflowRunIds(cancelledRunIds);
 
-	const cancelStateTransitionEntries: StateTransitionRowInsert[] = [];
+	const cancelStateTransitionEntries: WorkflowRunStateTransitionRowInsert[] = [];
 	const cancelledRunStateTransitionUpdates: {
 		filter: { namespaceId: NamespaceId; id: string };
 		update: { stateTransitionId: string };
@@ -448,7 +447,6 @@ async function cancelByIdsInTx(
 			id: stateTransitionId,
 			workflowRunId: run.id,
 			type: "workflow_run",
-			status: "cancelled",
 			attempt: run.attempts,
 			state: { status: "cancelled" } satisfies WorkflowRunStateCancelled,
 		});

--- a/types/src/schedule.ts
+++ b/types/src/schedule.ts
@@ -43,6 +43,24 @@ export interface ScheduleActivateOptions {
 	reference?: ScheduleReference;
 }
 
+export const SCHEDULE_ACTIVE_REASONS = ["activated", "resumed", "reactivated"] as const;
+export type ScheduleActiveReason = (typeof SCHEDULE_ACTIVE_REASONS)[number];
+
+export interface ScheduleStateActive {
+	status: "active";
+	reason: ScheduleActiveReason;
+}
+
+export interface ScheduleStatePaused {
+	status: "paused";
+}
+
+export interface ScheduleStateInactive {
+	status: "inactive";
+}
+
+export type ScheduleState = ScheduleStateActive | ScheduleStatePaused | ScheduleStateInactive;
+
 export interface Schedule {
 	id: string;
 	workflowSource: WorkflowSource;


### PR DESCRIPTION
Schedules previously stored only their current `status`. This PR records schedule state changes in the existing `state_transition` log, so the database can explain why a scheduled occurrence was missed.

Schedule transitions use `type = 'schedule'` and `schedule_id`; run-specific columns are nullable and a check constraint enforces the column shape for each transition type. The `status` query column is generated from `state->>'status'`, making the state document the single source of truth.

| type | `workflow_run_id` | `attempt` | `task_id` | `schedule_id` |
|---|---|---|---|---|
| `workflow_run` | required | required | absent | absent |
| `task` | required | required | required | absent |
| `schedule` | absent | absent | absent | required |

The schedule row stores `latest_state_transition_id`, updated in the same transaction as its status. Existing schedules receive an initial transition during migration. New schedules record `{ status: "active", reason: "activated" }`; later active-state reasons distinguish `resumed` from `reactivated`.

Schedule operations now use a row lock before deciding what to do:

| Call | from `active` | from `paused` | from `inactive` |
|---|---|---|---|
| `pause` | writes `paused` | no-op | refused |
| `resume` | no-op | writes `resumed` | refused |
| `deactivate` | writes `inactive` | writes `inactive` | no-op |
| `activate` | unchanged | unchanged | writes `reactivated` |

A no-op succeeds and writes no transition. A reference can be attached to an existing anonymous schedule in the same activation update; this does not append a transition unless the schedule is inactive and is reactivated. Payload and hash updates remain atomic, and an announced newer hash is preserved.

The migration adds the schedule transition type in one migration, then changes the transition columns, backfills existing schedule history, and makes the latest-transition pointer required in the next migration.

## Breaking changes

- `state_transition.status` is now generated from `state`.
- `state_transition.workflow_run_id` and `attempt` are nullable for schedule transitions; `schedule_id` and the `schedule` type are added.
- `schedule.latest_state_transition_id` is required after migration.
- Activating a paused schedule leaves it paused; only `resume()` resumes it.
- `pause()` and `resume()` on an inactive schedule return a 400 invalid-transition error.

