### PR TITLE
Fix workflow queue name collisions in the memory and Redis adapters.

### DIFF
--- a/sdk/adapter/memory/src/queue/key.test.ts
+++ b/sdk/adapter/memory/src/queue/key.test.ts
@@ -1,0 +1,64 @@
+import { getWorkflowQueueName } from "./key";
+import { describe, expect, test } from "bun:test";
+
+describe("getWorkflowQueueName", () => {
+	test("preserves ordinary queue names", () => {
+		expect(getWorkflowQueueName({ source: "user", name: "billing", versionId: "1.0.0" })).toBe("user:billing:1.0.0");
+		expect(getWorkflowQueueName({ source: "user", name: "billing", versionId: "1.0.0", pool: "dedicated" })).toBe(
+			"user:billing:1.0.0:dedicated"
+		);
+	});
+
+	const collisions = [
+		{
+			label: "name and version",
+			first: { name: "billing:v2", versionId: "1.0.0", expected: "user:billing%3Av2:1.0.0" },
+			second: { name: "billing", versionId: "v2:1.0.0", expected: "user:billing:v2%3A1.0.0" },
+		},
+		{
+			label: "version and pool",
+			first: { name: "billing", versionId: "1.0.0:dedicated", expected: "user:billing:1.0.0%3Adedicated" },
+			second: { name: "billing", versionId: "1.0.0", pool: "dedicated", expected: "user:billing:1.0.0:dedicated" },
+		},
+		{
+			label: "colons within pools",
+			first: {
+				name: "billing",
+				versionId: "1.0.0:dedicated",
+				pool: "east",
+				expected: "user:billing:1.0.0%3Adedicated:east",
+			},
+			second: {
+				name: "billing",
+				versionId: "1.0.0",
+				pool: "dedicated:east",
+				expected: "user:billing:1.0.0:dedicated%3Aeast",
+			},
+		},
+	];
+	for (const { label, first, second } of collisions) {
+		test(`distinguishes delimiters in ${label}`, () => {
+			const firstQueueName = getWorkflowQueueName({ source: "user", ...first });
+			const secondQueueName = getWorkflowQueueName({ source: "user", ...second });
+
+			expect(firstQueueName).toBe(first.expected);
+			expect(secondQueueName).toBe(second.expected);
+			expect(firstQueueName).not.toBe(secondQueueName);
+		});
+	}
+
+	const escapedFields = {
+		name: ["user:a%3Ab:1.0.0:dedicated", "user:a%253Ab:1.0.0:dedicated"],
+		versionId: ["user:billing:a%3Ab:dedicated", "user:billing:a%253Ab:dedicated"],
+		pool: ["user:billing:1.0.0:a%3Ab", "user:billing:1.0.0:a%253Ab"],
+	};
+	for (const [field, expected] of Object.entries(escapedFields)) {
+		test(`distinguishes literal escape sequences in ${field}`, () => {
+			const workflow = { source: "user" as const, name: "billing", versionId: "1.0.0", pool: "dedicated" };
+			expect([
+				getWorkflowQueueName({ ...workflow, [field]: "a:b" }),
+				getWorkflowQueueName({ ...workflow, [field]: "a%3Ab" }),
+			]).toEqual(expected);
+		});
+	}
+});

--- a/sdk/adapter/memory/src/queue/key.ts
+++ b/sdk/adapter/memory/src/queue/key.ts
@@ -8,7 +8,11 @@ export function getWorkflowQueueName(params: {
 	pool?: string;
 }): string {
 	const { source, name, versionId, pool } = params;
-	return pool ? `${source}:${name}:${versionId}:${pool}` : `${source}:${name}:${versionId}`;
+	const parts = [source, name, versionId];
+	if (pool) {
+		parts.push(pool);
+	}
+	return parts.map((part) => part.replaceAll("%", "%25").replaceAll(":", "%3A")).join(":");
 }
 
 export function getWorkflowQueueNames(workflows: WorkflowMeta[], pools?: string[]): string[] {

--- a/sdk/adapter/redis/src/queue/key.test.ts
+++ b/sdk/adapter/redis/src/queue/key.test.ts
@@ -1,0 +1,75 @@
+import { getWorkflowQueueName } from "./key";
+import { describe, expect, test } from "bun:test";
+
+describe("getWorkflowQueueName", () => {
+	test("preserves ordinary queue names", () => {
+		expect(getWorkflowQueueName({ source: "user", name: "billing", versionId: "1.0.0" })).toBe(
+			"aiki:workflow:user:billing:1.0.0"
+		);
+		expect(getWorkflowQueueName({ source: "user", name: "billing", versionId: "1.0.0", pool: "dedicated" })).toBe(
+			"aiki:workflow:user:billing:1.0.0:dedicated"
+		);
+	});
+
+	const collisions = [
+		{
+			label: "name and version",
+			first: { name: "billing:v2", versionId: "1.0.0", expected: "aiki:workflow:user:billing%3Av2:1.0.0" },
+			second: { name: "billing", versionId: "v2:1.0.0", expected: "aiki:workflow:user:billing:v2%3A1.0.0" },
+		},
+		{
+			label: "version and pool",
+			first: {
+				name: "billing",
+				versionId: "1.0.0:dedicated",
+				expected: "aiki:workflow:user:billing:1.0.0%3Adedicated",
+			},
+			second: {
+				name: "billing",
+				versionId: "1.0.0",
+				pool: "dedicated",
+				expected: "aiki:workflow:user:billing:1.0.0:dedicated",
+			},
+		},
+		{
+			label: "colons within pools",
+			first: {
+				name: "billing",
+				versionId: "1.0.0:dedicated",
+				pool: "east",
+				expected: "aiki:workflow:user:billing:1.0.0%3Adedicated:east",
+			},
+			second: {
+				name: "billing",
+				versionId: "1.0.0",
+				pool: "dedicated:east",
+				expected: "aiki:workflow:user:billing:1.0.0:dedicated%3Aeast",
+			},
+		},
+	];
+	for (const { label, first, second } of collisions) {
+		test(`distinguishes delimiters in ${label}`, () => {
+			const firstQueueName = getWorkflowQueueName({ source: "user", ...first });
+			const secondQueueName = getWorkflowQueueName({ source: "user", ...second });
+
+			expect(firstQueueName).toBe(first.expected);
+			expect(secondQueueName).toBe(second.expected);
+			expect(firstQueueName).not.toBe(secondQueueName);
+		});
+	}
+
+	const escapedFields = {
+		name: ["aiki:workflow:user:a%3Ab:1.0.0:dedicated", "aiki:workflow:user:a%253Ab:1.0.0:dedicated"],
+		versionId: ["aiki:workflow:user:billing:a%3Ab:dedicated", "aiki:workflow:user:billing:a%253Ab:dedicated"],
+		pool: ["aiki:workflow:user:billing:1.0.0:a%3Ab", "aiki:workflow:user:billing:1.0.0:a%253Ab"],
+	};
+	for (const [field, expected] of Object.entries(escapedFields)) {
+		test(`distinguishes literal escape sequences in ${field}`, () => {
+			const workflow = { source: "user" as const, name: "billing", versionId: "1.0.0", pool: "dedicated" };
+			expect([
+				getWorkflowQueueName({ ...workflow, [field]: "a:b" }),
+				getWorkflowQueueName({ ...workflow, [field]: "a%3Ab" }),
+			]).toEqual(expected);
+		});
+	}
+});

--- a/sdk/adapter/redis/src/queue/key.ts
+++ b/sdk/adapter/redis/src/queue/key.ts
@@ -8,7 +8,11 @@ export function getWorkflowQueueName(params: {
 	pool?: string;
 }): string {
 	const { source, name, versionId, pool } = params;
-	return pool ? `aiki:workflow:${source}:${name}:${versionId}:${pool}` : `aiki:workflow:${source}:${name}:${versionId}`;
+	const parts = ["aiki", "workflow", source, name, versionId];
+	if (pool) {
+		parts.push(pool);
+	}
+	return parts.map((part) => part.replaceAll("%", "%25").replaceAll(":", "%3A")).join(":");
 }
 
 export function getWorkflowQueueNames(workflows: WorkflowMeta[], pools?: string[]): string[] {


### PR DESCRIPTION
## Problem
Server to worker messages are isolated by queue name. Each workflow maps to some queue and only workers that registered that workflow version listen on that queue.

This queue name is produced by concatenating some meta data about the workflow with a `:` separator
```
{source}:{name}:{version}:{pool}
```

However, this could lead to collisions when those parts can contain the `:` separator.

Example:
```
  name `billing:v2`  version `1.0.0`        => billing:v2:1.0.0
  name `billing`     version `v2:1.0.0`     => billing:v2:1.0.0
```

This allowed workers to receive runs they weren't subscribed to. They reject the run, but it's still wasted work.

## Solution

Escape `%` as `%25` and `:` as `%3A` within each queue field before joining fields with `:`.

The example now produces `billing%3Av2:1.0.0` and `billing:v2%3A1.0.0`, without collision.

## Why field prefixes aren't enough

A different idea is to prefix parts with labels before concatenating:
```
source:{source}name:{name}:v:{version}:pool:{pool}
```

However, this doesn't prevent collisions because values can contain those labels too.

For example, these inputs produce a collision:

```
  name `billing:v:v2`  version `1.0.0`      => name:billing:v:v2:v:1.0.0
  name `billing`       version `v2:v:1.0.0` => name:billing:v:v2:v:1.0.0
```