### PR TITLE
Redis lazyConnect should not block client

### DIFF
--- a/sdk/adapter/redis/src/connection.test.ts
+++ b/sdk/adapter/redis/src/connection.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { createBinaryLatch, delay } from "@aikirun/lib/async";
+import { createBinaryLatch, delay, settleWithin } from "@aikirun/lib/async";
 import type { Logger } from "@aikirun/lib/logger";
 import type { Redis } from "ioredis";
 
@@ -122,6 +122,23 @@ describe("untilReadyHandshake", () => {
 
 		redis.emit("ready");
 		await handshakeReadyPromise;
+
+		expect(redis.listenerCount("ready")).toBe(0);
+		expect(redis.listenerCount("close")).toBe(0);
+	});
+
+	test("rejects when the connection does not become ready within the connect timeout", async () => {
+		const handshakeReadyPromise = untilReadyHandshake(fakeRedis("wait", 5));
+
+		expect(handshakeReadyPromise).rejects.toThrow("did not complete the ready handshake within 5ms");
+		expect(await settleWithin(handshakeReadyPromise, 1_000)).toBe(true);
+	});
+
+	test("removes both listeners after timing out", async () => {
+		const redis = fakeRedis("wait", 5);
+
+		const handshakeReadyPromise = untilReadyHandshake(redis);
+		expect(await settleWithin(handshakeReadyPromise, 1_000)).toBe(true);
 
 		expect(redis.listenerCount("ready")).toBe(0);
 		expect(redis.listenerCount("close")).toBe(0);

--- a/sdk/adapter/redis/src/connection.ts
+++ b/sdk/adapter/redis/src/connection.ts
@@ -74,22 +74,41 @@ export const connectionTracker = (() => {
 
 /**
  * Resolves when the connection's connect → ready handshake completes, rejecting
- * if the connection closes first.
+ * if the connection closes first, or if it is still not ready after the
+ * connection's own connect timeout.
+ *
+ * A client that never starts connecting emits no events at all, so without the
+ * timeout this would wait forever. The rejection includes the connection's
+ * status, so the log shows what it was stuck on.
  */
 export function untilReadyHandshake(redis: Redis): Promise<void> {
 	if (redis.status === "ready") {
 		return Promise.resolve();
 	}
 
+	const handshakeTimeoutMs = redis.options.connectTimeout ?? 10_000;
+
 	return new Promise((resolve, reject) => {
 		const onReady = () => {
+			clearTimeout(handshakeTimeout);
 			redis.off("close", onClose);
 			resolve();
 		};
 		const onClose = () => {
+			clearTimeout(handshakeTimeout);
 			redis.off("ready", onReady);
 			reject(new Error("Redis connection closed before completing the ready handshake"));
 		};
+		const handshakeTimeout = setTimeout(() => {
+			redis.off("ready", onReady);
+			redis.off("close", onClose);
+			reject(
+				new Error(
+					`Redis connection did not complete the ready handshake within ${handshakeTimeoutMs}ms (status: ${redis.status})`
+				)
+			);
+		}, handshakeTimeoutMs);
+
 		redis.once("ready", onReady);
 		redis.once("close", onClose);
 	});

--- a/sdk/adapter/redis/src/timer/priority-queue.test.ts
+++ b/sdk/adapter/redis/src/timer/priority-queue.test.ts
@@ -1,0 +1,33 @@
+import { EventEmitter } from "node:events";
+import { noopLogger } from "@aikirun/lib/logger";
+import type { Redis } from "ioredis";
+
+import { redisTimerPriorityQueue } from "./priority-queue";
+import { describe, expect, test } from "bun:test";
+
+function fakeRedis(options: { lazyConnect: boolean }) {
+	const duplicateOverrides: unknown[] = [];
+	const redis = Object.assign(new EventEmitter(), {
+		status: "wait" as Redis["status"],
+		options,
+		duplicate: (override: object) => {
+			duplicateOverrides.push(override);
+			return Object.assign(new EventEmitter(), {
+				status: "wait" as Redis["status"],
+				options: { ...options, ...override },
+			}) as unknown as Redis;
+		},
+	}) as unknown as Redis;
+
+	return { redis, duplicateOverrides };
+}
+
+describe("redisTimerPriorityQueue", () => {
+	test("the waiter's connection does not inherit lazyConnect from the client it duplicates", () => {
+		const { redis, duplicateOverrides } = fakeRedis({ lazyConnect: true });
+
+		redisTimerPriorityQueue(redis, "aiki:timers:test")({ logger: noopLogger }).createWaiter();
+
+		expect(duplicateOverrides).toEqual([{ maxRetriesPerRequest: 0, enableOfflineQueue: false, lazyConnect: false }]);
+	});
+});

--- a/sdk/adapter/redis/src/timer/priority-queue.ts
+++ b/sdk/adapter/redis/src/timer/priority-queue.ts
@@ -133,9 +133,13 @@ export function redisTimerPriorityQueue(redis: Redis, key: string): CreateTimerP
 			},
 
 			createWaiter(): TimerPriorityQueueWaiter {
+				// A lazy client waits for its first command before connecting, and this
+				// connection waits to be ready before it sends one. Left lazy, both
+				// sides wait forever, so it connects up front.
 				const redisDuplicate = redis.duplicate({
 					maxRetriesPerRequest: 0,
 					enableOfflineQueue: false,
+					lazyConnect: false,
 				});
 
 				let completedReadyHandshake = false;


### PR DESCRIPTION
The due-timers consumer blocks on `BRPOP` over a connection duplicated from the Redis client the server is given. That connection turns off ioredis's offline queue, so a command issued before the connection is ready is rejected rather than buffered — the waiter therefore waits for the ready handshake before sending its first command.

`duplicate()` copies the parent's options, `lazyConnect` among them, and a lazy client does not connect until its first command:

```
waiter   waits for ready before sending its first command
client   status "wait" — connects once it gets its first command
```

Neither side moves, and a client in `wait` emits no events, so nothing errors. Sleeps and retries still run, because the polling daemons process whatever is already due straight from the database — what is lost is the precise wakeup, leaving latency at the poll interval. The waiter's connection now sets `lazyConnect: false`.

That wait also had no upper bound, which is what kept it silent. It now rejects after the connection's own connect timeout, carrying the connection's status: `wait` means nothing ever started connecting, `connecting` means it stalled partway. The queue subscriber shares the helper and gets the same deadline.