### PR TITLE
Binary setup steps and a troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ mkdir aiki && cd aiki
 curl -fsSL https://github.com/aikirun/aiki/releases/latest/download/docker-compose.yml -o docker-compose.yml
 
 # Create a .env with your DATABASE_URL, then:
-docker-compose up -d
+docker compose up -d
 
 # Server: http://localhost:9850 — Dashboard: http://localhost:9851
 ```

--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -59,7 +59,16 @@ There are three ways to run this stack:
 
 ### With the aiki binary
 
-Download the `aiki` binary for your platform from the [latest release](https://github.com/aikirun/aiki/releases/latest) and put it on your `PATH`. It carries the migrate and server commands plus its own runtime.
+Download the binary for your platform from the [latest release](https://github.com/aikirun/aiki/releases/latest). It carries the migrate and server commands plus its own runtime. Assets are published for macOS on Apple Silicon (`aiki-darwin-arm64`) and Linux (`aiki-linux-arm64`, `aiki-linux-x64`); on any other platform use [Docker](#with-docker) or [From source](#from-source) instead.
+
+The asset is named for its platform and downloads without the executable bit, so rename it and make it executable before putting it on your `PATH`:
+
+```bash
+mv aiki-darwin-arm64 aiki
+chmod +x aiki
+```
+
+If you downloaded the asset with a browser rather than `curl`, macOS also flags it as quarantined; clear that with `xattr -c aiki`.
 
 ```bash
 export DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
@@ -91,14 +100,16 @@ Create a `.env` next to it with your database URL:
 DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
 ```
 
+If Postgres runs on the same machine as the stack rather than on a remote host, use `host.docker.internal` as the host instead of `localhost` — inside a container, `localhost` is the container itself, not the machine running it.
+
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 - Server: http://localhost:9850
 - Dashboard: http://localhost:9851
 
-The migration step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker-compose up -d`.
+The migration step applies the packages listed in `AIKI_MIGRATE_PACKAGES` — by default `server`, plus `iam` when `AIKI_SERVER_AUTH_SECRET` is set. Override the list to depart from that, for example to create the iam tables before turning auth on: `AIKI_MIGRATE_PACKAGES=server,iam docker compose up -d`.
 
 #### Without Docker Compose
 

--- a/app/website/content/docs/getting-started/installation.md
+++ b/app/website/content/docs/getting-started/installation.md
@@ -22,7 +22,7 @@ You need Node.js 18+ or Bun 1.0+, and a PostgreSQL 14+ database (SQLite and MySQ
 If you will [run the standalone server](#run-the-standalone-server-and-dashboard), skip this step — that section covers migration for each way of running it.
 
 ```bash
-DATABASE_URL=postgresql://user:password@localhost:5432/aiki \
+DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki \
   npx aiki-server migrate apply
 ```
 
@@ -81,11 +81,11 @@ Download the binary for your platform from the [latest release](https://github.c
 The asset is named for its platform and downloads without the executable bit, so rename it and make it executable before putting it on your `PATH`:
 
 ```bash
-mv aiki-darwin-arm64 aiki
+mv aiki-<platform> aiki
 chmod +x aiki
 ```
 
-If you downloaded the asset with a browser rather than `curl`, macOS also flags it as quarantined; clear that with `xattr -c aiki`.
+If macOS then refuses to run it, see [Troubleshooting](#troubleshooting).
 
 ```bash
 export DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
@@ -117,7 +117,7 @@ Create a `.env` next to it with your database URL:
 DATABASE_URL=postgresql://user:password@your-db-host:5432/aiki
 ```
 
-If Postgres runs on the same machine as the stack rather than on a remote host, use `host.docker.internal` as the host instead of `localhost` — inside a container, `localhost` is the container itself, not the machine running it.
+Running Postgres on the same machine as the stack? See [Troubleshooting](#troubleshooting).
 
 ```bash
 docker compose up -d
@@ -212,6 +212,24 @@ These apply to the standalone server and the dashboard. If you embed the server 
 | `VITE_AIKI_SERVER_URL` | If on a static host | — | Build-time server URL for a dashboard served outside the docker image |
 
 Which variable applies depends on how you serve the dashboard: the docker image reads `AIKI_SERVER_UPSTREAM_URL` (see [With Docker](#with-docker)), and a static-host build reads `VITE_AIKI_SERVER_URL` (see [Run the dashboard on its own](#run-the-dashboard-on-its-own)). The bundled `docker-compose.yml` sets `AIKI_SERVER_UPSTREAM_URL` for you.
+
+## Troubleshooting
+
+**macOS won't run the binary.** macOS quarantines anything downloaded with a browser. Clear the quarantine, using the name you gave the binary:
+
+```bash
+xattr -c aiki
+```
+
+Downloads fetched with `curl` are not quarantined.
+
+**The server can't reach your database.** The server runs in a container, so `localhost` in the `DATABASE_URL` you set names that container — not your machine. When Postgres runs on your machine, use `host.docker.internal` as the host:
+
+```bash
+DATABASE_URL=postgresql://user:password@host.docker.internal:5432/aiki
+```
+
+The bundled `docker-compose.yml` already maps that name to the host. If you run the images yourself, add `--add-host=host.docker.internal:host-gateway` to each `docker run`.
 
 ---
 

--- a/presentations/durable-execution.md
+++ b/presentations/durable-execution.md
@@ -711,7 +711,7 @@ We've been solving infrastructure problems in application code.
 ```bash
 git clone https://github.com/aikirun/aiki
 cd aiki
-docker-compose up -d
+docker compose up -d
 ```
 
 ---


### PR DESCRIPTION
The Installation page pointed at an `aiki` release asset that doesn't exist. The assets are `aiki-darwin-arm64`, `aiki-linux-arm64` and `aiki-linux-x64`, each downloaded without the executable bit, so following the page ends in `permission denied`. There is no Intel macOS or Windows asset.

The binary section now names the three assets and shows the rename and `chmod +x`.

Two machine-dependent failures move to a Troubleshooting section at the end of the page: macOS quarantining a browser download, and `localhost` naming the container rather than the host.

`localhost` becomes `your-db-host` in the migration snippet. `docker-compose` becomes `docker compose` here, in the README and in the durable-execution presentation.

Includes #169 by @net-folade.