### PR TITLE
Timers on commit for sleeps, waits, and retries

### DIFF
--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.test.ts
@@ -19,23 +19,23 @@ function createQueues(lookaheadWindowMs: number) {
 }
 
 describe("ImminentRunTimerQueue", () => {
-	test("adds a scheduled timer for a run due within the window", async () => {
+	test("adds a timer of the run's type for a run due within the window", async () => {
 		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
 
-		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0, priority: undefined }]);
+		imminentRunTimerQueue.add([{ type: "sleep", id: "run-1", dueAt: 0, priority: undefined }]);
 
 		expect(await timerPriorityQueue.popDue({ maxRank: computeRank({ dueAt: 0 }), limit: 10 })).toEqual([
-			{ type: "scheduled", id: "run-1", rank: computeRank({ dueAt: 0 }) },
+			{ type: "sleep", id: "run-1", rank: computeRank({ dueAt: 0 }) },
 		]);
 	});
 
 	test("mints the timer's rank with the run's priority", async () => {
 		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
 
-		imminentRunTimerQueue.add([{ id: "run-1", scheduledAt: 0, priority: 2 }]);
+		imminentRunTimerQueue.add([{ type: "sleep", id: "run-1", dueAt: 0, priority: 2 }]);
 
 		expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
-			{ type: "scheduled", id: "run-1", rank: computeRank({ dueAt: 0, priority: 2 }) },
+			{ type: "sleep", id: "run-1", rank: computeRank({ dueAt: 0, priority: 2 }) },
 		]);
 	});
 
@@ -43,12 +43,12 @@ describe("ImminentRunTimerQueue", () => {
 		const { timerPriorityQueue, imminentRunTimerQueue } = createQueues(60_000);
 
 		imminentRunTimerQueue.add([
-			{ id: "run-due", scheduledAt: 0, priority: undefined },
-			{ id: "run-far", scheduledAt: Number.MAX_SAFE_INTEGER, priority: undefined },
+			{ type: "sleep", id: "run-due", dueAt: 0, priority: undefined },
+			{ type: "sleep", id: "run-far", dueAt: Number.MAX_SAFE_INTEGER, priority: undefined },
 		]);
 
 		expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
-			{ type: "scheduled", id: "run-due", rank: computeRank({ dueAt: 0 }) },
+			{ type: "sleep", id: "run-due", rank: computeRank({ dueAt: 0 }) },
 		]);
 	});
 });

--- a/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
+++ b/sdk/server/src/infra/timer/imminent-run-timer-queue.ts
@@ -2,9 +2,16 @@ import { fireAndForget } from "@aikirun/lib/async";
 import { isNonEmptyArray, type NonEmptyArray } from "@aikirun/lib/collection/array";
 import type { ConfigProvider } from "@aikirun/lib/config";
 import type { Logger } from "@aikirun/lib/logger";
-import type { TimerEntry, TimerPriorityQueue } from "@aikirun/types/infra/timer";
+import type { TimerEntry, TimerPriorityQueue, TimerType } from "@aikirun/types/infra/timer";
 
 import { computeRank } from "../../lib/rank";
+
+interface ImminentRunTimer {
+	type: TimerType;
+	id: string;
+	dueAt: number;
+	priority: number | undefined;
+}
 
 export interface ImminentRunTimerQueueDeps {
 	timerPriorityQueue: TimerPriorityQueue;
@@ -18,17 +25,17 @@ export const createImminentRunTimerQueue = ({
 	logger,
 }: ImminentRunTimerQueueDeps) => ({
 	/**
-	 * Adds a "scheduled" timer for each run due within the lookahead window, so
-	 * the due-timers consumer picks the run up without waiting for the next
+	 * Adds a timer for each run due within the lookahead window, so the
+	 * due-timers consumer picks the run up without waiting for the next
 	 * promoter poll. Failures are logged and dropped: the poll is the backstop,
 	 * so a missed timer costs latency, never the run.
 	 */
-	add(runs: NonEmptyArray<{ id: string; scheduledAt: number; priority: number | undefined }>): void {
+	add(runs: NonEmptyArray<ImminentRunTimer>): void {
 		const dueBefore = Date.now() + configProvider.config.lookaheadWindowMs;
 		const timers: TimerEntry[] = [];
-		for (const { id, scheduledAt, priority } of runs) {
-			if (scheduledAt <= dueBefore) {
-				timers.push({ type: "scheduled", id, rank: computeRank({ dueAt: scheduledAt, priority }) });
+		for (const { type, id, dueAt, priority } of runs) {
+			if (dueAt <= dueBefore) {
+				timers.push({ type, id, rank: computeRank({ dueAt, priority }) });
 			}
 		}
 		if (!isNonEmptyArray(timers)) {

--- a/sdk/server/src/service/cancel-child-runs.ts
+++ b/sdk/server/src/service/cancel-child-runs.ts
@@ -126,8 +126,9 @@ export const createChildRunCanceller = (imminentRunTimerQueue?: ImminentRunTimer
 
 			if (imminentRunTimerQueue) {
 				const imminentRuns = workflowRunEntries.map((entry) => ({
+					type: "scheduled" as const,
 					id: entry.id,
-					scheduledAt: now,
+					dueAt: now,
 					priority: entry.options?.priority,
 				}));
 				txRepos.onCommit(() => imminentRunTimerQueue.add(asNonEmptyArray(imminentRuns)));

--- a/sdk/server/src/service/deliver-terminated-signals.ts
+++ b/sdk/server/src/service/deliver-terminated-signals.ts
@@ -146,8 +146,9 @@ export async function deliverTerminatedSignalToParentRun(
 			imminentRunTimerQueue.add(
 				asNonEmptyArray(
 					scheduledParentRunIds.map((id) => ({
+						type: "scheduled",
 						id,
-						scheduledAt: now,
+						dueAt: now,
 						priority: incrementedParentRunsById.get(id)?.options?.priority,
 					}))
 				)

--- a/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.integration.test.ts
@@ -19,7 +19,7 @@ import { withFakeClock } from "../../testing/clock";
 import { daemonContextFactory } from "../../testing/data-factory/middleware/context";
 import { createServiceHarness, withRepos } from "../../testing/harness";
 import { claimRun, seedClaimedRun, seedCompletedRun, seedScheduledRun, seedStalledRun } from "../../testing/seed/run";
-import { seedRunningTask, seedSiblingAwaitingRetryTasks } from "../../testing/seed/task";
+import { seedAwaitingRetryTask, seedRunningTask, seedSiblingAwaitingRetryTasks } from "../../testing/seed/task";
 import { createChildRunCanceller } from "../cancel-child-runs";
 import { createEventService } from "../event";
 
@@ -1223,6 +1223,203 @@ describe("WorkflowRunStateMachine imminent run timers", () => {
 
 			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
 				{ type: "scheduled", id: parent.runId, rank: computeRank({ dueAt: childTerminatedAt, priority: 2 }) },
+			]);
+		}));
+
+	test("a transition into sleeping adds the run's wakeup timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const sleepStartedAt = Date.now();
+			await withFakeClock(sleepStartedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "sleeping", sleepName: "restock-window", durationMs: 5_000 },
+					expectedRevision: revisionWhenClaimed,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "sleep", id: runId, rank: computeRank({ dueAt: sleepStartedAt + 5_000 }) },
+			]);
+		}));
+
+	test("a park on an event with a timeout adds the run's timeout timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const parkedAt = Date.now();
+			await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: { status: "awaiting_event", eventName: "paymentReceived", timeoutInMs: 5_000 },
+					expectedRevision: revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "event_wait_timeout", id: runId, rank: computeRank({ dueAt: parkedAt + 5_000 }) },
+			]);
+		}));
+
+	test("a park on an event with no timeout adds no timer", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "awaiting_event", eventName: "paymentReceived" },
+				expectedRevision: revisionWhenClaimed,
+				expectedSignalSequence: 0,
+			});
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([]);
+		}));
+
+	test("a park on a child with a timeout adds the run's timeout timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const parent = await seedClaimedRun({ namespaceRequestContext: context, repos, publisher });
+			const child = await seedClaimedRun(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ parent: { workflowRunId: parent.runId, expectedRevision: parent.revisionWhenClaimed } }
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const parkedAt = Date.now();
+			await withFakeClock(parkedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: parent.runId,
+					state: { status: "awaiting_child_workflow", childWorkflowRunId: child.runId, timeoutInMs: 5_000 },
+					expectedRevision: parent.revisionWhenClaimed,
+					expectedSignalSequence: 0,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "child_wait_timeout", id: parent.runId, rank: computeRank({ dueAt: parkedAt + 5_000 }) },
+			]);
+		}));
+
+	test("a transition into awaiting_retry adds the run's retry timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedClaimedRun({
+				namespaceRequestContext: context,
+				repos,
+				publisher,
+			});
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			const failedAt = Date.now();
+			await withFakeClock(failedAt, () =>
+				stateMachine.transitionState(context, {
+					type: "optimistic",
+					id: runId,
+					state: {
+						status: "awaiting_retry",
+						cause: "self",
+						error: { name: "Error", message: "boom" },
+						nextAttemptInMs: 5_000,
+					},
+					expectedRevision: revisionWhenClaimed,
+				})
+			);
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "retry", id: runId, rank: computeRank({ dueAt: failedAt + 5_000 }) },
+			]);
+		}));
+
+	test("a park on a retrying task adds the run's task retry timer to the priority queue", () =>
+		withHarness(async ({ context, repos, publisher }) => {
+			const { runId, revisionWhenClaimed } = await seedAwaitingRetryTask(
+				{ namespaceRequestContext: context, repos, publisher },
+				{ nextAttemptAt: 1 }
+			);
+
+			const timerPriorityQueue = inMemoryTimerPriorityQueue()({ logger: noopLogger });
+			const stateMachine = createStateMachine(
+				repos,
+				createImminentRunTimerQueue({
+					timerPriorityQueue,
+					configProvider: asConfigProvider(() => ({ lookaheadWindowMs: 30_000 })),
+					logger: noopLogger,
+				})
+			);
+
+			await stateMachine.transitionState(context, {
+				type: "optimistic",
+				id: runId,
+				state: { status: "awaiting_task_retry" },
+				expectedRevision: revisionWhenClaimed,
+			});
+
+			expect(await timerPriorityQueue.popDue({ maxRank: Number.MAX_SAFE_INTEGER, limit: 10 })).toEqual([
+				{ type: "task_retry", id: runId, rank: computeRank({ dueAt: 1 }) },
 			]);
 		}));
 });

--- a/sdk/server/src/service/state-machine/workflow-run.ts
+++ b/sdk/server/src/service/state-machine/workflow-run.ts
@@ -6,6 +6,7 @@ import type {
 	WorkflowRunTransitionStateRequestV1,
 	WorkflowRunTransitionStateResponseV1,
 } from "@aikirun/types/api/workflow-run";
+import type { TimerType } from "@aikirun/types/infra/timer";
 import type {
 	WaitingForSignalWorkflowRunStatus,
 	WorkflowRunId,
@@ -261,10 +262,11 @@ async function transitionStateInTx(
 		state: toState,
 	});
 
-	if (imminentRunTimerQueue && toState.status === "scheduled") {
-		txRepos.onCommit(() =>
-			imminentRunTimerQueue.add([{ id: runId, scheduledAt: toState.scheduledAt, priority: run.options?.priority }])
-		);
+	if (imminentRunTimerQueue) {
+		const timer = extractTimer(toState);
+		if (timer) {
+			txRepos.onCommit(() => imminentRunTimerQueue.add([{ ...timer, id: runId, priority: run.options?.priority }]));
+		}
 	}
 
 	if (toState.status === "cancelled") {
@@ -420,6 +422,41 @@ function extractDueTimestamp(state: Exclude<WorkflowRunState, { status: WaitingF
 				timeoutAt?: never;
 			};
 			return {};
+	}
+}
+
+function extractTimer(state: WorkflowRunState): { type: TimerType; dueAt: number } | undefined {
+	switch (state.status) {
+		case "scheduled":
+			return { type: "scheduled", dueAt: state.scheduledAt };
+		case "sleeping":
+			return { type: "sleep", dueAt: state.wakeupAt };
+		case "awaiting_retry":
+			return { type: "retry", dueAt: state.nextAttemptAt };
+		case "awaiting_task_retry":
+			return { type: "task_retry", dueAt: state.nextAttemptAt };
+		case "awaiting_event": {
+			if (state.timeoutAt === undefined) {
+				return undefined;
+			}
+			return { type: "event_wait_timeout", dueAt: state.timeoutAt };
+		}
+		case "awaiting_child_workflow": {
+			if (state.timeoutAt === undefined) {
+				return undefined;
+			}
+			return { type: "child_wait_timeout", dueAt: state.timeoutAt };
+		}
+		case "queued":
+		case "running":
+		case "paused":
+		case "stalled":
+		case "cancelled":
+		case "completed":
+		case "failed":
+			return undefined;
+		default:
+			return state satisfies never;
 	}
 }
 

--- a/sdk/server/src/service/workflow-run.ts
+++ b/sdk/server/src/service/workflow-run.ts
@@ -404,7 +404,9 @@ async function createWorkflowRunInTx(
 	});
 
 	if (imminentRunTimerQueue) {
-		txRepos.onCommit(() => imminentRunTimerQueue.add([{ id: runId, scheduledAt, priority: options?.priority }]));
+		txRepos.onCommit(() =>
+			imminentRunTimerQueue.add([{ type: "scheduled", id: runId, dueAt: scheduledAt, priority: options?.priority }])
+		);
 	}
 
 	logger.info("Created workflow run", {


### PR DESCRIPTION
A run waiting on a future time is woken one of two ways. A daemon per wake-up kind scans every 10 seconds for runs due within the next 30 seconds and adds a timer for each to the timer priority queue, which the due-timers consumer pops at the exact due time. On top of that, a run created or moved into `scheduled` gets its timer added as the transaction commits, so a run due two seconds from now does not sit until the next scan.

Only `scheduled` did that. A run that went to sleep, parked on an event or a child with a timeout, or parked for a retry got no timer on commit, so its wake-up waited for a scan — a two-second sleep could take ten. Every transition that writes a due time now adds its timer on commit:

| state | due time | timer |
|---|---|---|
| `scheduled` | `scheduledAt` | `scheduled` |
| `sleeping` | `wakeupAt` | `sleep` |
| `awaiting_retry` | `nextAttemptAt` | `retry` |
| `awaiting_task_retry` | `nextAttemptAt` | `task_retry` | | `awaiting_event` | `timeoutAt` | `event_wait_timeout` | | `awaiting_child_workflow` | `timeoutAt` | `child_wait_timeout` |

A wait with no timeout has no due time and adds no timer — the event or the child's completion wakes the run. A park that is declined because a signal arrived first lands in `scheduled` and adds a `scheduled` timer, since the timer is read from the state that was persisted.

The scans stay as the backstop: a timer that fails to reach the queue costs latency, not the run.