### PR TITLE
Publish @aikirun/memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_CONFIG_TOKEN }}
         run: |
-          for dir in types sdk/server sdk/client sdk/workflow sdk/worker sdk/endpoint sdk/iam sdk/adapter/redis; do
+          for dir in types sdk/server sdk/client sdk/workflow sdk/worker sdk/endpoint sdk/iam sdk/adapter/memory sdk/adapter/redis; do
             name="$(jq -r .name "$dir/package.json")"
             if npm view "$name@$VERSION" version > /dev/null 2>&1; then
               echo "$name@$VERSION already published; skipping"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ See the [Installation Guide](https://aiki.run/docs/getting-started/installation)
 
 - [`@aikirun/endpoint`](https://www.npmjs.com/package/@aikirun/endpoint) — Push-based execution on serverless platforms (coming soon)
 - [`@aikirun/iam`](https://www.npmjs.com/package/@aikirun/iam) — Multi-tenancy, API keys, and dashboard auth
+- [`@aikirun/memory`](https://www.npmjs.com/package/@aikirun/memory) — Sub-second timer dispatch and work delivery inside a single process
 - [`@aikirun/redis`](https://www.npmjs.com/package/@aikirun/redis) — Sub-second timer dispatch and cross-host work distribution
 
 ## Community

--- a/app/website/content/docs/core-concepts/workers.md
+++ b/app/website/content/docs/core-concepts/workers.md
@@ -104,6 +104,28 @@ const aikiWorker = worker({
 });
 ```
 
+When the worker runs in the same process as the server, `inMemoryQueue()` pairs a publisher and a subscriber over one in-process broker, with no external service:
+
+```package-install
+@aikirun/memory
+```
+
+```typescript
+import { inMemoryQueue } from "@aikirun/memory";
+
+const queue = inMemoryQueue();
+
+const aikiServer = server({
+  db: database({ provider: "pg", url: databaseUrl }),
+  runtime: { publisher: queue.publisher },
+});
+
+const aikiWorker = worker({
+  workflows: [orderWorkflowV1],
+  subscriber: queue.subscriber,
+});
+```
+
 You can also implement your own subscriber by providing a function that matches the `CreateSubscriber` type from `@aikirun/types/infra/queue`. See [Subscribers](../architecture/subscribers.md) for how the implementations work and what custom subscribers must provide.
 
 ## Next Steps

--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -32,6 +32,23 @@ Re-run this command when upgrading Aiki to apply new migrations.
 
 Mount aiki server handler in any HTTP framework — in the same process as your app, or in a process dedicated to Aiki. The [Quick Start](./quick-start.mdx) walks through this end-to-end, including worker and client.
 
+An embedded server should also be given a timer priority queue. Without one it finds due work by scanning the database on an interval, so a short sleep or retry waits for the next scan:
+
+```package-install
+@aikirun/memory
+```
+
+```typescript
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+
+const aikiServer = server({
+  db: database({ provider: "pg", url: databaseUrl }),
+  timerPriorityQueue: inMemoryTimerPriorityQueue(),
+});
+```
+
+The in-process queue serves one server instance. Across several instances use `@aikirun/redis`, which hands each timer to exactly one of them — see [Server](../architecture/server.md).
+
 Workflow code is identical against an embedded or standalone server, so you can also skip embedding entirely and point your client at a server hosted per [Run the standalone server and dashboard](#run-the-standalone-server-and-dashboard).
 
 Want the web dashboard against your embedded server? Serve it separately — see [Run the dashboard on its own](#run-the-dashboard-on-its-own).

--- a/sdk/adapter/memory/README.md
+++ b/sdk/adapter/memory/README.md
@@ -1,0 +1,59 @@
+# @aikirun/memory
+
+In-process adapter for Aiki: a publisher/subscriber pair and a timer priority queue backed by in-memory data structures. No external service to run.
+
+## Installation
+
+```bash
+npm install @aikirun/memory
+```
+
+## Quick Start
+
+Without a timer priority queue, the server finds due work by periodic database scans, so a short sleep waits for the next scan. The in-process queue fires near-term timers when they actually come due:
+
+```typescript
+import { inMemoryTimerPriorityQueue } from "@aikirun/memory";
+import { database, server } from "@aikirun/server";
+
+const aikiServer = server({
+	db: database({ provider: "pg", url: databaseUrl }),
+	timerPriorityQueue: inMemoryTimerPriorityQueue(),
+});
+```
+
+`inMemoryQueue()` returns a publisher and a subscriber over one shared broker, for running a server and its workers in a single process:
+
+```typescript
+import { inMemoryQueue } from "@aikirun/memory";
+import { database, server } from "@aikirun/server";
+import { worker } from "@aikirun/worker";
+import { orderWorkflowV1 } from "./workflows.ts";
+
+const queue = inMemoryQueue();
+
+const aikiServer = server({
+	db: database({ provider: "pg", url: databaseUrl }),
+	runtime: { publisher: queue.publisher },
+});
+
+const aikiWorker = worker({ workflows: [orderWorkflowV1], subscriber: queue.subscriber });
+```
+
+## Process-local state
+
+Everything here lives in the process that created it, which decides where it fits:
+
+- A publisher and the subscriber that drains it have to be in the same process.
+- Timers are not shared between server instances. Each instance arms its own and wakes for every timer it armed, so several instances handle the same timer more than once. Nothing breaks — the database holds every deadline — but the work is duplicated. Use [`@aikirun/redis`](https://www.npmjs.com/package/@aikirun/redis) for a queue that hands each timer to exactly one instance.
+- State belongs to the factory, not to the queue it returns. `inMemoryTimerPriorityQueue()` keeps its timers across a server stop and restart in the same process. Both factories expose `clear()` to empty what they hold.
+
+The queue is disposable acceleration state. The database keeps every deadline, and the scans repopulate the queue after a restart.
+
+## Documentation
+
+See the [Server](https://aiki.run/docs/architecture/server) architecture guide.
+
+## License
+
+Apache-2.0

--- a/sdk/adapter/memory/package.json
+++ b/sdk/adapter/memory/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@aikirun/memory",
 	"version": "0.41.1",
-	"private": true,
 	"description": "In-memory adapter for Aiki - publisher, subscriber, and timer sorted set backed by in-process data structures",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,6 +23,9 @@
 	"devDependencies": {
 		"@aikirun/lib": "workspace:*",
 		"@aikirun/testing": "workspace:*"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"license": "Apache-2.0"
 }

--- a/sdk/adapter/memory/src/queue/broker.ts
+++ b/sdk/adapter/memory/src/queue/broker.ts
@@ -17,7 +17,7 @@ export interface Queue {
 	clear(): void;
 }
 
-export interface Store {
+export interface Broker {
 	getOrCreateQueue(queueName: string): Queue;
 	getQueue(queueName: string): Queue | undefined;
 	/**
@@ -74,7 +74,7 @@ function createQueue(): Queue {
 	};
 }
 
-export function createStore(): Store {
+export function createBroker(): Broker {
 	const queuesByName = new Map<string, Queue>();
 
 	return {

--- a/sdk/adapter/memory/src/queue/in-memory-queue.ts
+++ b/sdk/adapter/memory/src/queue/in-memory-queue.ts
@@ -1,7 +1,7 @@
 import type { CreatePublisher, CreateSubscriber } from "@aikirun/types/infra/queue";
 
+import { createBroker } from "./broker";
 import { createInMemoryPublisher } from "./publisher";
-import { createStore } from "./store";
 import { createInMemorySubscriber } from "./subscriber";
 
 export interface InMemoryQueue {
@@ -11,14 +11,14 @@ export interface InMemoryQueue {
 }
 
 /**
- * In-process publisher + subscriber sharing a single store. The store
+ * In-process publisher + subscriber sharing a single broker. The broker
  * holds workflow-run queues and a registry of subscribers parked on the queues.
  */
 export function inMemoryQueue(): InMemoryQueue {
-	const store = createStore();
+	const broker = createBroker();
 	return {
-		publisher: createInMemoryPublisher(store),
-		subscriber: createInMemorySubscriber(store),
-		clear: () => store.clear(),
+		publisher: createInMemoryPublisher(broker),
+		subscriber: createInMemorySubscriber(broker),
+		clear: () => broker.clear(),
 	};
 }

--- a/sdk/adapter/memory/src/queue/publisher.ts
+++ b/sdk/adapter/memory/src/queue/publisher.ts
@@ -7,16 +7,16 @@ import type {
 	ReadyWorkflowRun,
 } from "@aikirun/types/infra/queue";
 
+import type { Broker, Queue } from "./broker";
 import { getWorkflowQueueName } from "./key";
-import type { Queue, Store } from "./store";
 
-export function createInMemoryPublisher(store: Store): CreatePublisher {
+export function createInMemoryPublisher(broker: Broker): CreatePublisher {
 	return (_context: PublisherContext): Publisher => ({
 		async publishRuns(runs: NonEmptyArray<ReadyWorkflowRun>): Promise<PublishRunsResult> {
 			const touchedQueues = new Map<string, Queue>();
 			for (const { id, source, name, versionId, rank, pool } of runs) {
 				const queueName = getWorkflowQueueName({ source, name, versionId, pool });
-				const queue = store.getOrCreateQueue(queueName);
+				const queue = broker.getOrCreateQueue(queueName);
 				queue.push({ rank, id });
 				touchedQueues.set(queueName, queue);
 			}

--- a/sdk/adapter/memory/src/queue/subscriber.ts
+++ b/sdk/adapter/memory/src/queue/subscriber.ts
@@ -7,10 +7,10 @@ import type {
 } from "@aikirun/types/infra/queue";
 import type { WorkflowRunId } from "@aikirun/types/workflow/run";
 
+import type { Broker } from "./broker";
 import { getWorkflowQueueNames } from "./key";
-import type { Store } from "./store";
 
-export function createInMemorySubscriber(store: Store): CreateSubscriber {
+export function createInMemorySubscriber(broker: Broker): CreateSubscriber {
 	const getNextDelay = (delayParams: SubscriberDelayParams): number => {
 		switch (delayParams.type) {
 			case "no_work":
@@ -45,7 +45,7 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 				}
 
 				const startQueueIndex = Math.floor(Math.random() * queueNames.length);
-				const initialBatch = store.roundRobinPop({ queueNames, startQueueIndex, limit });
+				const initialBatch = broker.roundRobinPop({ queueNames, startQueueIndex, limit });
 				if (initialBatch.length > 0) {
 					return initialBatch;
 				}
@@ -80,7 +80,7 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 							while (true) {
 								queueIndex = (queueIndex + 1) % queueCount;
 								const queueName = queueNames[queueIndex];
-								const queue = queueName !== undefined ? store.getQueue(queueName) : undefined;
+								const queue = queueName !== undefined ? broker.getQueue(queueName) : undefined;
 
 								if (!visited[queueIndex]) {
 									queue?.waiterHandles.delete(handle);
@@ -109,7 +109,7 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 
 						close: () => {
 							for (const queueName of queueNames) {
-								store.getQueue(queueName)?.waiterHandles.delete(handle);
+								broker.getQueue(queueName)?.waiterHandles.delete(handle);
 							}
 							detach();
 							resolve([]);
@@ -123,7 +123,7 @@ export function createInMemorySubscriber(store: Store): CreateSubscriber {
 					signal.addEventListener("abort", handle.abortHandler, { once: true });
 
 					for (const queueName of queueNames) {
-						store.getOrCreateQueue(queueName).waiterHandles.add(handle);
+						broker.getOrCreateQueue(queueName).waiterHandles.add(handle);
 					}
 				});
 			},

--- a/sdk/server/src/runtime.ts
+++ b/sdk/server/src/runtime.ts
@@ -43,6 +43,10 @@ export async function startRuntime(params: StartRuntimeParams): Promise<StartedR
 		signal,
 	});
 
+	if (!timerPriorityQueue) {
+		logger.warn("No timer priority queue configured, runs may wake seconds later than expected.");
+	}
+
 	const childRunCanceller = createChildRunCanceller(
 		timerPriorityQueue &&
 			createImminentRunTimerQueue({


### PR DESCRIPTION
`@aikirun/memory` is Aiki's in-process adapter: a publisher and subscriber over one shared broker, and a timer priority queue. The standalone server falls back to it when Redis is not configured, and the architecture guide tells embedded servers to configure it — but the package was marked private and could not be installed.

`private` is dropped, the package joins the publish loop in the release workflow, and it ships with a README. The installation and workers guides now show the in-process option alongside Redis.

A server started with no timer priority queue now warns at startup and names the configured scan interval.

Inside the package, the structure the publisher and subscriber share is renamed from `Store` to `Broker`, the name the rest of the codebase already uses for it.
